### PR TITLE
feat(images): episode images support + GraphQL cast fix

### DIFF
--- a/trr_backend/integrations/imdb/fullcredits_cast_parser.py
+++ b/trr_backend/integrations/imdb/fullcredits_cast_parser.py
@@ -399,7 +399,19 @@ def is_self_role_text(value: str | None) -> bool:
 
 
 def filter_self_cast_rows(rows: Sequence[CastRow]) -> list[CastRow]:
-    return [row for row in rows if is_self_role_text(row.raw_role_text)]
+    """Filter cast rows to only include 'Self' roles.
+
+    A cast member is considered a 'Self' role if either:
+    1. raw_role_text starts with "self" (from HTML parsing), OR
+    2. job_category_id == IMDB_JOB_CATEGORY_SELF (from GraphQL)
+
+    This dual check is necessary because GraphQL responses for reality TV shows
+    may have category.id = "self" but no character names in the characters array,
+    resulting in empty raw_role_text.
+    """
+    return [
+        row for row in rows if is_self_role_text(row.raw_role_text) or row.job_category_id == IMDB_JOB_CATEGORY_SELF
+    ]
 
 
 def normalize_api_credits_to_cast_rows(
@@ -614,16 +626,12 @@ def normalize_graphql_credits_to_cast_rows(
 
         raw_role_text = ", ".join(role_parts) if role_parts else None
 
-        # Map to job_category_id for filtering by filter_self_cast_rows()
-        # Check if raw_role_text starts with "Self" (for reality shows)
-        job_category_id = None
-        if is_self_role_text(raw_role_text):
-            job_category_id = IMDB_JOB_CATEGORY_SELF
-
-        # GraphQL also provides category field
-        category = node.get("category", {}).get("id")
-        if category and "self" in category.lower():
-            job_category_id = IMDB_JOB_CATEGORY_SELF
+        # IMPORTANT: The GraphQL query (fetch_title_credits_paginated_v2) already filters
+        # by category_id=IMDB_JOB_CATEGORY_SELF, so ALL credits returned are self roles.
+        # For reality TV shows, the response often has empty characters[] and category{},
+        # but they are still self roles since they passed the category filter.
+        # Always set job_category_id for GraphQL credits to ensure filter_self_cast_rows() works.
+        job_category_id = IMDB_JOB_CATEGORY_SELF
 
         rows.append(
             CastRow(


### PR DESCRIPTION
## Summary

This PR adds episode images support and fixes critical bugs in the image sync pipeline.

### New Features
- **Episode Images Table** (`core.episode_images`) - Stores TMDb episode stills with S3 mirroring
- **TMDb Image Endpoints** - Added `fetch_tv_season_images()` and `fetch_tv_episode_images()` for dedicated image endpoints
- **S3 Mirroring** - Added `mirror_episode_image_row()` and `prune_orphaned_episode_image_objects()`

### Bug Fixes
- **GraphQL Cast Filtering** - Fixed `filter_self_cast_rows()` to recognize reality TV cast members from GraphQL responses. The GraphQL API returns empty `characters[]` and `category{}` for reality TV shows, but the credits ARE self roles since they passed the category filter. Now unconditionally sets `job_category_id` for GraphQL credits.
  - Before: `cast_rows_self=0`, `show_cast_upserted=0`
  - After: `cast_rows_self=407`, `show_cast_upserted=407`

- **Stale DB Connection** - Fixed `sync_show_complete.py` to refresh DB connection before querying cast members (line 237), ensuring subprocess-written data is visible.

- **Season Images Payload** - Added missing `url` and `source_image_id` fields to `_extract_posters()` (required by migration 0052).

### Files Changed
- `supabase/migrations/0067_create_episode_images.sql` - New episode_images table
- `trr_backend/repositories/episode_images.py` - New repository (upsert, fetch, update)
- `trr_backend/integrations/tmdb/client.py` - New season/episode image endpoints
- `trr_backend/media/s3_mirror.py` - Episode image S3 functions
- `trr_backend/integrations/imdb/fullcredits_cast_parser.py` - GraphQL cast fix
- `scripts/sync_season_episode_images.py` - Integrated episode images
- `scripts/sync_show_complete.py` - DB connection refresh

## Test plan
- [x] All 392 unit tests pass
- [x] Ruff check/format passes
- [x] `sync_show_cast.py --imdb-id tt1720601` now upserts 407 cast members
- [x] `sync_season_episode_images.py --imdb-id tt1720601` syncs season posters
- [x] `sync_show_complete.py --imdb-id tt1720601` completes all phases successfully
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)