### PR TITLE
fix: regenerate schema docs to match current migration state

### DIFF
--- a/supabase/schema_docs/INDEX.md
+++ b/supabase/schema_docs/INDEX.md
@@ -2,6 +2,7 @@
 
 - [core.admin_operation_events](core.admin_operation_events.md) ([diagram](diagrams/core.admin_operation_events.mermaid.md))
 - [core.admin_operations](core.admin_operations.md) ([diagram](diagrams/core.admin_operations.mermaid.md))
+- [core.bravotv_image_runs](core.bravotv_image_runs.md) ([diagram](diagrams/core.bravotv_image_runs.mermaid.md))
 - [core.cast_fandom](core.cast_fandom.md) ([diagram](diagrams/core.cast_fandom.mermaid.md))
 - [core.cast_photos](core.cast_photos.md) ([diagram](diagrams/core.cast_photos.mermaid.md))
 - [core.cast_tmdb](core.cast_tmdb.md) ([diagram](diagrams/core.cast_tmdb.mermaid.md))
@@ -36,6 +37,7 @@
 - [core.season_source_latest](core.season_source_latest.md) ([diagram](diagrams/core.season_source_latest.mermaid.md))
 - [core.seasons](core.seasons.md) ([diagram](diagrams/core.seasons.mermaid.md))
 - [core.show_alternative_names](core.show_alternative_names.md) ([diagram](diagrams/core.show_alternative_names.mermaid.md))
+- [core.show_cast_overrides](core.show_cast_overrides.md) ([diagram](diagrams/core.show_cast_overrides.mermaid.md))
 - [core.show_cast_role_assignments](core.show_cast_role_assignments.md) ([diagram](diagrams/core.show_cast_role_assignments.mermaid.md))
 - [core.show_external_ids](core.show_external_ids.md) ([diagram](diagrams/core.show_external_ids.mermaid.md))
 - [core.show_images](core.show_images.md) ([diagram](diagrams/core.show_images.mermaid.md))

--- a/supabase/schema_docs/core.cast_photos.json
+++ b/supabase/schema_docs/core.cast_photos.json
@@ -323,6 +323,30 @@
       "is_generated": "NEVER"
     },
     {
+      "name": "archived_at",
+      "data_type": "timestamp with time zone",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_by_firebase_uid",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_reason",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
       "name": "source_asset_id",
       "data_type": "text",
       "is_nullable": "YES",
@@ -378,6 +402,15 @@
       ],
       "unique": false,
       "definition": "CREATE INDEX cast_photos_person_gallery_idx ON core.cast_photos USING btree (person_id, gallery_index) WHERE (gallery_index IS NOT NULL)"
+    },
+    {
+      "name": "cast_photos_person_hosted_gallery_idx",
+      "columns": [
+        "person_id",
+        "gallery_index) WHERE (hosted_url IS NOT NULL"
+      ],
+      "unique": false,
+      "definition": "CREATE INDEX cast_photos_person_hosted_gallery_idx ON core.cast_photos USING btree (person_id, gallery_index) WHERE (hosted_url IS NOT NULL)"
     },
     {
       "name": "cast_photos_person_source_idx",
@@ -452,6 +485,25 @@
       "definition": "CREATE INDEX core_cast_photos_source_source_image_id_idx ON core.cast_photos USING btree (source, source_image_id)"
     },
     {
+      "name": "idx_cast_photos_archived",
+      "columns": [
+        "archived_at) WHERE (archived_at IS NOT NULL"
+      ],
+      "unique": false,
+      "definition": "CREATE INDEX idx_cast_photos_archived ON core.cast_photos USING btree (archived_at) WHERE (archived_at IS NOT NULL)"
+    },
+    {
+      "name": "idx_cast_photos_person_source_id_hosted",
+      "columns": [
+        "person_id",
+        "source",
+        "id",
+        "hosted_url"
+      ],
+      "unique": false,
+      "definition": "CREATE INDEX idx_cast_photos_person_source_id_hosted ON core.cast_photos USING btree (person_id, source, id, hosted_url)"
+    },
+    {
       "name": "idx_cast_photos_source_tmdb",
       "columns": [
         "person_id",
@@ -503,6 +555,9 @@
     "hosted_bytes": 0,
     "hosted_etag": "example",
     "hosted_at": "1970-01-01T00:00:00Z",
+    "archived_at": "1970-01-01T00:00:00Z",
+    "archived_by_firebase_uid": "example",
+    "archived_reason": "example",
     "source_asset_id": "example"
   }
 }

--- a/supabase/schema_docs/core.cast_photos.md
+++ b/supabase/schema_docs/core.cast_photos.md
@@ -44,6 +44,9 @@
 | hosted_bytes | integer | YES |  | NO | NEVER |
 | hosted_etag | text | YES |  | NO | NEVER |
 | hosted_at | timestamp with time zone | YES |  | NO | NEVER |
+| archived_at | timestamp with time zone | YES |  | NO | NEVER |
+| archived_by_firebase_uid | text | YES |  | NO | NEVER |
+| archived_reason | text | YES |  | NO | NEVER |
 | source_asset_id | text | YES |  | NO | NEVER |
 
 ## Primary Key
@@ -64,6 +67,7 @@ id
 - cast_photos_hosted_at_idx (non-unique): hosted_at) WHERE (hosted_at IS NOT NULL
 - cast_photos_hosted_sha_idx (non-unique): hosted_sha256) WHERE (hosted_sha256 IS NOT NULL
 - cast_photos_person_gallery_idx (non-unique): person_id, gallery_index) WHERE (gallery_index IS NOT NULL
+- cast_photos_person_hosted_gallery_idx (non-unique): person_id, gallery_index) WHERE (hosted_url IS NOT NULL
 - cast_photos_person_source_idx (non-unique): person_id, source
 - cast_photos_person_source_image_url_canonical_key (unique): person_id, source, image_url_canonical
 - cast_photos_person_source_source_image_id_key (unique): person_id, source, source_image_id
@@ -72,6 +76,8 @@ id
 - core_cast_photos_person_id_idx (non-unique): person_id
 - core_cast_photos_person_source_asset_id_idx (non-unique): person_id, source, source_asset_id) WHERE (source_asset_id IS NOT NULL
 - core_cast_photos_source_source_image_id_idx (non-unique): source, source_image_id
+- idx_cast_photos_archived (non-unique): archived_at) WHERE (archived_at IS NOT NULL
+- idx_cast_photos_person_source_id_hosted (non-unique): person_id, source, id, hosted_url
 - idx_cast_photos_source_tmdb (non-unique): person_id, source) WHERE (source = 'tmdb'::text
 
 ## RLS Enabled
@@ -122,6 +128,9 @@ false
   "hosted_bytes": 0,
   "hosted_etag": "example",
   "hosted_at": "1970-01-01T00:00:00Z",
+  "archived_at": "1970-01-01T00:00:00Z",
+  "archived_by_firebase_uid": "example",
+  "archived_reason": "example",
   "source_asset_id": "example"
 }
 ```

--- a/supabase/schema_docs/core.cast_tmdb.json
+++ b/supabase/schema_docs/core.cast_tmdb.json
@@ -311,7 +311,7 @@
       "definition": "CREATE INDEX idx_cast_tmdb_twitter_id ON core.cast_tmdb USING btree (twitter_id) WHERE (twitter_id IS NOT NULL)"
     }
   ],
-  "rls_enabled": true,
+  "rls_enabled": false,
   "example_row": {
     "id": "00000000-0000-0000-0000-000000000000",
     "person_id": "00000000-0000-0000-0000-000000000000",

--- a/supabase/schema_docs/core.cast_tmdb.md
+++ b/supabase/schema_docs/core.cast_tmdb.md
@@ -59,7 +59,7 @@ id
 
 ## RLS Enabled
 
-true
+false
 
 ## Example Row
 

--- a/supabase/schema_docs/core.episode_images.json
+++ b/supabase/schema_docs/core.episode_images.json
@@ -265,6 +265,30 @@
       "default": null,
       "is_identity": "NO",
       "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_at",
+      "data_type": "timestamp with time zone",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_by_firebase_uid",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_reason",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
     }
   ],
   "primary_key": [
@@ -401,6 +425,14 @@
       ],
       "unique": false,
       "definition": "CREATE INDEX episode_images_tmdb_series_season_episode_idx ON core.episode_images USING btree (tmdb_series_id, season_number, episode_number)"
+    },
+    {
+      "name": "idx_episode_images_archived",
+      "columns": [
+        "archived_at) WHERE (archived_at IS NOT NULL"
+      ],
+      "unique": false,
+      "definition": "CREATE INDEX idx_episode_images_archived ON core.episode_images USING btree (archived_at) WHERE (archived_at IS NOT NULL)"
     }
   ],
   "rls_enabled": true,
@@ -437,6 +469,9 @@
     "hosted_content_type": "example",
     "hosted_bytes": 0,
     "hosted_etag": "example",
-    "hosted_at": "1970-01-01T00:00:00Z"
+    "hosted_at": "1970-01-01T00:00:00Z",
+    "archived_at": "1970-01-01T00:00:00Z",
+    "archived_by_firebase_uid": "example",
+    "archived_reason": "example"
   }
 }

--- a/supabase/schema_docs/core.episode_images.md
+++ b/supabase/schema_docs/core.episode_images.md
@@ -37,6 +37,9 @@
 | hosted_bytes | bigint | YES |  | NO | NEVER |
 | hosted_etag | text | YES |  | NO | NEVER |
 | hosted_at | timestamp with time zone | YES |  | NO | NEVER |
+| archived_at | timestamp with time zone | YES |  | NO | NEVER |
+| archived_by_firebase_uid | text | YES |  | NO | NEVER |
+| archived_reason | text | YES |  | NO | NEVER |
 
 ## Primary Key
 
@@ -67,6 +70,7 @@ id
 - episode_images_source_image_id_idx (non-unique): source, source_image_id) WHERE (source_image_id IS NOT NULL
 - episode_images_tmdb_episode_source_file_unique (unique): tmdb_series_id, season_number, episode_number, source, file_path
 - episode_images_tmdb_series_season_episode_idx (non-unique): tmdb_series_id, season_number, episode_number
+- idx_episode_images_archived (non-unique): archived_at) WHERE (archived_at IS NOT NULL
 
 ## RLS Enabled
 
@@ -108,6 +112,9 @@ true
   "hosted_content_type": "example",
   "hosted_bytes": 0,
   "hosted_etag": "example",
-  "hosted_at": "1970-01-01T00:00:00Z"
+  "hosted_at": "1970-01-01T00:00:00Z",
+  "archived_at": "1970-01-01T00:00:00Z",
+  "archived_by_firebase_uid": "example",
+  "archived_reason": "example"
 }
 ```

--- a/supabase/schema_docs/core.media_assets.json
+++ b/supabase/schema_docs/core.media_assets.json
@@ -282,6 +282,16 @@
       "definition": "CREATE INDEX idx_media_assets_archived ON core.media_assets USING btree (archived_at) WHERE (archived_at IS NOT NULL)"
     },
     {
+      "name": "idx_media_assets_id_source_hosted",
+      "columns": [
+        "id",
+        "source",
+        "hosted_url"
+      ],
+      "unique": false,
+      "definition": "CREATE INDEX idx_media_assets_id_source_hosted ON core.media_assets USING btree (id, source, hosted_url)"
+    },
+    {
       "name": "media_assets_hosted_url_idx",
       "columns": [
         "hosted_url) WHERE (hosted_url IS NOT NULL"

--- a/supabase/schema_docs/core.media_assets.md
+++ b/supabase/schema_docs/core.media_assets.md
@@ -53,6 +53,7 @@ id
 ## Indexes
 
 - idx_media_assets_archived (non-unique): archived_at) WHERE (archived_at IS NOT NULL
+- idx_media_assets_id_source_hosted (non-unique): id, source, hosted_url
 - media_assets_hosted_url_idx (non-unique): hosted_url) WHERE (hosted_url IS NOT NULL
 - media_assets_ingest_next_retry_idx (non-unique): ingest_next_retry_at) WHERE ((ingest_status = 'failed'::text) AND (ingest_next_retry_at IS NOT NULL)
 - media_assets_ingest_pending_failed_idx (non-unique): source, ingest_status) WHERE (ingest_status = ANY (ARRAY['pending'::text, 'failed'::text])

--- a/supabase/schema_docs/core.media_links.json
+++ b/supabase/schema_docs/core.media_links.json
@@ -104,6 +104,17 @@
   "unique_constraints": [],
   "indexes": [
     {
+      "name": "idx_media_links_person_gallery_entity_kind_id",
+      "columns": [
+        "entity_type",
+        "entity_id",
+        "kind",
+        "id) WHERE ((entity_type = 'person'::text) AND (kind = 'gallery'::text)"
+      ],
+      "unique": false,
+      "definition": "CREATE INDEX idx_media_links_person_gallery_entity_kind_id ON core.media_links USING btree (entity_type, entity_id, kind, id) WHERE ((entity_type = 'person'::text) AND (kind = 'gallery'::text))"
+    },
+    {
       "name": "media_links_entity_idx",
       "columns": [
         "entity_type",

--- a/supabase/schema_docs/core.media_links.md
+++ b/supabase/schema_docs/core.media_links.md
@@ -30,6 +30,7 @@ id
 
 ## Indexes
 
+- idx_media_links_person_gallery_entity_kind_id (non-unique): entity_type, entity_id, kind, id) WHERE ((entity_type = 'person'::text) AND (kind = 'gallery'::text)
 - media_links_entity_idx (non-unique): entity_type, entity_id
 - media_links_entity_kind_asset_uq (unique): entity_type, entity_id, kind, media_asset_id
 - media_links_facebank_seed_idx (non-unique): entity_type, entity_id, kind, facebank_seed

--- a/supabase/schema_docs/core.people.json
+++ b/supabase/schema_docs/core.people.json
@@ -97,6 +97,14 @@
       "default": "'{}'::jsonb",
       "is_identity": "NO",
       "is_generated": "NEVER"
+    },
+    {
+      "name": "alternative_names",
+      "data_type": "jsonb",
+      "is_nullable": "NO",
+      "default": "'{}'::jsonb",
+      "is_identity": "NO",
+      "is_generated": "NEVER"
     }
   ],
   "primary_key": [
@@ -143,6 +151,7 @@
     "biography": {},
     "place_of_birth": {},
     "homepage": {},
-    "profile_image_url": {}
+    "profile_image_url": {},
+    "alternative_names": {}
   }
 }

--- a/supabase/schema_docs/core.people.md
+++ b/supabase/schema_docs/core.people.md
@@ -16,6 +16,7 @@
 | place_of_birth | jsonb | NO | '{}'::jsonb | NO | NEVER |
 | homepage | jsonb | NO | '{}'::jsonb | NO | NEVER |
 | profile_image_url | jsonb | NO | '{}'::jsonb | NO | NEVER |
+| alternative_names | jsonb | NO | '{}'::jsonb | NO | NEVER |
 
 ## Primary Key
 
@@ -54,6 +55,7 @@ true
   "biography": {},
   "place_of_birth": {},
   "homepage": {},
-  "profile_image_url": {}
+  "profile_image_url": {},
+  "alternative_names": {}
 }
 ```

--- a/supabase/schema_docs/core.season_images.json
+++ b/supabase/schema_docs/core.season_images.json
@@ -265,6 +265,30 @@
       "default": null,
       "is_identity": "NO",
       "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_at",
+      "data_type": "timestamp with time zone",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_by_firebase_uid",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "archived_reason",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
     }
   ],
   "primary_key": [
@@ -311,6 +335,14 @@
       ],
       "unique": true,
       "definition": "CREATE UNIQUE INDEX core_season_images_unique ON core.season_images USING btree (tmdb_series_id, season_number, source, file_path)"
+    },
+    {
+      "name": "idx_season_images_archived",
+      "columns": [
+        "archived_at) WHERE (archived_at IS NOT NULL"
+      ],
+      "unique": false,
+      "definition": "CREATE INDEX idx_season_images_archived ON core.season_images USING btree (archived_at) WHERE (archived_at IS NOT NULL)"
     },
     {
       "name": "season_images_fetch_method_idx",
@@ -390,6 +422,9 @@
     "updated_at": "1970-01-01T00:00:00Z",
     "created_at": "1970-01-01T00:00:00Z",
     "fetch_method": "example",
-    "fetched_from_url": "example"
+    "fetched_from_url": "example",
+    "archived_at": "1970-01-01T00:00:00Z",
+    "archived_by_firebase_uid": "example",
+    "archived_reason": "example"
   }
 }

--- a/supabase/schema_docs/core.season_images.md
+++ b/supabase/schema_docs/core.season_images.md
@@ -37,6 +37,9 @@
 | created_at | timestamp with time zone | NO | now() | NO | NEVER |
 | fetch_method | text | YES |  | NO | NEVER |
 | fetched_from_url | text | YES |  | NO | NEVER |
+| archived_at | timestamp with time zone | YES |  | NO | NEVER |
+| archived_by_firebase_uid | text | YES |  | NO | NEVER |
+| archived_reason | text | YES |  | NO | NEVER |
 
 ## Primary Key
 
@@ -56,6 +59,7 @@ id
 - core_season_images_season_id_idx (non-unique): season_id
 - core_season_images_tmdb_series_season_idx (non-unique): tmdb_series_id, season_number
 - core_season_images_unique (unique): tmdb_series_id, season_number, source, file_path
+- idx_season_images_archived (non-unique): archived_at) WHERE (archived_at IS NOT NULL
 - season_images_fetch_method_idx (non-unique): fetch_method
 - season_images_metadata_idx (non-unique): metadata
 - season_images_pkey (unique): id
@@ -102,6 +106,9 @@ true
   "updated_at": "1970-01-01T00:00:00Z",
   "created_at": "1970-01-01T00:00:00Z",
   "fetch_method": "example",
-  "fetched_from_url": "example"
+  "fetched_from_url": "example",
+  "archived_at": "1970-01-01T00:00:00Z",
+  "archived_by_firebase_uid": "example",
+  "archived_reason": "example"
 }
 ```

--- a/supabase/schema_docs/core.show_images.json
+++ b/supabase/schema_docs/core.show_images.json
@@ -99,33 +99,9 @@
       "is_generated": "ALWAYS"
     },
     {
-      "name": "caption",
-      "data_type": "text",
-      "is_nullable": "YES",
-      "default": null,
-      "is_identity": "NO",
-      "is_generated": "NEVER"
-    },
-    {
       "name": "source_image_id",
       "data_type": "text",
       "is_nullable": "NO",
-      "default": null,
-      "is_identity": "NO",
-      "is_generated": "NEVER"
-    },
-    {
-      "name": "image_type",
-      "data_type": "text",
-      "is_nullable": "YES",
-      "default": null,
-      "is_identity": "NO",
-      "is_generated": "NEVER"
-    },
-    {
-      "name": "position",
-      "data_type": "integer",
-      "is_nullable": "YES",
       "default": null,
       "is_identity": "NO",
       "is_generated": "NEVER"
@@ -147,6 +123,22 @@
       "is_generated": "NEVER"
     },
     {
+      "name": "caption",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "position",
+      "data_type": "integer",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
       "name": "metadata",
       "data_type": "jsonb",
       "is_nullable": "NO",
@@ -155,7 +147,15 @@
       "is_generated": "NEVER"
     },
     {
-      "name": "updated_at",
+      "name": "image_type",
+      "data_type": "text",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
+      "name": "created_at",
       "data_type": "timestamp with time zone",
       "is_nullable": "NO",
       "default": "now()",
@@ -163,7 +163,7 @@
       "is_generated": "NEVER"
     },
     {
-      "name": "created_at",
+      "name": "updated_at",
       "data_type": "timestamp with time zone",
       "is_nullable": "NO",
       "default": "now()",
@@ -413,25 +413,6 @@
       "definition": "CREATE UNIQUE INDEX show_images_show_source_source_image_id_key ON core.show_images USING btree (show_id, source, source_image_id)"
     },
     {
-      "name": "show_images_source_image_id_idx",
-      "columns": [
-        "source",
-        "source_image_id) WHERE (source_image_id IS NOT NULL"
-      ],
-      "unique": false,
-      "definition": "CREATE INDEX show_images_source_image_id_idx ON core.show_images USING btree (source, source_image_id) WHERE (source_image_id IS NOT NULL)"
-    },
-    {
-      "name": "show_images_source_unique",
-      "columns": [
-        "show_id",
-        "source",
-        "source_image_id"
-      ],
-      "unique": true,
-      "definition": "CREATE UNIQUE INDEX show_images_source_unique ON core.show_images USING btree (show_id, source, source_image_id)"
-    },
-    {
       "name": "show_images_tmdb_source_kind_file_path_key",
       "columns": [
         "tmdb_id",
@@ -457,15 +438,15 @@
     "fetched_at": "1970-01-01T00:00:00Z",
     "tmdb_id": 0,
     "url_original": "example",
-    "caption": "example",
     "source_image_id": "example",
-    "image_type": "example",
-    "position": 0,
     "url": "example",
     "url_path": "example",
+    "caption": "example",
+    "position": 0,
     "metadata": {},
-    "updated_at": "1970-01-01T00:00:00Z",
+    "image_type": "example",
     "created_at": "1970-01-01T00:00:00Z",
+    "updated_at": "1970-01-01T00:00:00Z",
     "fetch_method": "example",
     "fetched_from_url": "example",
     "hosted_bucket": "example",

--- a/supabase/schema_docs/core.show_images.md
+++ b/supabase/schema_docs/core.show_images.md
@@ -16,15 +16,15 @@
 | fetched_at | timestamp with time zone | NO | now() | NO | NEVER |
 | tmdb_id | integer | YES |  | NO | NEVER |
 | url_original | text | YES |  | NO | ALWAYS |
-| caption | text | YES |  | NO | NEVER |
 | source_image_id | text | NO |  | NO | NEVER |
-| image_type | text | YES |  | NO | NEVER |
-| position | integer | YES |  | NO | NEVER |
 | url | text | NO |  | NO | NEVER |
 | url_path | text | YES |  | NO | NEVER |
+| caption | text | YES |  | NO | NEVER |
+| position | integer | YES |  | NO | NEVER |
 | metadata | jsonb | NO | '{}'::jsonb | NO | NEVER |
-| updated_at | timestamp with time zone | NO | now() | NO | NEVER |
+| image_type | text | YES |  | NO | NEVER |
 | created_at | timestamp with time zone | NO | now() | NO | NEVER |
+| updated_at | timestamp with time zone | NO | now() | NO | NEVER |
 | fetch_method | text | YES |  | NO | NEVER |
 | fetched_from_url | text | YES |  | NO | NEVER |
 | hosted_bucket | text | YES |  | NO | NEVER |
@@ -67,8 +67,6 @@ id
 - show_images_fetch_method_idx (non-unique): fetch_method
 - show_images_pkey (unique): id
 - show_images_show_source_source_image_id_key (unique): show_id, source, source_image_id
-- show_images_source_image_id_idx (non-unique): source, source_image_id) WHERE (source_image_id IS NOT NULL
-- show_images_source_unique (unique): show_id, source, source_image_id
 - show_images_tmdb_source_kind_file_path_key (unique): tmdb_id, source, kind, file_path
 
 ## RLS Enabled
@@ -91,15 +89,15 @@ true
   "fetched_at": "1970-01-01T00:00:00Z",
   "tmdb_id": 0,
   "url_original": "example",
-  "caption": "example",
   "source_image_id": "example",
-  "image_type": "example",
-  "position": 0,
   "url": "example",
   "url_path": "example",
+  "caption": "example",
+  "position": 0,
   "metadata": {},
-  "updated_at": "1970-01-01T00:00:00Z",
+  "image_type": "example",
   "created_at": "1970-01-01T00:00:00Z",
+  "updated_at": "1970-01-01T00:00:00Z",
   "fetch_method": "example",
   "fetched_from_url": "example",
   "hosted_bucket": "example",

--- a/supabase/schema_docs/core.shows.json
+++ b/supabase/schema_docs/core.shows.json
@@ -315,6 +315,14 @@
       "is_generated": "NEVER"
     },
     {
+      "name": "imdb_meta",
+      "data_type": "jsonb",
+      "is_nullable": "YES",
+      "default": null,
+      "is_identity": "NO",
+      "is_generated": "NEVER"
+    },
+    {
       "name": "tmdb_network_ids",
       "data_type": "ARRAY",
       "is_nullable": "YES",
@@ -331,26 +339,10 @@
       "is_generated": "NEVER"
     },
     {
-      "name": "imdb_meta",
-      "data_type": "jsonb",
-      "is_nullable": "YES",
-      "default": null,
-      "is_identity": "NO",
-      "is_generated": "NEVER"
-    },
-    {
       "name": "alternative_names",
       "data_type": "ARRAY",
       "is_nullable": "NO",
       "default": "'{}'::text[]",
-      "is_identity": "NO",
-      "is_generated": "NEVER"
-    },
-    {
-      "name": "external_ids",
-      "data_type": "jsonb",
-      "is_nullable": "NO",
-      "default": "'{}'::jsonb",
       "is_identity": "NO",
       "is_generated": "NEVER"
     },
@@ -400,32 +392,6 @@
       ],
       "unique": false,
       "definition": "CREATE INDEX core_shows_alternative_names_gin ON core.shows USING gin (alternative_names)"
-    },
-    {
-      "name": "core_shows_external_ids_gin",
-      "columns": [
-        "external_ids"
-      ],
-      "unique": false,
-      "definition": "CREATE INDEX core_shows_external_ids_gin ON core.shows USING gin (external_ids)"
-    },
-    {
-      "name": "core_shows_external_ids_imdb_unique",
-      "columns": [
-        "((external_ids ->> 'imdb'::text))) WHERE (COALESCE((external_ids ->> 'imdb'::text)",
-        "''::text) <> ''::text"
-      ],
-      "unique": true,
-      "definition": "CREATE UNIQUE INDEX core_shows_external_ids_imdb_unique ON core.shows USING btree (((external_ids ->> 'imdb'::text))) WHERE (COALESCE((external_ids ->> 'imdb'::text), ''::text) <> ''::text)"
-    },
-    {
-      "name": "core_shows_external_ids_tmdb_unique",
-      "columns": [
-        "((external_ids ->> 'tmdb'::text))) WHERE (COALESCE((external_ids ->> 'tmdb'::text)",
-        "''::text) <> ''::text"
-      ],
-      "unique": true,
-      "definition": "CREATE UNIQUE INDEX core_shows_external_ids_tmdb_unique ON core.shows USING btree (((external_ids ->> 'tmdb'::text))) WHERE (COALESCE((external_ids ->> 'tmdb'::text), ''::text) <> ''::text)"
     },
     {
       "name": "core_shows_genres_gin",
@@ -565,11 +531,10 @@
     "tmdb_fetched_at": "1970-01-01T00:00:00Z",
     "imdb_fetched_at": "1970-01-01T00:00:00Z",
     "tmdb_meta": {},
+    "imdb_meta": {},
     "tmdb_network_ids": [],
     "tmdb_production_company_ids": [],
-    "imdb_meta": {},
     "alternative_names": [],
-    "external_ids": {},
     "most_recent_episode": {},
     "slug": "example"
   }

--- a/supabase/schema_docs/core.shows.md
+++ b/supabase/schema_docs/core.shows.md
@@ -43,11 +43,10 @@
 | tmdb_fetched_at | timestamp with time zone | YES |  | NO | NEVER |
 | imdb_fetched_at | timestamp with time zone | YES |  | NO | NEVER |
 | tmdb_meta | jsonb | YES |  | NO | NEVER |
+| imdb_meta | jsonb | YES |  | NO | NEVER |
 | tmdb_network_ids | ARRAY | YES |  | NO | NEVER |
 | tmdb_production_company_ids | ARRAY | YES |  | NO | NEVER |
-| imdb_meta | jsonb | YES |  | NO | NEVER |
 | alternative_names | ARRAY | NO | '{}'::text[] | NO | NEVER |
-| external_ids | jsonb | NO | '{}'::jsonb | NO | NEVER |
 | most_recent_episode | jsonb | NO | '{}'::jsonb | NO | NEVER |
 | slug | text | YES |  | NO | NEVER |
 
@@ -68,9 +67,6 @@ id
 ## Indexes
 
 - core_shows_alternative_names_gin (non-unique): alternative_names
-- core_shows_external_ids_gin (non-unique): external_ids
-- core_shows_external_ids_imdb_unique (unique): ((external_ids ->> 'imdb'::text))) WHERE (COALESCE((external_ids ->> 'imdb'::text), ''::text) <> ''::text
-- core_shows_external_ids_tmdb_unique (unique): ((external_ids ->> 'tmdb'::text))) WHERE (COALESCE((external_ids ->> 'tmdb'::text), ''::text) <> ''::text
 - core_shows_genres_gin (non-unique): genres
 - core_shows_imdb_id_unique (unique): imdb_id) WHERE ((imdb_id IS NOT NULL) AND (btrim(imdb_id) <> ''::text)
 - core_shows_keywords_gin (non-unique): keywords
@@ -131,11 +127,10 @@ true
   "tmdb_fetched_at": "1970-01-01T00:00:00Z",
   "imdb_fetched_at": "1970-01-01T00:00:00Z",
   "tmdb_meta": {},
+  "imdb_meta": {},
   "tmdb_network_ids": [],
   "tmdb_production_company_ids": [],
-  "imdb_meta": {},
   "alternative_names": [],
-  "external_ids": {},
   "most_recent_episode": {},
   "slug": "example"
 }

--- a/supabase/schema_docs/diagrams/core.cast_photos.mermaid.md
+++ b/supabase/schema_docs/diagrams/core.cast_photos.mermaid.md
@@ -44,6 +44,9 @@ erDiagram
         INTEGER hosted_bytes
         TEXT hosted_etag
         TIMESTAMP_WITH_TIME_ZONE hosted_at
+        TIMESTAMP_WITH_TIME_ZONE archived_at
+        TEXT archived_by_firebase_uid
+        TEXT archived_reason
         TEXT source_asset_id
     }
 ```

--- a/supabase/schema_docs/diagrams/core.episode_images.mermaid.md
+++ b/supabase/schema_docs/diagrams/core.episode_images.mermaid.md
@@ -37,5 +37,8 @@ erDiagram
         BIGINT hosted_bytes
         TEXT hosted_etag
         TIMESTAMP_WITH_TIME_ZONE hosted_at
+        TIMESTAMP_WITH_TIME_ZONE archived_at
+        TEXT archived_by_firebase_uid
+        TEXT archived_reason
     }
 ```

--- a/supabase/schema_docs/diagrams/core.people.mermaid.md
+++ b/supabase/schema_docs/diagrams/core.people.mermaid.md
@@ -16,5 +16,6 @@ erDiagram
         JSONB place_of_birth
         JSONB homepage
         JSONB profile_image_url
+        JSONB alternative_names
     }
 ```

--- a/supabase/schema_docs/diagrams/core.season_images.mermaid.md
+++ b/supabase/schema_docs/diagrams/core.season_images.mermaid.md
@@ -37,5 +37,8 @@ erDiagram
         TIMESTAMP_WITH_TIME_ZONE created_at
         TEXT fetch_method
         TEXT fetched_from_url
+        TIMESTAMP_WITH_TIME_ZONE archived_at
+        TEXT archived_by_firebase_uid
+        TEXT archived_reason
     }
 ```

--- a/supabase/schema_docs/diagrams/core.show_images.mermaid.md
+++ b/supabase/schema_docs/diagrams/core.show_images.mermaid.md
@@ -16,15 +16,15 @@ erDiagram
         TIMESTAMP_WITH_TIME_ZONE fetched_at
         INTEGER tmdb_id
         TEXT url_original
-        TEXT caption
         TEXT source_image_id
-        TEXT image_type
-        INTEGER position
         TEXT url
         TEXT url_path
+        TEXT caption
+        INTEGER position
         JSONB metadata
-        TIMESTAMP_WITH_TIME_ZONE updated_at
+        TEXT image_type
         TIMESTAMP_WITH_TIME_ZONE created_at
+        TIMESTAMP_WITH_TIME_ZONE updated_at
         TEXT fetch_method
         TEXT fetched_from_url
         TEXT hosted_bucket

--- a/supabase/schema_docs/diagrams/core.shows.mermaid.md
+++ b/supabase/schema_docs/diagrams/core.shows.mermaid.md
@@ -43,11 +43,10 @@ erDiagram
         TIMESTAMP_WITH_TIME_ZONE tmdb_fetched_at
         TIMESTAMP_WITH_TIME_ZONE imdb_fetched_at
         JSONB tmdb_meta
+        JSONB imdb_meta
         INT4_ARRAY tmdb_network_ids
         INT4_ARRAY tmdb_production_company_ids
-        JSONB imdb_meta
         TEXT_ARRAY alternative_names
-        JSONB external_ids
         JSONB most_recent_episode
         TEXT slug
     }


### PR DESCRIPTION
## Summary
- Schema docs were stale after migration renumbering and recent column additions
- Updates cast_photos, episode_images, media_assets, shows, and other table docs
- Adds bravotv_image_runs to INDEX.md

## Test plan
- [ ] CI schema-docs-check should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)