### PR TITLE
fix(youtube): count undated shorts pages toward the pre-window cap

### DIFF
--- a/tests/repositories/test_youtube_catalog_backfill_diagnostics.py
+++ b/tests/repositories/test_youtube_catalog_backfill_diagnostics.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 def test_youtube_empty_channel_page_sets_error_code():
     """When YouTube scraper returns 0 posts with no error_code,
@@ -17,17 +19,22 @@ def test_youtube_empty_channel_page_sets_error_code():
         "total_posts": 0,
     }
 
-    with patch(
-        "trr_backend.socials.youtube.YouTubeScraper",
-        return_value=mock_scraper_instance,
-    ), patch(
-        "trr_backend.socials.youtube.YouTubeDataApiClient",
-    ) as mock_api_cls, patch(
-        "trr_backend.repositories.social_season_analytics._shared_catalog_mode",
-        return_value=True,
-    ), patch(
-        "trr_backend.repositories.social_season_analytics._persist_shared_catalog_posts_with_progress",
-        return_value=[],
+    with (
+        patch(
+            "trr_backend.socials.youtube.YouTubeScraper",
+            return_value=mock_scraper_instance,
+        ),
+        patch(
+            "trr_backend.socials.youtube.YouTubeDataApiClient",
+        ) as mock_api_cls,
+        patch(
+            "trr_backend.repositories.social_season_analytics._shared_catalog_mode",
+            return_value=True,
+        ),
+        patch(
+            "trr_backend.repositories.social_season_analytics._persist_shared_catalog_posts_with_progress",
+            return_value=[],
+        ),
     ):
         mock_api_cls.return_value.enabled.return_value = False
 
@@ -44,3 +51,51 @@ def test_youtube_empty_channel_page_sets_error_code():
     assert len(rows) == 0
     assert meta.get("error_code") == "youtube_empty_channel_page"
     assert meta.get("retryable") is True
+
+
+@pytest.mark.parametrize(
+    "stats,expected",
+    [
+        # Classic: all items are before-window
+        (
+            {"before_window_items": 10, "window_candidate_items": 0, "after_window_items": 0, "timestamp_unknown": 0},
+            True,
+        ),
+        # All items are undated (shorts with low-precision timestamps)
+        (
+            {"before_window_items": 0, "window_candidate_items": 0, "after_window_items": 0, "timestamp_unknown": 30},
+            True,
+        ),
+        # Mix of before-window and undated
+        (
+            {"before_window_items": 5, "window_candidate_items": 0, "after_window_items": 0, "timestamp_unknown": 20},
+            True,
+        ),
+        # Has window candidates — not before-only
+        (
+            {"before_window_items": 5, "window_candidate_items": 1, "after_window_items": 0, "timestamp_unknown": 10},
+            False,
+        ),
+        # Has after-window items — not before-only
+        (
+            {"before_window_items": 5, "window_candidate_items": 0, "after_window_items": 2, "timestamp_unknown": 0},
+            False,
+        ),
+        # Completely empty page — neither before nor anything
+        (
+            {"before_window_items": 0, "window_candidate_items": 0, "after_window_items": 0, "timestamp_unknown": 0},
+            False,
+        ),
+    ],
+    ids=["dated-before", "all-undated", "mixed-before-undated", "has-candidates", "has-after", "empty"],
+)
+def test_page_before_only_includes_undated_shorts(stats, expected):
+    """page_before_only should be True for pages with only before-window
+    and/or timestamp_unknown items, so the pre_window_page_cap triggers
+    correctly for shorts surfaces with low-precision dates."""
+    _has_window = bool(stats.get("window_candidate_items"))
+    _has_after = bool(stats.get("after_window_items"))
+    _has_before = bool(stats.get("before_window_items"))
+    _has_unknown = bool(stats.get("timestamp_unknown"))
+    page_before_only = (_has_before or _has_unknown) and not _has_window and not _has_after
+    assert page_before_only is expected

--- a/trr_backend/socials/youtube/scraper.py
+++ b/trr_backend/socials/youtube/scraper.py
@@ -1852,10 +1852,18 @@ class YouTubeScraper:
                 in_range_hits += int(page_stats.get("in_range_hits") or 0)
                 timestamp_unknown_count += int(page_stats.get("timestamp_unknown") or 0)
 
+                # Treat pages with only before-window and/or undated items as
+                # "before window" for capping.  Without this, shorts pages full
+                # of undated items (timestamp_unknown) never count toward the
+                # pre_window_page_cap and the scraper paginates indefinitely.
+                _has_window = bool(page_stats.get("window_candidate_items"))
+                _has_after = bool(page_stats.get("after_window_items"))
+                _has_before = bool(page_stats.get("before_window_items"))
+                _has_unknown = bool(page_stats.get("timestamp_unknown"))
                 page_before_only = (
-                    bool(page_stats.get("before_window_items"))
-                    and not bool(page_stats.get("window_candidate_items"))
-                    and not bool(page_stats.get("after_window_items"))
+                    (_has_before or _has_unknown)
+                    and not _has_window
+                    and not _has_after
                 )
                 page_after_only = (
                     bool(page_stats.get("after_window_items"))

--- a/trr_backend/socials/youtube/scraper.py
+++ b/trr_backend/socials/youtube/scraper.py
@@ -1860,11 +1860,7 @@ class YouTubeScraper:
                 _has_after = bool(page_stats.get("after_window_items"))
                 _has_before = bool(page_stats.get("before_window_items"))
                 _has_unknown = bool(page_stats.get("timestamp_unknown"))
-                page_before_only = (
-                    (_has_before or _has_unknown)
-                    and not _has_window
-                    and not _has_after
-                )
+                page_before_only = (_has_before or _has_unknown) and not _has_window and not _has_after
                 page_after_only = (
                     bool(page_stats.get("after_window_items"))
                     and not bool(page_stats.get("window_candidate_items"))


### PR DESCRIPTION
## Summary
- cherry-pick the reviewed YouTube pre-window cap fix from local main
- count undated Shorts pages toward `page_before_only` so the scraper stops correctly before the requested window
- keep this change isolated from the TikTok incident PR

## Validation
- `ruff check trr_backend/socials/youtube/scraper.py tests/repositories/test_youtube_catalog_backfill_diagnostics.py`: passed
- `ruff format --check trr_backend/socials/youtube/scraper.py tests/repositories/test_youtube_catalog_backfill_diagnostics.py`: passed
- `pytest -q tests/repositories/test_youtube_catalog_backfill_diagnostics.py`: passed