### PR TITLE
fix(tiktok): commit the ytdlp pivot and recovery diagnostics

### DIFF
--- a/api/routers/socials.py
+++ b/api/routers/socials.py
@@ -900,9 +900,7 @@ def _resolve_social_account_catalog_route_execution(
     queue_enabled = is_queue_enabled()
     remote_plane_enforced = is_remote_job_plane_enabled()
     used_inline_fallback = False
-    normalized_execution_preference = (
-        str(execution_preference or "auto").strip().lower() or "auto"
-    )
+    normalized_execution_preference = str(execution_preference or "auto").strip().lower() or "auto"
     prefer_local_inline = normalized_execution_preference == "prefer_local_inline"
     requires_modal_executor = _shared_account_catalog_requires_modal_executor(
         platform=platform,
@@ -1461,7 +1459,25 @@ class TikTokScrapeResponse(BaseModel):
     posts_found: int
     posts: list[TikTokPostResponse]
     filters_applied: dict
+    diagnostics: dict[str, Any] | None = None
     error: str | None = None
+
+
+def _build_tiktok_scrape_diagnostics(retrieval_meta: dict[str, Any]) -> dict[str, Any] | None:
+    allowed_keys = (
+        "retrieval_mode",
+        "http_client",
+        "fallback_chain",
+        "stop_reason",
+        "error_code",
+        "risk_state",
+        "operator_summary",
+        "operator_action",
+        "triage_bucket",
+        "profile_enrichment_status",
+    )
+    diagnostics = {key: retrieval_meta[key] for key in allowed_keys if key in retrieval_meta}
+    return diagnostics or None
 
 
 # TikTok Endpoints
@@ -1499,6 +1515,7 @@ async def scrape_tiktok(
         tiktok_cookies = _load_social_auth_or_503(platform="tiktok", surface="scrape", loader=_load_tiktok_cookies)
         scraper = TikTokScraper(cookies=tiktok_cookies)
         posts = scraper.scrape(config)
+        diagnostics = _build_tiktok_scrape_diagnostics(dict(getattr(scraper, "last_retrieval_meta", {}) or {}))
 
         return TikTokScrapeResponse(
             success=True,
@@ -1529,6 +1546,7 @@ async def scrape_tiktok(
                 "date_start": request.date_start.isoformat(),
                 "date_end": request.date_end.isoformat(),
             },
+            diagnostics=diagnostics,
         )
     except HTTPException:
         raise

--- a/scripts/socials/tiktok/scrape.py
+++ b/scripts/socials/tiktok/scrape.py
@@ -19,6 +19,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Add project root to path (scripts/socials/tiktok -> project root)
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
@@ -42,6 +43,115 @@ logger = logging.getLogger(__name__)
 def parse_date(date_str: str) -> datetime:
     """Parse date string in YYYY-MM-DD format."""
     return datetime.strptime(date_str, "%Y-%m-%d")
+
+
+def _proxy_label(proxy_url: str | None) -> str | None:
+    if not proxy_url:
+        return None
+    parsed = urlparse(str(proxy_url))
+    return parsed.hostname or str(proxy_url)
+
+
+def _parse_args(argv: list[str] | None = None) -> tuple[argparse.ArgumentParser, argparse.Namespace]:
+    parser = argparse.ArgumentParser(
+        description="Scrape TikTok posts and comments",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Scrape @bravotv posts with #RHOSLC
+  python -m scripts.socials.tiktok.scrape --username bravotv --hashtags RHOSLC --start 2025-08-14 --end 2026-02-04
+
+  # Scrape comments from a specific video
+  python -m scripts.socials.tiktok.scrape --comments --video 7123456789012345678 --video-user bravotv
+
+  # Scrape comments with replies and limit
+  python -m scripts.socials.tiktok.scrape --comments --video 7123456789012345678 --with-replies --max-comments 100
+        """,
+    )
+
+    parser.add_argument("--username", help="TikTok username to scrape (without @)")
+    parser.add_argument("--hashtags", nargs="+", help="Hashtags to filter by (without #)")
+    parser.add_argument("--start", help="Start date (YYYY-MM-DD)")
+    parser.add_argument("--end", help="End date (YYYY-MM-DD)")
+    parser.add_argument(
+        "--scrape-mode",
+        choices=("ytdlp", "api", "browser_intercept", "auto"),
+        default="ytdlp",
+        help=(
+            "Post scrape mode. Use 'ytdlp' for the production path. "
+            "'api' and 'browser_intercept' are experimental direct modes; "
+            "'auto' is a deprecated compatibility alias for 'ytdlp'."
+        ),
+    )
+    parser.add_argument("--comments", action="store_true", help="Scrape comments instead of posts")
+    parser.add_argument("--video", help="Video ID to scrape comments from (aweme_id)")
+    parser.add_argument("--video-user", help="Username of the video author (optional, for building URL)")
+    parser.add_argument("--with-replies", action="store_true", help="Also fetch replies to comments")
+    parser.add_argument("--max-comments", type=int, help="Maximum number of top-level comments to fetch")
+    parser.add_argument("--cookies", default="tiktok_cookies.json", help="Path to TikTok cookies JSON file")
+    parser.add_argument("--no-auth", action="store_true", help="Run without authentication (may limit availability)")
+    parser.add_argument("--output", help="Output file prefix (default: {username}_tiktok_posts or {video_id}_comments)")
+    parser.add_argument("--delay", type=float, default=2.0, help="Delay between requests in seconds (default: 2.0)")
+    parser.add_argument("--max-pages", type=int, help="Maximum number of pages to fetch (posts only)")
+    parser.add_argument("--show-id", type=int, help="Associated show ID for metadata")
+    parser.add_argument("--season", type=int, help="Associated season number for metadata")
+    parser.add_argument("--person-id", type=int, help="Associated person ID for metadata")
+    parser.add_argument(
+        "--http-client",
+        choices=("requests", "curl_cffi"),
+        help="HTTP transport for experimental direct TikTok requests only",
+    )
+    parser.add_argument(
+        "--proxy-url",
+        help="Single proxy URL for the experimental direct TikTok scraper transport only",
+    )
+    parser.add_argument("--diagnostics-json", help="Optional path to write scraper diagnostics JSON")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    return parser, parser.parse_args(argv)
+
+
+def _emit_diagnostics_summary(
+    *,
+    target_label: str,
+    scrape_mode: str,
+    diagnostics: dict[str, object],
+) -> None:
+    endpoint_responses = diagnostics.get("endpoint_responses") if isinstance(diagnostics, dict) else {}
+    endpoint_responses = endpoint_responses if isinstance(endpoint_responses, dict) else {}
+    failure_summary = {
+        endpoint: payload.get("failure_reason")
+        for endpoint, payload in endpoint_responses.items()
+        if isinstance(payload, dict) and payload.get("failure_reason")
+    }
+
+    print("\nDiagnostics:")
+    print(f"  Target: {target_label}")
+    print(f"  Scrape mode: {scrape_mode}")
+    print(f"  HTTP client: {diagnostics.get('http_client') or 'requests'}")
+    if diagnostics.get("curl_cffi_impersonate"):
+        print(f"  Impersonate: {diagnostics.get('curl_cffi_impersonate')}")
+    print(f"  Proxy: {diagnostics.get('proxy_label') or 'none'}")
+    print(f"  Auth mode: {diagnostics.get('auth_mode') or 'without_cookies'}")
+    if diagnostics.get("risk_state"):
+        print(f"  Risk state: {diagnostics.get('risk_state')}")
+    if diagnostics.get("operator_summary"):
+        print(f"  Operator summary: {diagnostics.get('operator_summary')}")
+    if diagnostics.get("operator_action"):
+        print(f"  Operator action: {diagnostics.get('operator_action')}")
+    if diagnostics.get("triage_bucket"):
+        print(f"  Triage bucket: {diagnostics.get('triage_bucket')}")
+    if diagnostics.get("stop_reason"):
+        print(f"  Stop reason: {diagnostics.get('stop_reason')}")
+    if failure_summary:
+        print(f"  Endpoint failures: {json.dumps(failure_summary, sort_keys=True)}")
+
+
+def _write_diagnostics_json(path: str | None, diagnostics: dict[str, object]) -> None:
+    if not path:
+        return
+    target = Path(path).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(diagnostics, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
 
 
 def save_results(posts: list[TikTokPost], output_prefix: str):
@@ -158,112 +268,8 @@ def save_comments(comments: list[TikTokComment], output_prefix: str, video_id: s
     logger.info(f"Saved {len(rows)} comments to {csv_file}")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Scrape TikTok posts and comments",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  # Scrape @bravotv posts with #RHOSLC
-  python -m scripts.socials.tiktok.scrape --username bravotv --hashtags RHOSLC --start 2025-08-14 --end 2026-02-04
-
-  # Scrape comments from a specific video
-  python -m scripts.socials.tiktok.scrape --comments --video 7123456789012345678 --video-user bravotv
-
-  # Scrape comments with replies and limit
-  python -m scripts.socials.tiktok.scrape --comments --video 7123456789012345678 --with-replies --max-comments 100
-        """,
-    )
-
-    # Post scraping arguments
-    parser.add_argument("--username", help="TikTok username to scrape (without @)")
-    parser.add_argument(
-        "--hashtags",
-        nargs="+",
-        help="Hashtags to filter by (without #)",
-    )
-    parser.add_argument(
-        "--start",
-        help="Start date (YYYY-MM-DD)",
-    )
-    parser.add_argument(
-        "--end",
-        help="End date (YYYY-MM-DD)",
-    )
-
-    # Comment scraping arguments
-    parser.add_argument(
-        "--comments",
-        action="store_true",
-        help="Scrape comments instead of posts",
-    )
-    parser.add_argument(
-        "--video",
-        help="Video ID to scrape comments from (aweme_id)",
-    )
-    parser.add_argument(
-        "--video-user",
-        help="Username of the video author (optional, for building URL)",
-    )
-    parser.add_argument(
-        "--with-replies",
-        action="store_true",
-        help="Also fetch replies to comments",
-    )
-    parser.add_argument(
-        "--max-comments",
-        type=int,
-        help="Maximum number of top-level comments to fetch",
-    )
-
-    # Common arguments
-    parser.add_argument(
-        "--cookies",
-        default="tiktok_cookies.json",
-        help="Path to TikTok cookies JSON file",
-    )
-    parser.add_argument(
-        "--no-auth",
-        action="store_true",
-        help="Run without authentication (may limit availability)",
-    )
-    parser.add_argument(
-        "--output",
-        help="Output file prefix (default: {username}_tiktok_posts or {video_id}_comments)",
-    )
-    parser.add_argument(
-        "--delay",
-        type=float,
-        default=2.0,
-        help="Delay between requests in seconds (default: 2.0)",
-    )
-    parser.add_argument(
-        "--max-pages",
-        type=int,
-        help="Maximum number of pages to fetch (posts only)",
-    )
-    parser.add_argument(
-        "--show-id",
-        type=int,
-        help="Associated show ID for metadata",
-    )
-    parser.add_argument(
-        "--season",
-        type=int,
-        help="Associated season number for metadata",
-    )
-    parser.add_argument(
-        "--person-id",
-        type=int,
-        help="Associated person ID for metadata",
-    )
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Enable debug logging",
-    )
-
-    args = parser.parse_args()
+def main(argv: list[str] | None = None):
+    parser, args = _parse_args(argv)
 
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
@@ -288,7 +294,11 @@ Examples:
         except Exception as exc:
             logger.error("Failed to load TikTok cookies: %s", exc)
             logger.warning("Running TikTok scrape without authenticated cookies")
-    scraper = TikTokScraper(cookies=tiktok_cookies)
+    scraper = TikTokScraper(
+        cookies=tiktok_cookies,
+        http_client_name=args.http_client,
+        proxy_urls=[args.proxy_url] if args.proxy_url else None,
+    )
 
     # Comment scraping mode
     if args.comments:
@@ -355,12 +365,19 @@ Examples:
         date_end=parse_date(args.end),
         delay_seconds=args.delay,
         max_pages=args.max_pages,
+        scrape_mode=args.scrape_mode,
         show_id=args.show_id,
         season_number=args.season,
         person_id=args.person_id,
     )
 
     posts = scraper.scrape(config)
+    diagnostics = dict(getattr(scraper, "last_retrieval_meta", {}) or {})
+    if args.proxy_url and "proxy_label" not in diagnostics:
+        diagnostics["proxy_label"] = _proxy_label(args.proxy_url)
+    if diagnostics:
+        _emit_diagnostics_summary(target_label=args.username, scrape_mode=args.scrape_mode, diagnostics=diagnostics)
+        _write_diagnostics_json(args.diagnostics_json, diagnostics)
 
     # Print summary
     print("\n" + "=" * 60)

--- a/tests/api/routers/test_socials_tiktok_scrape.py
+++ b/tests/api/routers/test_socials_tiktok_scrape.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from api.routers import socials as socials_router
+
+
+def test_scrape_tiktok_returns_safe_diagnostics_subset(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeScraper:
+        def __init__(self, *, cookies=None):  # noqa: ANN003
+            captured["cookies"] = cookies
+            self.last_retrieval_meta = {
+                "retrieval_mode": "browser_intercept",
+                "http_client": "curl_cffi",
+                "fallback_chain": ["browser_intercept", "ytdlp"],
+                "stop_reason": "path_degraded",
+                "error_code": "tiktok_posts_path_degraded",
+                "risk_state": "critical",
+                "operator_summary": "TikTok posts path degraded; use browser intercept.",
+                "operator_action": "Retry with browser intercept.",
+                "triage_bucket": "manual_review",
+                "profile_enrichment_status": "partial",
+                "ignored_field": "should_not_escape",
+            }
+
+        def scrape(self, config):  # noqa: ANN001
+            captured["config"] = config
+            return []
+
+    def _fake_preflight(*, platform: str, surface: str, loader):  # noqa: ANN001
+        captured["preflight"] = {"platform": platform, "surface": surface, "loader": loader}
+        return {"sessionid": "cookie"}
+
+    monkeypatch.setattr(socials_router, "_load_social_auth_or_503", _fake_preflight)
+    monkeypatch.setattr("trr_backend.socials.tiktok.TikTokScraper", _FakeScraper)
+
+    payload = asyncio.run(
+        socials_router.scrape_tiktok(
+            socials_router.TikTokScrapeRequest(
+                username="bravotv",
+                hashtags=["RHOSLC"],
+                date_start=datetime(2025, 1, 1, tzinfo=UTC),
+                date_end=datetime(2025, 1, 2, tzinfo=UTC),
+            ),
+            {"email": "admin@example.com"},
+        )
+    )
+
+    assert captured["preflight"]["platform"] == "tiktok"
+    assert captured["preflight"]["surface"] == "scrape"
+    assert captured["cookies"] == {"sessionid": "cookie"}
+    assert payload.diagnostics["risk_state"] == "critical"
+    assert payload.diagnostics["operator_summary"].startswith("TikTok posts path degraded")
+    assert "ignored_field" not in payload.diagnostics
+    assert set(payload.diagnostics) <= {
+        "retrieval_mode",
+        "http_client",
+        "fallback_chain",
+        "stop_reason",
+        "error_code",
+        "risk_state",
+        "operator_summary",
+        "operator_action",
+        "triage_bucket",
+        "profile_enrichment_status",
+    }

--- a/tests/repositories/test_social_season_analytics.py
+++ b/tests/repositories/test_social_season_analytics.py
@@ -4188,7 +4188,7 @@ def test_ingest_shared_accounts_tiktok_full_history_prefer_local_inline_seeds_di
     monkeypatch.setattr(
         social_repo,
         "_best_known_social_account_total_posts",
-        lambda _platform, _account_handle, **kwargs: (best_known_calls.append(kwargs) or 3277),
+        lambda _platform, _account_handle, **kwargs: best_known_calls.append(kwargs) or 3277,
     )
     monkeypatch.setattr(social_repo, "_cached_live_profile_total_posts", lambda *_args, **_kwargs: 0)
     monkeypatch.setattr(social_repo, "_run_counter_columns_ready", lambda: False)
@@ -4644,8 +4644,10 @@ def test_start_social_account_catalog_backfill_auto_resumes_instagram_full_histo
     monkeypatch.setattr(
         social_repo,
         "ingest_shared_accounts",
-        lambda **kwargs: ingest_calls.append(dict(kwargs))
-        or {"run_id": "catalog-run-auto-resume-1", "status": "queued", "catalog_action": "backfill"},
+        lambda **kwargs: (
+            ingest_calls.append(dict(kwargs))
+            or {"run_id": "catalog-run-auto-resume-1", "status": "queued", "catalog_action": "backfill"}
+        ),
     )
 
     payload = social_repo.start_social_account_catalog_backfill(
@@ -4680,8 +4682,10 @@ def test_start_social_account_catalog_backfill_starts_fresh_without_resumable_fr
     monkeypatch.setattr(
         social_repo,
         "ingest_shared_accounts",
-        lambda **kwargs: ingest_calls.append(dict(kwargs))
-        or {"run_id": "catalog-run-fresh-1", "status": "queued", "catalog_action": "backfill"},
+        lambda **kwargs: (
+            ingest_calls.append(dict(kwargs))
+            or {"run_id": "catalog-run-fresh-1", "status": "queued", "catalog_action": "backfill"}
+        ),
     )
 
     payload = social_repo.start_social_account_catalog_backfill(
@@ -24874,19 +24878,21 @@ def test_run_shared_account_frontier_posts_stage_continues_when_discovered_posts
     monkeypatch.setattr(
         social_repo,
         "_update_shared_account_run_frontier",
-        lambda **kwargs: frontier_updates.append(kwargs)
-        or {
-            "status": kwargs.get("status"),
-            "next_cursor": kwargs.get("next_cursor"),
-            "pages_scanned": kwargs.get("pages_scanned"),
-            "posts_checked": kwargs.get("posts_checked"),
-            "posts_saved": kwargs.get("posts_saved"),
-            "total_posts": kwargs.get("total_posts"),
-            "last_transport": kwargs.get("last_transport"),
-            "retry_count": kwargs.get("retry_count", 0),
-            "metadata": kwargs.get("metadata_updates", {}),
-            "exhausted": kwargs.get("exhausted"),
-        },
+        lambda **kwargs: (
+            frontier_updates.append(kwargs)
+            or {
+                "status": kwargs.get("status"),
+                "next_cursor": kwargs.get("next_cursor"),
+                "pages_scanned": kwargs.get("pages_scanned"),
+                "posts_checked": kwargs.get("posts_checked"),
+                "posts_saved": kwargs.get("posts_saved"),
+                "total_posts": kwargs.get("total_posts"),
+                "last_transport": kwargs.get("last_transport"),
+                "retry_count": kwargs.get("retry_count", 0),
+                "metadata": kwargs.get("metadata_updates", {}),
+                "exhausted": kwargs.get("exhausted"),
+            }
+        ),
     )
     monkeypatch.setattr(social_repo, "_release_shared_account_run_frontier", lambda **_kwargs: {})
     monkeypatch.setattr(social_repo, "_touch_shared_account_source", lambda **_kwargs: None)
@@ -24981,19 +24987,21 @@ def test_run_shared_account_frontier_posts_stage_raises_when_oldest_stored_post_
     monkeypatch.setattr(
         social_repo,
         "_update_shared_account_run_frontier",
-        lambda **kwargs: frontier_updates.append(kwargs)
-        or {
-            "status": kwargs.get("status"),
-            "next_cursor": kwargs.get("next_cursor"),
-            "pages_scanned": kwargs.get("pages_scanned"),
-            "posts_checked": kwargs.get("posts_checked"),
-            "posts_saved": kwargs.get("posts_saved"),
-            "total_posts": kwargs.get("total_posts"),
-            "last_transport": kwargs.get("last_transport"),
-            "retry_count": kwargs.get("retry_count", 0),
-            "metadata": kwargs.get("metadata_updates", {}),
-            "exhausted": kwargs.get("exhausted"),
-        },
+        lambda **kwargs: (
+            frontier_updates.append(kwargs)
+            or {
+                "status": kwargs.get("status"),
+                "next_cursor": kwargs.get("next_cursor"),
+                "pages_scanned": kwargs.get("pages_scanned"),
+                "posts_checked": kwargs.get("posts_checked"),
+                "posts_saved": kwargs.get("posts_saved"),
+                "total_posts": kwargs.get("total_posts"),
+                "last_transport": kwargs.get("last_transport"),
+                "retry_count": kwargs.get("retry_count", 0),
+                "metadata": kwargs.get("metadata_updates", {}),
+                "exhausted": kwargs.get("exhausted"),
+            }
+        ),
     )
     monkeypatch.setattr(social_repo, "_release_shared_account_run_frontier", lambda **_kwargs: {})
     monkeypatch.setattr(
@@ -25263,7 +25271,7 @@ def test_scrape_shared_tiktok_posts_single_runner_fallback_bypasses_partition_ap
             }
 
         def scrape(self, _config: Any, progress_cb=None) -> list[SimpleNamespace]:
-            assert _config.scrape_mode == "auto"
+            assert _config.scrape_mode == "ytdlp"
             assert _config.ytdlp_max_videos_hint == 10_100
             if progress_cb:
                 progress_cb(
@@ -25305,6 +25313,57 @@ def test_scrape_shared_tiktok_posts_single_runner_fallback_bypasses_partition_ap
     assert retrieval_meta["total_posts"] == 10_100
 
 
+def test_scrape_shared_tiktok_posts_cursor_breakpoints_still_bypass_partition_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    partitioned_calls: list[dict[str, Any]] = []
+
+    def fake_partitioned(**kwargs: Any) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        partitioned_calls.append(kwargs)
+        return [], {"retrieval_mode": "api_partition", "posts_checked": 0}
+
+    class FakeTikTokScraper:
+        def __init__(self, *, cookies: Any) -> None:
+            self.last_retrieval_meta = {
+                "pages_scanned": 2,
+                "posts_checked": 8,
+                "total_posts": 10_100,
+                "profile_snapshot": {"username": "bravotv", "display_name": "BravoTV"},
+            }
+
+        def scrape(self, _config: Any, progress_cb=None) -> list[SimpleNamespace]:
+            assert _config.scrape_mode == "ytdlp"
+            assert _config.ytdlp_max_videos_hint == 10_100
+            return [SimpleNamespace(video_id="123", author_nickname=None, user_avatar_url=None)]
+
+    monkeypatch.setattr(social_repo, "_scrape_shared_tiktok_posts_partitioned", fake_partitioned)
+    monkeypatch.setattr("trr_backend.socials.tiktok.TikTokScraper", FakeTikTokScraper)
+    monkeypatch.setattr(social_repo, "_load_tiktok_cookies", lambda: [])
+    monkeypatch.setattr(social_repo, "_shared_catalog_progress_interval_posts", lambda: 50)
+    monkeypatch.setattr(
+        social_repo,
+        "_upsert_shared_catalog_post",
+        lambda **kwargs: {"source_id": getattr(kwargs["post"], "video_id", None)},
+    )
+
+    rows, retrieval_meta = social_repo._scrape_shared_tiktok_posts(
+        run_id="run-1",
+        account_handle="bravotv",
+        config={
+            "pipeline_ingest_mode": social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            "partition_strategy": social_repo.CATALOG_FULL_HISTORY_CURSOR_PARTITION_STRATEGY,
+            "runner_strategy": "full_history_cursor_breakpoints",
+            "discovery_total_posts": 10_100,
+        },
+        job_id="job-1",
+        progress_cb=None,
+    )
+
+    assert partitioned_calls == []
+    assert len(rows) == 1
+    assert retrieval_meta["persist_counters"]["posts_upserted"] == 1
+
+
 def test_run_shared_account_discovery_stage_enqueues_tiktok_empty_body_transport_recovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -25332,7 +25391,7 @@ def test_run_shared_account_discovery_stage_enqueues_tiktok_empty_body_transport
     monkeypatch.setattr(
         social_repo,
         "_best_known_social_account_total_posts",
-        lambda _platform, _account, **kwargs: (best_known_calls.append(kwargs) or 4444),
+        lambda _platform, _account, **kwargs: best_known_calls.append(kwargs) or 4444,
     )
     monkeypatch.setattr(
         social_repo,
@@ -25808,12 +25867,14 @@ def test_run_shared_account_frontier_posts_stage_allows_public_transport_when_au
     monkeypatch.setattr(
         social_repo,
         "_fetch_shared_instagram_graphql_posts_page",
-        lambda **kwargs: fetch_calls.append(kwargs)
-        or (
-            [{"shortcode": "def", "taken_at": 1738454400}],
-            {"has_next_page": False, "end_cursor": None},
-            {"total_posts": 34},
-            "public",
+        lambda **kwargs: (
+            fetch_calls.append(kwargs)
+            or (
+                [{"shortcode": "def", "taken_at": 1738454400}],
+                {"has_next_page": False, "end_cursor": None},
+                {"total_posts": 34},
+                "public",
+            )
         ),
     )
     monkeypatch.setattr(

--- a/tests/scripts/test_tiktok_scrape_cli.py
+++ b/tests/scripts/test_tiktok_scrape_cli.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from scripts.socials.tiktok import scrape as tiktok_cli
+
+
+def test_emit_diagnostics_summary_prints_risk_and_operator_fields(capsys) -> None:
+    tiktok_cli._emit_diagnostics_summary(  # noqa: SLF001
+        target_label="bravotv",
+        scrape_mode="ytdlp",
+        diagnostics={
+            "http_client": "requests",
+            "risk_state": "critical",
+            "operator_summary": "TikTok posts path degraded; browser intercept fallback recommended.",
+            "operator_action": "Inspect fallback chain and retry with browser intercept.",
+            "triage_bucket": "manual_review",
+        },
+    )
+
+    output = capsys.readouterr().out
+
+    assert "Risk state: critical" in output
+    assert "Operator summary: TikTok posts path degraded;" in output
+    assert "Operator action: Inspect fallback chain and retry with browser intercept." in output
+    assert "Triage bucket: manual_review" in output

--- a/tests/socials/tiktok/test_scraper.py
+++ b/tests/socials/tiktok/test_scraper.py
@@ -1,0 +1,293 @@
+"""Unit tests for TikTok scraper path-health and browser-intercept triage."""
+
+import builtins
+from datetime import datetime
+
+from trr_backend.socials.tiktok.scraper import TikTokScrapeConfig, TikTokScraper
+
+
+def _config() -> TikTokScrapeConfig:
+    return TikTokScrapeConfig(
+        username="bravotv",
+        hashtags=["RHOBH"],
+        date_start=datetime.fromisoformat("2026-03-31T00:00:00+00:00"),
+        date_end=datetime.fromisoformat("2026-04-10T00:00:00+00:00"),
+        max_pages=2,
+    )
+
+
+def test_ytdlp_zero_posts_marks_single_path_degraded(monkeypatch) -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+    monkeypatch.setattr(scraper, "_scrape_via_ytdlp", lambda *args, **kwargs: [])
+
+    posts = scraper.scrape(_config())
+
+    assert posts == []
+    assert scraper.last_retrieval_meta["retrieval_mode"] == "ytdlp"
+    assert scraper.last_retrieval_meta["path_role"] == "primary"
+    assert scraper.last_retrieval_meta["topology_state"] == "single_path_ytdlp"
+    assert scraper.last_retrieval_meta["risk_state"] == "critical"
+    assert scraper.last_retrieval_meta["operator_summary"] == (
+        "TikTok posts path degraded: yt-dlp returned zero posts while browser_intercept is not proven live."
+    )
+
+
+def test_browser_intercept_zero_posts_classifies_target_drift() -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+
+    bucket = scraper._classify_browser_intercept_failure(  # noqa: SLF001
+        posts_found=0,
+        intercepted_post_responses=0,
+        intercepted_user_detail_responses=1,
+        dom_cards_seen=0,
+        scroll_iterations=5,
+        authenticated=True,
+        playwright_error=None,
+    )
+
+    assert bucket == "interception_target_drift"
+
+
+def test_browser_intercept_zero_posts_classifies_scroll_or_pagination_drift() -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+
+    bucket = scraper._classify_browser_intercept_failure(  # noqa: SLF001
+        posts_found=0,
+        intercepted_post_responses=2,
+        intercepted_user_detail_responses=1,
+        dom_cards_seen=0,
+        scroll_iterations=3,
+        authenticated=True,
+        playwright_error=None,
+    )
+
+    assert bucket == "scroll_or_pagination_drift"
+
+
+def test_browser_intercept_zero_posts_classifies_playwright_runtime_change() -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+
+    bucket = scraper._classify_browser_intercept_failure(  # noqa: SLF001
+        posts_found=0,
+        intercepted_post_responses=0,
+        intercepted_user_detail_responses=0,
+        dom_cards_seen=0,
+        scroll_iterations=0,
+        authenticated=True,
+        playwright_error="TimeoutError",
+    )
+
+    assert bucket == "playwright_runtime_change"
+
+
+def test_browser_intercept_zero_posts_preserves_triage_bucket_after_structured_failure(monkeypatch) -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+    scraper.last_retrieval_meta.update(
+        {
+            "intercepted_post_responses": 0,
+            "intercepted_user_detail_responses": 1,
+            "dom_cards_seen": 0,
+            "scroll_iterations": 5,
+            "auth_mode": "with_cookies",
+            "playwright_error": "TimeoutError",
+        }
+    )
+    monkeypatch.setattr(scraper, "_scrape_browser_intercept", lambda *args, **kwargs: [])
+
+    posts = scraper.scrape(TikTokScrapeConfig(username="bravotv", scrape_mode="browser_intercept"))
+
+    assert posts == []
+    assert scraper.last_retrieval_meta["error_code"] == "browser_intercept_zero_posts"
+    assert scraper.last_retrieval_meta["stop_reason"] == "browser_intercept_zero_posts"
+    assert scraper.last_retrieval_meta["triage_bucket"] == "playwright_runtime_change"
+    assert scraper.last_retrieval_meta["intercepted_post_responses"] == 0
+    assert scraper.last_retrieval_meta["intercepted_user_detail_responses"] == 1
+    assert scraper.last_retrieval_meta["dom_cards_seen"] == 0
+    assert scraper.last_retrieval_meta["scroll_iterations"] == 5
+    assert scraper.last_retrieval_meta["playwright_error"] == "TimeoutError"
+
+
+def test_browser_intercept_playwright_unavailable_preserves_runtime_triage(monkeypatch) -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+    real_import = builtins.__import__
+
+    def _fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "playwright.sync_api":
+            raise ModuleNotFoundError("playwright unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    posts = scraper.scrape(TikTokScrapeConfig(username="bravotv", scrape_mode="browser_intercept"))
+
+    assert posts == []
+    assert scraper.last_retrieval_meta["error_code"] == "playwright_unavailable"
+    assert scraper.last_retrieval_meta["playwright_error"] == "ModuleNotFoundError"
+    assert scraper.last_retrieval_meta["triage_bucket"] == "playwright_runtime_change"
+
+
+def test_browser_intercept_direct_preflight_does_not_count_as_intercepted_user_detail(monkeypatch) -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+
+    class _FakeLocator:
+        def count(self) -> int:
+            return 0
+
+    class _FakePage:
+        def __init__(self) -> None:
+            self._response_handler = None
+
+        def goto(self, *_args, **_kwargs) -> None:
+            return None
+
+        def wait_for_timeout(self, *_args, **_kwargs) -> None:
+            return None
+
+        def on(self, event: str, handler) -> None:
+            assert event == "response"
+            self._response_handler = handler
+
+        def evaluate(self, *_args, **_kwargs) -> None:
+            return None
+
+        def locator(self, _selector: str) -> _FakeLocator:
+            return _FakeLocator()
+
+    class _FakeContext:
+        def add_cookies(self, _cookies) -> None:
+            return None
+
+        def new_page(self) -> _FakePage:
+            return _FakePage()
+
+    class _FakeBrowser:
+        def new_context(self, **_kwargs) -> _FakeContext:
+            return _FakeContext()
+
+        def close(self) -> None:
+            return None
+
+    class _FakePlaywrightContextManager:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr("playwright.sync_api.sync_playwright", lambda: _FakePlaywrightContextManager())
+    monkeypatch.setattr(
+        "trr_backend.socials.browser_cookie_refresh.launch_browser",
+        lambda *_args, **_kwargs: _FakeBrowser(),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_user_detail",
+        lambda *_args, **_kwargs: {"userInfo": {"user": {"secUid": "sec"}}},
+    )
+    monkeypatch.setattr(scraper, "build_profile_snapshot", lambda *_args, **_kwargs: {"avatar_url": None})
+
+    posts = scraper.scrape(TikTokScrapeConfig(username="bravotv", scrape_mode="browser_intercept"))
+
+    assert posts == []
+    assert scraper.last_retrieval_meta["intercepted_user_detail_responses"] == 0
+    assert scraper.last_retrieval_meta["intercepted_post_responses"] == 0
+    assert scraper.last_retrieval_meta["triage_bucket"] == "scroll_or_pagination_drift"
+
+
+def test_browser_intercept_launch_failure_preserves_runtime_triage(monkeypatch) -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+
+    class _FakePlaywrightContextManager:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr("playwright.sync_api.sync_playwright", lambda: _FakePlaywrightContextManager())
+    monkeypatch.setattr(
+        "trr_backend.socials.browser_cookie_refresh.launch_browser",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("launch failed")),
+    )
+
+    posts = scraper.scrape(TikTokScrapeConfig(username="bravotv", scrape_mode="browser_intercept"))
+
+    assert posts == []
+    assert scraper.last_retrieval_meta["error_code"] == "browser_intercept_error"
+    assert scraper.last_retrieval_meta["playwright_error"] == "RuntimeError"
+    assert scraper.last_retrieval_meta["triage_bucket"] == "playwright_runtime_change"
+
+
+def test_browser_intercept_failed_browser_user_detail_does_not_classify_target_drift(monkeypatch) -> None:
+    scraper = TikTokScraper(cookies={"sessionid": "cookie"})
+
+    class _FakeResponse:
+        url = "https://www.tiktok.com/api/user/detail/"
+        ok = True
+
+        def json(self):
+            raise ValueError("non-json")
+
+    class _FakeLocator:
+        def count(self) -> int:
+            return 0
+
+    class _FakePage:
+        def __init__(self) -> None:
+            self._response_handler = None
+
+        def goto(self, *_args, **_kwargs) -> None:
+            return None
+
+        def wait_for_timeout(self, *_args, **_kwargs) -> None:
+            return None
+
+        def on(self, event: str, handler) -> None:
+            assert event == "response"
+            self._response_handler = handler
+
+        def evaluate(self, *_args, **_kwargs) -> None:
+            if self._response_handler is not None:
+                self._response_handler(_FakeResponse())
+
+        def locator(self, _selector: str) -> _FakeLocator:
+            return _FakeLocator()
+
+    class _FakeContext:
+        def add_cookies(self, _cookies) -> None:
+            return None
+
+        def new_page(self) -> _FakePage:
+            return _FakePage()
+
+    class _FakeBrowser:
+        def new_context(self, **_kwargs) -> _FakeContext:
+            return _FakeContext()
+
+        def close(self) -> None:
+            return None
+
+    class _FakePlaywrightContextManager:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    monkeypatch.setattr("playwright.sync_api.sync_playwright", lambda: _FakePlaywrightContextManager())
+    monkeypatch.setattr(
+        "trr_backend.socials.browser_cookie_refresh.launch_browser",
+        lambda *_args, **_kwargs: _FakeBrowser(),
+    )
+    monkeypatch.setattr(
+        scraper,
+        "fetch_user_detail",
+        lambda *_args, **_kwargs: {"userInfo": {"user": {"secUid": "sec"}}},
+    )
+    monkeypatch.setattr(scraper, "build_profile_snapshot", lambda *_args, **_kwargs: {"avatar_url": None})
+
+    posts = scraper.scrape(TikTokScrapeConfig(username="bravotv", scrape_mode="browser_intercept"))
+
+    assert posts == []
+    assert scraper.last_retrieval_meta["intercepted_user_detail_responses"] == 0
+    assert scraper.last_retrieval_meta["triage_bucket"] != "interception_target_drift"

--- a/trr_backend/repositories/social_season_analytics.py
+++ b/trr_backend/repositories/social_season_analytics.py
@@ -29510,7 +29510,6 @@ def _scrape_shared_tiktok_posts(
     from trr_backend.socials.tiktok import TikTokScrapeConfig, TikTokScraper
 
     scraper = TikTokScraper(cookies=_load_tiktok_cookies())
-    runner_strategy = str(config.get("runner_strategy") or "").strip().lower()
     expected_total_posts = max(
         _normalize_non_negative_int(config.get("discovery_total_posts")),
         _shared_account_expected_total_posts_from_config(
@@ -29526,7 +29525,7 @@ def _scrape_shared_tiktok_posts(
         date_end=_coerce_dt(config.get("date_end")),
         delay_seconds=0.35,
         max_pages=_shared_stage_post_limit(config),
-        scrape_mode="auto" if runner_strategy == "single_runner_fallback" else "api",
+        scrape_mode="ytdlp",
         ytdlp_max_videos_hint=expected_total_posts or None,
     )
     posts = scraper.scrape(scrape_config, progress_cb=progress_cb)
@@ -30633,10 +30632,7 @@ def _run_shared_account_discovery_stage(
         # more jobs that will also fail.
         if discovery_checked == 0:
             if platform == "tiktok":
-                if (
-                    _tiktok_discovery_empty_body_transport_failure(discovery_meta)
-                    and recovery_depth <= 0
-                ):
+                if _tiktok_discovery_empty_body_transport_failure(discovery_meta) and recovery_depth <= 0:
                     recovery_expected_total_posts = max(
                         expected_total_posts,
                         _best_known_social_account_total_posts(
@@ -30667,9 +30663,7 @@ def _run_shared_account_discovery_stage(
                             "max_posts_per_target": 0,
                             "discovery_total_posts": discovery_meta.get("total_posts"),
                             "expected_total_posts": recovery_expected_total_posts,
-                            "completion_target_posts": _normalize_non_negative_int(
-                                discovery_meta.get("total_posts")
-                            )
+                            "completion_target_posts": _normalize_non_negative_int(discovery_meta.get("total_posts"))
                             or expected_total_posts
                             or recovery_expected_total_posts,
                             "discovery_fallback_reason": "tiktok_empty_body_transport_failure",
@@ -34227,10 +34221,7 @@ def ingest_shared_accounts(
         for row in sources
         if (
             (_normalize_platform_name(row.get("platform")) or "")
-            and (
-                _normalize_account_handle(row.get("account_handle"))
-                or str(row.get("account_handle") or "").strip()
-            )
+            and (_normalize_account_handle(row.get("account_handle")) or str(row.get("account_handle") or "").strip())
             and (
                 (
                     _normalize_platform_name(row.get("platform")) or "",
@@ -34304,9 +34295,7 @@ def ingest_shared_accounts(
             catalog_runner_count = CATALOG_BACKFILL_FULL_HISTORY_RUNNER_COUNT
             catalog_runner_strategy = CATALOG_FULL_HISTORY_FRONTIER_STRATEGY
             catalog_partition_strategy = CATALOG_FULL_HISTORY_FRONTIER_STRATEGY
-        elif any(
-            _catalog_full_history_partition_supported(row.get("platform")) for row in partition_eligible_sources
-        ):
+        elif any(_catalog_full_history_partition_supported(row.get("platform")) for row in partition_eligible_sources):
             catalog_runner_count = CATALOG_BACKFILL_FULL_HISTORY_RUNNER_COUNT
             catalog_runner_strategy = "full_history_cursor_breakpoints"
             catalog_partition_strategy = CATALOG_FULL_HISTORY_CURSOR_PARTITION_STRATEGY

--- a/trr_backend/socials/tiktok/scraper.py
+++ b/trr_backend/socials/tiktok/scraper.py
@@ -31,6 +31,24 @@ logger = logging.getLogger(__name__)
 URL_RE = re.compile(r"https?://[^\s<>()]+", re.IGNORECASE)
 
 
+def _coerce_utc_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+class _DeferredTikTokHttpClient:
+    """Lazy wrapper so the default yt-dlp path does not eagerly build direct transports."""
+
+    def __init__(self, owner: "TikTokScraper") -> None:
+        self._owner = owner
+
+    def get(self, *args: Any, **kwargs: Any) -> Any:
+        return self._owner._ensure_http_client().get(*args, **kwargs)
+
+
 @dataclass
 class TikTokScrapeConfig:
     """Configuration for a TikTok scrape operation."""
@@ -46,10 +64,10 @@ class TikTokScrapeConfig:
     fast_mode: bool = False
     """When True, uses aggressive rate-limiting tiers and reduced delays."""
 
-    scrape_mode: str = "api"
-    """Scraping strategy: 'api' (default, direct TikTok API), 'browser_intercept'
-    (headless Playwright scroll + response interception), or 'auto' (api first,
-    browser_intercept fallback)."""
+    scrape_mode: str = "ytdlp"
+    """Scraping strategy: 'ytdlp' (production default), 'api' (experimental
+    direct TikTok API), 'browser_intercept' (experimental Playwright
+    interception), or 'auto' (compatibility alias to 'ytdlp')."""
 
     ytdlp_max_videos_hint: int | None = None
     """Advisory upper bound for yt-dlp profile enumeration in fallback mode."""
@@ -75,11 +93,13 @@ class TikTokScrapeConfig:
 
     @property
     def start_timestamp(self) -> float:
-        return self.date_start.timestamp() if self.date_start else 0
+        coerced = _coerce_utc_datetime(self.date_start)
+        return coerced.timestamp() if coerced else 0
 
     @property
     def end_timestamp(self) -> float:
-        return self.date_end.timestamp() if self.date_end else datetime.now(UTC).timestamp()
+        coerced = _coerce_utc_datetime(self.date_end)
+        return coerced.timestamp() if coerced else datetime.now(UTC).timestamp()
 
     def matches_hashtags(self, text: str) -> bool:
         """Check if text contains any of the configured hashtags."""
@@ -200,14 +220,28 @@ class TikTokScraper:
     RETRY_BACKOFF_FACTOR = 1.5
     REQUEST_TIMEOUT_SECONDS = (10, 45)
 
-    def __init__(self, cookies: dict | None = None):
+    def __init__(
+        self,
+        cookies: dict | None = None,
+        *,
+        http_client_name: str | None = None,
+        proxy_urls: list[str] | tuple[str, ...] | None = None,
+    ):
         self.cookies = cookies or {}
-        self.session = self._create_session()
+        self._http_client_name_input = str(http_client_name or "").strip().lower() or None
+        self._proxy_urls_input = list(proxy_urls or [])
+        self._selected_proxy_url = next(
+            (str(value or "").strip() for value in self._proxy_urls_input if str(value or "").strip()),
+            None,
+        )
+        self._direct_http_client: requests.Session | None = None
+        self.session = _DeferredTikTokHttpClient(self)
         self._request_count = 0
         self._consecutive_success = 0
         self.last_retrieval_meta: dict[str, Any] = {}
         self._last_api_fail_reason: str | None = None
         self.last_comment_fetch_reason: str | None = None
+        self.last_comment_fetch_meta: dict[str, Any] = {}
         self.comments_auth_failed = False
 
     @staticmethod
@@ -240,6 +274,13 @@ class TikTokScraper:
         normalized = str(reason or "").strip().lower()
         return normalized in {"non_json_response", "challenge_or_blocked"}
 
+    @staticmethod
+    def _proxy_label(proxy_url: str | None) -> str | None:
+        if not proxy_url:
+            return None
+        parsed = urlparse(str(proxy_url))
+        return parsed.hostname or str(proxy_url)
+
     def _create_session(self) -> requests.Session:
         """Create a session with retry logic."""
         session = requests.Session()
@@ -252,7 +293,48 @@ class TikTokScraper:
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)
         session.mount("http://", adapter)
+        if self._selected_proxy_url:
+            session.proxies.update({"http": self._selected_proxy_url, "https": self._selected_proxy_url})
         return session
+
+    def _ensure_http_client(self) -> requests.Session:
+        if self._direct_http_client is None:
+            self._direct_http_client = self._create_session()
+        return self._direct_http_client
+
+    def _run_context_meta(self, *, retrieval_mode: str | None = None, auth_mode: str | None = None) -> dict[str, Any]:
+        resolved_auth_mode = auth_mode or ("with_cookies" if self.cookies else "without_cookies")
+        mode = str(retrieval_mode or "").strip().lower() or None
+        if mode == "ytdlp":
+            return {
+                "http_client": "yt_dlp",
+                "proxy_label": None,
+                "auth_mode": resolved_auth_mode,
+            }
+        return {
+            "http_client": self._http_client_name_input or "requests",
+            "proxy_label": self._proxy_label(self._selected_proxy_url),
+            "auth_mode": resolved_auth_mode,
+        }
+
+    def _set_retrieval_meta(
+        self,
+        *,
+        context_mode: str | None = None,
+        auth_mode: str | None = None,
+        **values: Any,
+    ) -> None:
+        endpoint_responses = dict(self.last_retrieval_meta.get("endpoint_responses") or {})
+        payload = self._run_context_meta(
+            retrieval_mode=context_mode or str(values.get("retrieval_mode") or "").strip() or None,
+            auth_mode=auth_mode,
+        )
+        if context_mode == "ytdlp":
+            payload["endpoint_responses"] = {}
+        elif endpoint_responses:
+            payload["endpoint_responses"] = endpoint_responses
+        payload.update(values)
+        self.last_retrieval_meta = payload
 
     def _get_headers(self, referer: str | None = None) -> dict:
         """Get request headers."""
@@ -780,6 +862,21 @@ class TikTokScraper:
         yt-dlp for authenticated access.
         """
         if not self._has_ytdlp():
+            self._set_retrieval_meta(
+                context_mode="ytdlp",
+                auth_mode="none",
+                retrieval_mode="ytdlp",
+                error_code="ytdlp_unavailable",
+                stop_reason="ytdlp_unavailable",
+                pages_scanned=0,
+                posts_checked=0,
+                videos_scanned=0,
+                ytdlp_posts_found=0,
+                ytdlp_max_videos=0,
+                ytdlp_cookie_file_present=False,
+                ytdlp_cookie_file_used=False,
+                fallback_chain=["yt_dlp"],
+            )
             return []
 
         logger.info("Attempting yt-dlp bulk fallback scraper...")
@@ -787,8 +884,10 @@ class TikTokScraper:
         # Estimate how many videos to fetch based on date range.
         # @bravotv posts ~16 videos/day across all shows; use 22/day for buffer.
         max_videos = 500
-        if config.date_start:
-            days_back = (datetime.now(tz=UTC) - config.date_start).days
+        start_dt = _coerce_utc_datetime(config.date_start)
+        end_dt = _coerce_utc_datetime(config.date_end)
+        if start_dt:
+            days_back = max(0, (datetime.now(tz=UTC) - start_dt).days)
             max_videos = max(500, min(12000, days_back * 22))
         config_max_videos_hint = (
             max(0, int(config.ytdlp_max_videos_hint or 0)) if config.ytdlp_max_videos_hint is not None else 0
@@ -812,6 +911,7 @@ class TikTokScraper:
 
         # Pass cookies if a Netscape-format file exists
         cookie_file = self._find_ytdlp_cookie_file()
+        cookie_file_used = bool(cookie_file)
         if cookie_file:
             cmd.extend(["--cookies", cookie_file])
             logger.info(f"yt-dlp using cookies from {cookie_file}")
@@ -828,10 +928,45 @@ class TikTokScraper:
             )
         except subprocess.TimeoutExpired:
             logger.warning("yt-dlp bulk listing timed out")
+            self._set_retrieval_meta(
+                context_mode="ytdlp",
+                auth_mode="ytdlp_cookies" if cookie_file_used else "none",
+                retrieval_mode="ytdlp",
+                error_code="ytdlp_timeout",
+                stop_reason="timeout",
+                pages_scanned=0,
+                posts_checked=0,
+                videos_scanned=0,
+                ytdlp_posts_found=0,
+                ytdlp_max_videos=max_videos,
+                ytdlp_cookie_file_present=bool(cookie_file),
+                ytdlp_cookie_file_used=cookie_file_used,
+                fallback_chain=["yt_dlp"],
+            )
+            return []
+        if int(getattr(proc, "returncode", 0) or 0) != 0:
+            logger.warning("yt-dlp bulk listing exited non-zero: %s", getattr(proc, "stderr", "")[:240])
+            self._set_retrieval_meta(
+                context_mode="ytdlp",
+                auth_mode="ytdlp_cookies" if cookie_file_used else "none",
+                retrieval_mode="ytdlp",
+                error_code="ytdlp_nonzero_exit",
+                stop_reason="nonzero_exit",
+                error_message=str(getattr(proc, "stderr", "") or "")[:240] or None,
+                pages_scanned=0,
+                posts_checked=0,
+                videos_scanned=0,
+                ytdlp_posts_found=0,
+                ytdlp_max_videos=max_videos,
+                ytdlp_cookie_file_present=bool(cookie_file),
+                ytdlp_cookie_file_used=cookie_file_used,
+                fallback_chain=["yt_dlp"],
+            )
             return []
 
         posts: list[TikTokPost] = []
         total = 0
+        stop_reason = "playlist_exhausted"
         for line in proc.stdout.strip().splitlines():
             try:
                 data = json.loads(line)
@@ -840,10 +975,11 @@ class TikTokScraper:
             total += 1
 
             ts = data.get("timestamp", 0) or 0
-            in_range = config.is_in_date_range(ts)
-            if in_range is None:
+            item_dt = datetime.fromtimestamp(ts, tz=UTC)
+            if start_dt and item_dt < start_dt:
+                stop_reason = "date_start_reached"
                 break  # Before date range, stop
-            if in_range is False:
+            if end_dt and item_dt > end_dt:
                 continue  # After date range, skip
 
             description = data.get("title", "") or data.get("description", "") or ""
@@ -869,17 +1005,24 @@ class TikTokScraper:
                     logger.debug("TikTok yt-dlp progress callback raised", exc_info=True)
 
             if max_posts_hint and len(posts) >= max_posts_hint:
+                stop_reason = "max_posts_reached"
                 break
 
         logger.info(f"yt-dlp bulk: scanned {total} videos, found {len(posts)} matches")
-        self.last_retrieval_meta = {
-            "retrieval_mode": "ytdlp",
-            "pages_scanned": 0,
-            "posts_checked": total,
-            "videos_scanned": total,
-            "ytdlp_posts_found": len(posts),
-            "ytdlp_max_videos": max_videos,
-        }
+        self._set_retrieval_meta(
+            context_mode="ytdlp",
+            auth_mode="ytdlp_cookies" if cookie_file_used else "none",
+            retrieval_mode="ytdlp",
+            pages_scanned=0,
+            posts_checked=total,
+            videos_scanned=total,
+            ytdlp_posts_found=len(posts),
+            ytdlp_max_videos=max_videos,
+            stop_reason=stop_reason,
+            fallback_chain=["yt_dlp"],
+            ytdlp_cookie_file_present=bool(cookie_file),
+            ytdlp_cookie_file_used=cookie_file_used,
+        )
         return posts
 
     def _extract_hashtags(self, text: str) -> list[str]:
@@ -1380,8 +1523,14 @@ class TikTokScraper:
             self.last_retrieval_meta.update(
                 {
                     "retrieval_mode": "browser_intercept",
+                    "auth_mode": "with_cookies" if self.cookies else "without_cookies",
                     "error_code": "playwright_unavailable",
                     "error_class": type(exc).__name__,
+                    "playwright_error": type(exc).__name__,
+                    "intercepted_post_responses": 0,
+                    "intercepted_user_detail_responses": 0,
+                    "dom_cards_seen": 0,
+                    "scroll_iterations": 0,
                 }
             )
             return []
@@ -1399,14 +1548,32 @@ class TikTokScraper:
         no_new_data_scrolls = 0
         max_no_new_data_scrolls = 5
         scroll_count = 0
+        intercepted_post_responses = 0
+        intercepted_user_detail_responses = 0
+        dom_cards_seen = 0
+        playwright_error: str | None = None
+        auth_mode = "with_cookies" if self.cookies else "without_cookies"
+
+        self.last_retrieval_meta.update(
+            {
+                "retrieval_mode": "browser_intercept",
+                "auth_mode": auth_mode,
+                "intercepted_post_responses": intercepted_post_responses,
+                "intercepted_user_detail_responses": intercepted_user_detail_responses,
+                "dom_cards_seen": dom_cards_seen,
+                "scroll_iterations": scroll_count,
+                "playwright_error": playwright_error,
+            }
+        )
 
         user_agent = self._get_headers().get("user-agent", "Mozilla/5.0")
         timeout_ms = 60_000
         max_posts = config.max_pages * 50 if config.max_pages else 10_000
 
-        with sync_playwright() as playwright:
-            browser = launch_browser(playwright, headless=True)
-            try:
+        browser: Any | None = None
+        try:
+            with sync_playwright() as playwright:
+                browser = launch_browser(playwright, headless=True)
                 context = browser.new_context(
                     viewport={"width": 1280, "height": 900},
                     user_agent=user_agent,
@@ -1437,12 +1604,31 @@ class TikTokScraper:
                 except Exception:  # noqa: BLE001
                     pass
 
-                # Register response interceptor for post list API
+                # Register response interceptor for browser traffic relevant to recovery triage.
                 def _handle_post_list_response(response: Any) -> None:
-                    nonlocal reached_date_limit, no_new_data_scrolls
+                    nonlocal intercepted_post_responses, intercepted_user_detail_responses, reached_date_limit
+                    nonlocal no_new_data_scrolls
                     try:
-                        if "/api/post/item_list/" not in str(response.url or ""):
+                        response_url = str(response.url or "")
+                        normalized_response_url = response_url.lower()
+                        if (
+                            "/api/user/detail/" in normalized_response_url
+                            or "fetch_user_detail" in normalized_response_url
+                        ):
+                            if response.ok:
+                                try:
+                                    browser_user_detail_payload = response.json()
+                                except Exception:  # noqa: BLE001
+                                    browser_user_detail_payload = None
+                                if isinstance(browser_user_detail_payload, (dict, list)):
+                                    intercepted_user_detail_responses += 1
+                                    self.last_retrieval_meta["intercepted_user_detail_responses"] = (
+                                        intercepted_user_detail_responses
+                                    )
+                        if "/api/post/item_list/" not in normalized_response_url:
                             return
+                        intercepted_post_responses += 1
+                        self.last_retrieval_meta["intercepted_post_responses"] = intercepted_post_responses
                         if not response.ok:
                             return
                         payload = response.json()
@@ -1516,6 +1702,9 @@ class TikTokScraper:
                         no_new_data_scrolls += 1
                     else:
                         no_new_data_scrolls = 0
+                    dom_cards_seen = max(dom_cards_seen, int(page.locator("a[href*='/video/']").count() or 0))
+                    self.last_retrieval_meta["dom_cards_seen"] = dom_cards_seen
+                    self.last_retrieval_meta["scroll_iterations"] = scroll_count
 
                     if scroll_count % 20 == 0:
                         logger.info(
@@ -1524,21 +1713,28 @@ class TikTokScraper:
                             len(posts),
                         )
 
-            except Exception as exc:
-                logger.error(
-                    "browser_intercept failed for @%s: %s",
-                    config.username,
-                    exc,
-                )
-                self.last_retrieval_meta.update(
-                    {
-                        "retrieval_mode": "browser_intercept",
-                        "error_code": "browser_intercept_error",
-                        "error_class": type(exc).__name__,
-                        "error_message": str(exc),
-                    }
-                )
-            finally:
+        except Exception as exc:
+            playwright_error = type(exc).__name__
+            logger.error(
+                "browser_intercept failed for @%s: %s",
+                config.username,
+                exc,
+            )
+            self.last_retrieval_meta.update(
+                {
+                    "retrieval_mode": "browser_intercept",
+                    "error_code": "browser_intercept_error",
+                    "error_class": playwright_error,
+                    "error_message": str(exc),
+                    "intercepted_post_responses": intercepted_post_responses,
+                    "intercepted_user_detail_responses": intercepted_user_detail_responses,
+                    "dom_cards_seen": dom_cards_seen,
+                    "scroll_iterations": scroll_count,
+                    "playwright_error": playwright_error,
+                }
+            )
+        finally:
+            if browser is not None:
                 browser.close()
 
         stop_reason = (
@@ -1557,13 +1753,84 @@ class TikTokScraper:
             scroll_count,
             stop_reason,
         )
-        self.last_retrieval_meta = {
-            "retrieval_mode": "browser_intercept",
-            "posts_checked": len(seen_ids),
-            "pages_scanned": scroll_count,
-            "stop_reason": stop_reason,
-        }
+        error_code = str(self.last_retrieval_meta.get("error_code") or "").strip() or None
+        error_class = str(self.last_retrieval_meta.get("error_class") or "").strip() or None
+        error_message = str(self.last_retrieval_meta.get("error_message") or "").strip() or None
+        fallback_chain = self.last_retrieval_meta.get("fallback_chain") or None
+        self._set_retrieval_meta(
+            retrieval_mode="browser_intercept",
+            auth_mode=auth_mode,
+            posts_checked=len(seen_ids),
+            pages_scanned=scroll_count,
+            stop_reason=stop_reason,
+            intercepted_post_responses=intercepted_post_responses,
+            intercepted_user_detail_responses=intercepted_user_detail_responses,
+            dom_cards_seen=dom_cards_seen,
+            scroll_iterations=scroll_count,
+            playwright_error=playwright_error,
+            error_code=error_code,
+            error_class=error_class,
+            error_message=error_message,
+            fallback_chain=fallback_chain,
+        )
+        self.last_retrieval_meta["playwright_error"] = playwright_error
         return posts
+
+    def _ensure_structured_direct_failure(self, *, mode: str) -> None:
+        if self.last_retrieval_meta.get("error_code"):
+            return
+        stop_reason = f"{mode}_zero_posts"
+        self._set_retrieval_meta(
+            retrieval_mode=mode,
+            error_code=stop_reason,
+            stop_reason=stop_reason,
+            fallback_chain=[mode],
+        )
+
+    def _set_tiktok_path_health(
+        self,
+        *,
+        retrieval_mode: str,
+        posts_found: int,
+        stop_reason: str | None = None,
+    ) -> None:
+        mode = str(retrieval_mode or "").strip().lower() or "ytdlp"
+        self.last_retrieval_meta["retrieval_mode"] = mode
+        self.last_retrieval_meta["path_role"] = "primary" if mode == "ytdlp" else "fallback"
+        self.last_retrieval_meta["topology_state"] = "single_path_ytdlp"
+        if stop_reason:
+            self.last_retrieval_meta["stop_reason"] = stop_reason
+        if mode == "ytdlp" and posts_found <= 0:
+            self.last_retrieval_meta["risk_state"] = "critical"
+            self.last_retrieval_meta["operator_summary"] = (
+                "TikTok posts path degraded: yt-dlp returned zero posts while browser_intercept is not proven live."
+            )
+        elif mode == "ytdlp":
+            self.last_retrieval_meta["risk_state"] = "healthy"
+            self.last_retrieval_meta["operator_summary"] = "TikTok posts path healthy on yt-dlp."
+
+    def _classify_browser_intercept_failure(
+        self,
+        *,
+        posts_found: int,
+        intercepted_post_responses: int,
+        intercepted_user_detail_responses: int,
+        dom_cards_seen: int,
+        scroll_iterations: int,
+        authenticated: bool,
+        playwright_error: str | None,
+    ) -> str:
+        if playwright_error:
+            return "playwright_runtime_change"
+        if not authenticated:
+            return "auth_or_session_state"
+        if intercepted_post_responses == 0 and intercepted_user_detail_responses > 0:
+            return "interception_target_drift"
+        if dom_cards_seen == 0 and scroll_iterations > 0:
+            return "scroll_or_pagination_drift"
+        if posts_found <= 0:
+            return "unclassified_zero_posts"
+        return "healthy"
 
     def scrape(
         self,
@@ -1591,71 +1858,58 @@ class TikTokScraper:
             )
 
         # ----- scrape_mode routing -----
-        mode = (config.scrape_mode or "api").strip().lower()
+        mode = (config.scrape_mode or "ytdlp").strip().lower()
 
-        if mode == "browser_intercept":
-            return self._scrape_browser_intercept(config, progress_cb=progress_cb)
-
-        if mode == "auto":
-            # Try the default API path first; fall back to browser_intercept
-            # if the API returns fewer than 5 posts.
-            api_posts = self._scrape_api(config, progress_cb=progress_cb)
-            if len(api_posts) >= 5:
-                return api_posts
-            logger.info(
-                "auto mode: API returned only %d posts for @%s; falling back to browser_intercept",
-                len(api_posts),
-                config.username,
-            )
-            intercept_posts = self._scrape_browser_intercept(
-                config,
-                progress_cb=progress_cb,
-            )
-            # Merge, preferring the larger result set and deduplicating
-            if len(intercept_posts) > len(api_posts):
-                seen = {p.video_id for p in intercept_posts}
-                for p in api_posts:
-                    if p.video_id and p.video_id not in seen:
-                        intercept_posts.append(p)
-                        seen.add(p.video_id)
-                return intercept_posts
-            seen = {p.video_id for p in api_posts}
-            for p in intercept_posts:
-                if p.video_id and p.video_id not in seen:
-                    api_posts.append(p)
-                    seen.add(p.video_id)
-            if len(api_posts) >= 5 or not self._has_ytdlp():
-                return api_posts
-            logger.info(
-                "auto mode: API + browser_intercept returned only %d posts for @%s; falling back to yt-dlp",
-                len(api_posts),
-                config.username,
-            )
-            combined_posts_before_ytdlp = len(api_posts)
-            ytdlp_posts = self._scrape_via_ytdlp(
+        if mode in {"ytdlp", "auto"}:
+            if mode == "auto":
+                logger.warning("TikTok scrape_mode=auto is deprecated; using ytdlp alias")
+            posts = self._scrape_via_ytdlp(
                 config,
                 max_videos_hint=config.ytdlp_max_videos_hint,
                 max_posts_hint=config.ytdlp_max_videos_hint,
                 progress_cb=progress_cb,
             )
-            if not ytdlp_posts:
-                return api_posts
-            seen = {p.video_id for p in api_posts}
-            for p in ytdlp_posts:
-                if p.video_id and p.video_id not in seen:
-                    api_posts.append(p)
-                    seen.add(p.video_id)
-            merged_meta = dict(self.last_retrieval_meta or {})
-            merged_meta["retrieval_mode"] = "ytdlp_fallback"
-            merged_meta["auto_fallback_chain"] = ["api", "browser_intercept", "yt_dlp"]
-            merged_meta["auto_combined_posts_before_ytdlp"] = combined_posts_before_ytdlp
-            merged_meta["auto_browser_intercept_posts"] = len(intercept_posts)
-            merged_meta["auto_ytdlp_posts"] = len(ytdlp_posts)
-            self.last_retrieval_meta = merged_meta
-            return api_posts
+            self._set_tiktok_path_health(
+                retrieval_mode="ytdlp",
+                posts_found=len(posts),
+                stop_reason=str(self.last_retrieval_meta.get("stop_reason") or "").strip() or None,
+            )
+            self.last_retrieval_meta["profile_enrichment_status"] = "skipped"
+            return posts
 
-        # Default: mode == "api" — fall through to existing logic below
-        return self._scrape_api(config, progress_cb=progress_cb)
+        if mode == "browser_intercept":
+            posts = self._scrape_browser_intercept(config, progress_cb=progress_cb)
+            if not posts:
+                browser_intercept_meta = {
+                    "intercepted_post_responses": int(self.last_retrieval_meta.get("intercepted_post_responses") or 0),
+                    "intercepted_user_detail_responses": int(
+                        self.last_retrieval_meta.get("intercepted_user_detail_responses") or 0
+                    ),
+                    "dom_cards_seen": int(self.last_retrieval_meta.get("dom_cards_seen") or 0),
+                    "scroll_iterations": int(self.last_retrieval_meta.get("scroll_iterations") or 0),
+                    "auth_mode": str(self.last_retrieval_meta.get("auth_mode") or "").strip() or None,
+                    "playwright_error": str(self.last_retrieval_meta.get("playwright_error") or "").strip() or None,
+                }
+                self._ensure_structured_direct_failure(mode="browser_intercept")
+                self.last_retrieval_meta.update(browser_intercept_meta)
+                self.last_retrieval_meta["triage_bucket"] = self._classify_browser_intercept_failure(
+                    posts_found=0,
+                    intercepted_post_responses=browser_intercept_meta["intercepted_post_responses"],
+                    intercepted_user_detail_responses=browser_intercept_meta["intercepted_user_detail_responses"],
+                    dom_cards_seen=browser_intercept_meta["dom_cards_seen"],
+                    scroll_iterations=browser_intercept_meta["scroll_iterations"],
+                    authenticated=bool(browser_intercept_meta["auth_mode"] == "with_cookies"),
+                    playwright_error=browser_intercept_meta["playwright_error"],
+                )
+            return posts
+
+        if mode == "api":
+            posts = self._scrape_api(config, progress_cb=progress_cb)
+            if not posts:
+                self._ensure_structured_direct_failure(mode="api")
+            return posts
+
+        raise ValueError(f"Unsupported TikTok scrape_mode: {config.scrape_mode}")
 
     def _scrape_api(
         self,


### PR DESCRIPTION
## Summary
- commit the unmerged TikTok ytdlp-first pivot in three reviewable commits
- force shared-account single-runner fallback onto explicit `scrape_mode="ytdlp"`
- surface safe TikTok scraper diagnostics through the CLI and `/tiktok/scrape`

## Runtime Drift Diagnosis
- Modal social images are built from repo source at image build time via `add_local_python_source(...)` / `add_local_dir(...)` in `trr_backend/modal_jobs.py`; this is not a pinned wheel flow.
- Run `b38c33b5-fffe-43a6-b8ab-5926770bcd43` observed two runtime labels in one run: `modal` and `modal:main · im-sMysH7ppTegIK6j75iXci9`.
- Discovery ran on the unlabeled runtime; the fallback posts job ran on the labeled `main` image. That mixed labeling is the concrete source of the Runtime Version Drift warning.
- Merging to `main` is necessary but not sufficient for production cutover; a fresh Modal image build/deploy is still required after merge.

## Stall Finding
- The earlier `400 / 3277` snapshot was not a natural yt-dlp ceiling.
- Local clean-branch dry-run on `@bravowwhl` reached `1800` posts in `104.7s` with `retrieval_mode=ytdlp`.
- The live Modal run advanced to `3277 / 3277` checked posts.
- The code risk on `origin/main` was that shared-account single-runner fallback still routed TikTok through `scrape_mode="auto"`, preserving direct-path semantics and misleading recovery diagnostics instead of treating yt-dlp as the primary recovery path.

## Validation
- `ruff check` on touched TikTok files: passed
- `ruff format --check` on touched TikTok files: passed
- `pytest -q tests/socials/tiktok/test_scraper.py`: passed
- `pytest -q tests/scripts/test_tiktok_scrape_cli.py tests/api/routers/test_socials_tiktok_scrape.py`: passed
- `pytest -q tests/repositories/test_social_season_analytics.py -k "single_runner_fallback or runtime_version or tiktok_empty_body_transport_failure"`: passed
- `ruff check .` / `ruff format --check .` still fail on unrelated pre-existing repo baseline files
- `pytest -q` was interrupted after 171.59s during collection without reaching test execution in this workspace

## Notes
- Workspace-root research artifacts and the local status file were corrected locally, but they are outside this backend PR branch scope.