### PR TITLE
chore(backend): remove retained screentime service-token fallback

### DIFF
--- a/api/screenalytics_auth.py
+++ b/api/screenalytics_auth.py
@@ -1,10 +1,8 @@
-"""Screenalytics service-to-service auth."""
+"""Auth shim for retained internal screentime worker endpoints."""
 
 from __future__ import annotations
 
-import hmac
 import logging
-import os
 
 from fastapi import HTTPException, Request
 
@@ -12,22 +10,6 @@ from api.auth import get_bearer_token
 from trr_backend.security.internal_admin import InvalidTokenError, verify_internal_admin_token
 
 logger = logging.getLogger(__name__)
-
-
-def get_screenalytics_service_token() -> str | None:
-    token = os.getenv("SCREENALYTICS_SERVICE_TOKEN", "").strip()
-    return token or None
-
-
-def _internal_admin_secret_configured() -> bool:
-    return bool((os.getenv("TRR_INTERNAL_ADMIN_SHARED_SECRET") or "").strip())
-
-
-def _env_flag(name: str, default: bool = False) -> bool:
-    raw = (os.getenv(name) or "").strip().lower()
-    if not raw:
-        return default
-    return raw not in {"0", "false", "no", "off"}
 
 
 async def require_screenalytics_service_token(request: Request) -> None:
@@ -39,22 +21,9 @@ async def require_screenalytics_service_token(request: Request) -> None:
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    expected = get_screenalytics_service_token()
-    allow_service_token_fallback = _env_flag("TRR_SCREENALYTICS_ALLOW_SERVICE_TOKEN_FALLBACK", False)
-
-    if expected and allow_service_token_fallback and hmac.compare_digest(token, expected):
-        logger.info("screenalytics auth fallback accepted via service token")
-        return None
-
-    if expected and allow_service_token_fallback and not _internal_admin_secret_configured():
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid service token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
     try:
         verify_internal_admin_token(token)
+        logger.debug("retained screentime worker request accepted via internal admin token")
         return None
     except RuntimeError as exc:
         raise HTTPException(
@@ -63,17 +32,10 @@ async def require_screenalytics_service_token(request: Request) -> None:
             headers={"x-error-code": "AUTH_SERVICE_UNAVAILABLE"},
         ) from exc
     except InvalidTokenError:
-        pass
-
-    if expected and allow_service_token_fallback:
-        raise HTTPException(
-            status_code=401,
-            detail="Invalid service token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+        logger.info("retained screentime worker request rejected: invalid internal admin token")
 
     raise HTTPException(
         status_code=401,
-        detail="Valid internal admin token required; service-token fallback is transitional and disabled by default",
+        detail="Valid internal admin token required for retained screentime worker endpoints",
         headers={"WWW-Authenticate": "Bearer"},
     )

--- a/tests/api/test_admin_cast_screentime.py
+++ b/tests/api/test_admin_cast_screentime.py
@@ -11,6 +11,11 @@ from api.auth import require_cast_screentime_admin
 from api.main import app
 from api.routers import admin_cast_screentime as router_module
 from trr_backend.repositories import cast_screentime as repo
+from trr_backend.security.internal_admin import (
+    DEFAULT_INTERNAL_ADMIN_ISSUER,
+    INTERNAL_ADMIN_AUDIENCE,
+    INTERNAL_ADMIN_SCOPE,
+)
 from trr_backend.services import cast_screentime_artifacts, retained_cast_screentime_dispatch
 
 
@@ -28,9 +33,10 @@ def override_admin(request):
 
 
 @pytest.fixture(autouse=True)
-def set_service_token(monkeypatch):
-    monkeypatch.setenv("SCREENALYTICS_SERVICE_TOKEN", "test-token")
-    monkeypatch.setenv("TRR_SCREENALYTICS_ALLOW_SERVICE_TOKEN_FALLBACK", "1")
+def set_internal_admin_auth_env(monkeypatch):
+    monkeypatch.setenv("TRR_INTERNAL_ADMIN_SHARED_SECRET", "internal-secret")
+    monkeypatch.delenv("SCREENALYTICS_SERVICE_TOKEN", raising=False)
+    monkeypatch.delenv("TRR_SCREENALYTICS_ALLOW_SERVICE_TOKEN_FALLBACK", raising=False)
     yield
 
 
@@ -42,6 +48,20 @@ def _make_admin_token(secret: str, subject: str = "admin-1") -> str:
         "nbf": int(now.timestamp()),
         "exp": int((now + timedelta(minutes=5)).timestamp()),
         "role": "service_role",
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _make_internal_admin_token(secret: str, subject: str = "internal-worker-1") -> str:
+    now = datetime.now(tz=UTC)
+    payload = {
+        "sub": subject,
+        "iat": int(now.timestamp()),
+        "nbf": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=5)).timestamp()),
+        "iss": DEFAULT_INTERNAL_ADMIN_ISSUER,
+        "aud": INTERNAL_ADMIN_AUDIENCE,
+        "scope": INTERNAL_ADMIN_SCOPE,
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 
@@ -641,7 +661,8 @@ def fake_storage(monkeypatch):
 
 
 def _service_headers():
-    return {"Authorization": "Bearer test-token"}
+    token = _make_internal_admin_token("internal-secret")
+    return {"Authorization": f"Bearer {token}"}
 
 
 def test_upload_complete_and_run_flow():
@@ -1095,6 +1116,21 @@ def test_internal_finalize_and_reads():
     artifact_response = client.get(f"/api/v1/admin/cast-screentime/runs/{run_id}/artifacts/shots.json")
     assert artifact_response.status_code == 200
     assert artifact_response.json()["payload"]["shots"][0]["shot_key"] == "shot-1"
+
+
+def test_internal_worker_routes_reject_legacy_service_token(monkeypatch):
+    monkeypatch.setenv("SCREENALYTICS_SERVICE_TOKEN", "test-token")
+    monkeypatch.setenv("TRR_SCREENALYTICS_ALLOW_SERVICE_TOKEN_FALLBACK", "1")
+
+    client = TestClient(app)
+    response = client.patch(
+        f"/api/v1/internal/screenalytics/cast-screentime/runs/{uuid4()}/status",
+        headers={"Authorization": "Bearer test-token"},
+        json={"status": "running"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Valid internal admin token required for retained screentime worker endpoints"
 
 
 def test_review_status_rejects_non_success_run():

--- a/tests/test_startup_config.py
+++ b/tests/test_startup_config.py
@@ -16,7 +16,6 @@ def _clear_runtime_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TRR_ENV",
         "TRR_ENVIRONMENT",
         "PYTHON_ENV",
-        "SCREENALYTICS_API_URL",
         "TRR_INTERNAL_ADMIN_SHARED_SECRET",
         "SUPABASE_JWT_SECRET",
     ):
@@ -57,7 +56,7 @@ def test_validate_startup_config_requires_deployed_only_secrets_for_deployed_run
     assert "SUPABASE_JWT_SECRET" in message
 
 
-def test_validate_startup_config_does_not_require_screenalytics_service_token_for_deployed_runtime(
+def test_validate_startup_config_does_not_require_retired_screenalytics_envs_for_deployed_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _clear_runtime_env(monkeypatch)
@@ -82,10 +81,9 @@ def test_workspace_shared_env_manifest_matches_backend_contract() -> None:
     backend_contract = manifest["repo_validation"]["TRR-Backend"]
 
     assert {"TRR_DB_URL", "TRR_DB_FALLBACK_URL", "TRR_INTERNAL_ADMIN_SHARED_SECRET"} <= canonical
-    assert {"SCREENALYTICS_API_URL", "SCREENALYTICS_SERVICE_TOKEN"} <= transitional
+    assert "SCREENALYTICS_API_URL" not in transitional
+    assert "SCREENALYTICS_SERVICE_TOKEN" not in transitional
     assert set(backend_contract["db_any_of"]) == {"TRR_DB_URL", "TRR_DB_FALLBACK_URL"}
     assert set(backend_contract["required_in_deployed"]) == {"TRR_INTERNAL_ADMIN_SHARED_SECRET"}
-    assert set(backend_contract["transitional_compat"]) == {
-        "SCREENALYTICS_API_URL",
-        "SCREENALYTICS_SERVICE_TOKEN",
-    }
+    assert "SCREENALYTICS_API_URL" not in set(backend_contract["transitional_compat"])
+    assert "SCREENALYTICS_SERVICE_TOKEN" not in set(backend_contract["transitional_compat"])


### PR DESCRIPTION
## Summary
- remove the retained screentime service-token fallback
- require internal-admin JWT for retained screentime worker endpoints
- update tests to prove JWT works and legacy service tokens are rejected

## Validation
- `ruff check api/screenalytics_auth.py api/routers/admin_cast_screentime.py tests/api/test_admin_cast_screentime.py tests/test_startup_config.py`
- `ruff format --check api/screenalytics_auth.py api/routers/admin_cast_screentime.py tests/api/test_admin_cast_screentime.py tests/test_startup_config.py`
- `pytest -q tests/api/test_admin_cast_screentime.py tests/test_startup_config.py`

## Notes
- local full `ruff check . && ruff format --check . && pytest -q` is not clean on a fresh `origin/main` worktree due unrelated pre-existing backend lint failures outside this change set
- internal `/internal/screenalytics/...` route names remain unchanged intentionally