### PR TITLE
fix(instagram): complete scraper remediation hardening

### DIFF
--- a/api/routers/socials.py
+++ b/api/routers/socials.py
@@ -346,6 +346,122 @@ def _start_runs_in_background(
     background_tasks.add_task(_runner)
 
 
+def _start_catalog_backfill_finalize_in_background(
+    *,
+    platform: str,
+    account_handle: str,
+    run_id: str,
+    source_scope: str,
+    date_start: datetime | None,
+    date_end: datetime | None,
+    initiated_by: str | None,
+    allow_local_dev_inline_bypass: bool,
+    execution_preference: str,
+    selected_tasks: list[str] | None,
+    launch_group_id: str | None,
+) -> None:
+    from trr_backend.repositories.social_season_analytics import finalize_social_account_catalog_backfill_launch
+
+    normalized_platform = str(platform or "").strip().lower()
+    normalized_account = str(account_handle or "").strip().lower()
+    normalized_run_id = str(run_id or "").strip()
+    normalized_launch_group_id = str(launch_group_id or "").strip() or None
+
+    if not normalized_run_id:
+        return
+
+    def _runner() -> None:
+        logger.info(
+            "[catalog-launch] finalize_start platform=%s account=%s run_id=%s launch_group_id=%s",
+            normalized_platform,
+            normalized_account,
+            normalized_run_id,
+            normalized_launch_group_id,
+        )
+        try:
+            finalize_social_account_catalog_backfill_launch(
+                platform=normalized_platform,
+                account_handle=normalized_account,
+                run_id=normalized_run_id,
+                source_scope=source_scope,
+                date_start=date_start,
+                date_end=date_end,
+                initiated_by=initiated_by,
+                allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+                execution_preference=execution_preference,
+                selected_tasks=selected_tasks,
+                launch_group_id=normalized_launch_group_id,
+            )
+            _clear_account_profile_caches()
+        except Exception:  # noqa: BLE001
+            _clear_account_profile_caches()
+            logger.exception(
+                "[catalog-launch] finalize_thread_failed platform=%s account=%s run_id=%s launch_group_id=%s",
+                normalized_platform,
+                normalized_account,
+                normalized_run_id,
+                normalized_launch_group_id,
+            )
+
+    Thread(
+        target=_runner,
+        name=f"catalog-finalize:{normalized_platform}:{normalized_account[:24]}",
+        daemon=True,
+    ).start()
+
+
+def _cancel_catalog_run_in_background(
+    *,
+    platform: str,
+    account_handle: str,
+    run_id: str,
+    cancelled_by: str | None,
+) -> None:
+    from trr_backend.repositories.social_season_analytics import (
+        cancel_social_account_catalog_run,
+        reconcile_cancelled_shared_run,
+    )
+
+    normalized_platform = str(platform or "").strip().lower()
+    normalized_account = str(account_handle or "").strip().lower()
+    normalized_run_id = str(run_id or "").strip()
+    if not normalized_run_id:
+        return
+
+    def _runner() -> None:
+        logger.info(
+            "[catalog-cancel] finalize_start platform=%s account=%s run_id=%s",
+            normalized_platform,
+            normalized_account,
+            normalized_run_id,
+        )
+        try:
+            cancel_social_account_catalog_run(
+                platform=normalized_platform,
+                account_handle=normalized_account,
+                run_id=normalized_run_id,
+                cancelled_by=cancelled_by,
+                reconcile_summary=False,
+            )
+        finally:
+            try:
+                reconcile_cancelled_shared_run(normalized_run_id)
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "[catalog-cancel] reconcile_failed platform=%s account=%s run_id=%s",
+                    normalized_platform,
+                    normalized_account,
+                    normalized_run_id,
+                )
+            _clear_account_profile_caches()
+
+    Thread(
+        target=_runner,
+        name=f"catalog-cancel:{normalized_platform}:{normalized_account[:24]}",
+        daemon=True,
+    ).start()
+
+
 def _normalize_run_summary_payload(summary: Any) -> dict[str, Any]:
     payload = dict(summary) if isinstance(summary, dict) else {}
     if not payload:
@@ -4397,7 +4513,7 @@ async def post_social_account_comments_scrape_route(
     except SocialIngestConflictError as exc:
         raise HTTPException(
             status_code=409,
-            detail={"code": exc.code, "message": str(exc), **exc.detail},
+            detail={"code": exc.code, "message": str(exc), **jsonable_encoder(exc.detail)},
         ) from exc
     except SocialIngestValidationError as exc:
         raise HTTPException(status_code=400, detail={"code": exc.code, "message": str(exc)}) from exc
@@ -4848,20 +4964,23 @@ def post_social_account_catalog_run_cancel_route(
     user: InternalAdminUser,
 ) -> dict[str, Any]:
     from trr_backend.repositories.social_season_analytics import (
-        cancel_social_account_catalog_run,
-        reconcile_cancelled_shared_run,
+        request_cancel_social_account_catalog_run,
     )
 
     try:
-        result = cancel_social_account_catalog_run(
+        result = request_cancel_social_account_catalog_run(
             platform=platform,
             account_handle=account_handle,
             run_id=str(run_id),
             cancelled_by=(user or {}).get("email"),
-            reconcile_summary=False,
         )
-        background_tasks.add_task(reconcile_cancelled_shared_run, str(run_id))
-        _clear_account_profile_caches()
+        background_tasks.add_task(
+            _cancel_catalog_run_in_background,
+            platform=platform,
+            account_handle=account_handle,
+            run_id=str(run_id),
+            cancelled_by=(user or {}).get("email"),
+        )
         return result
     except ValueError as exc:
         raise _value_error_to_bad_request(exc) from exc
@@ -5000,6 +5119,7 @@ async def post_social_account_catalog_backfill_route(
         SocialIngestValidationError,
         SocialWorkerUnavailableError,
         _normalize_catalog_backfill_window,
+        begin_social_account_catalog_backfill_launch,
         launch_social_account_catalog_backfill,
     )
 
@@ -5019,24 +5139,57 @@ async def post_social_account_catalog_backfill_route(
             date_start=date_start,
             date_end=date_end,
         )
-        result = await run_in_threadpool(
-            launch_social_account_catalog_backfill,
-            platform=platform,
-            account_handle=account_handle,
-            source_scope=payload.source_scope,
-            date_start=date_start,
-            date_end=date_end,
-            initiated_by=(user or {}).get("email"),
-            inline_worker_id=None if queue_enabled else f"api-background:catalog:{platform}",
-            allow_local_dev_inline_bypass=used_inline_fallback,
-            execution_preference=payload.execution_preference,
-            selected_tasks=payload.selected_tasks,
+        use_async_instagram_kickoff = (
+            platform == "instagram"
+            and queue_enabled
+            and not used_inline_fallback
+            and list(payload.selected_tasks or []) != ["comments"]
         )
+        if use_async_instagram_kickoff:
+            result = await run_in_threadpool(
+                begin_social_account_catalog_backfill_launch,
+                platform=platform,
+                account_handle=account_handle,
+                source_scope=payload.source_scope,
+                date_start=date_start,
+                date_end=date_end,
+                initiated_by=(user or {}).get("email"),
+                allow_local_dev_inline_bypass=used_inline_fallback,
+                execution_preference=payload.execution_preference,
+                selected_tasks=payload.selected_tasks,
+            )
+            _start_catalog_backfill_finalize_in_background(
+                platform=platform,
+                account_handle=account_handle,
+                run_id=str(result.get("run_id") or ""),
+                source_scope=payload.source_scope,
+                date_start=date_start,
+                date_end=date_end,
+                initiated_by=(user or {}).get("email"),
+                allow_local_dev_inline_bypass=used_inline_fallback,
+                execution_preference=payload.execution_preference,
+                selected_tasks=payload.selected_tasks,
+                launch_group_id=str(result.get("launch_group_id") or ""),
+            )
+        else:
+            result = await run_in_threadpool(
+                launch_social_account_catalog_backfill,
+                platform=platform,
+                account_handle=account_handle,
+                source_scope=payload.source_scope,
+                date_start=date_start,
+                date_end=date_end,
+                initiated_by=(user or {}).get("email"),
+                inline_worker_id=None if queue_enabled else f"api-background:catalog:{platform}",
+                allow_local_dev_inline_bypass=used_inline_fallback,
+                execution_preference=payload.execution_preference,
+                selected_tasks=payload.selected_tasks,
+            )
         _clear_account_profile_caches()
     except SocialIngestConflictError as exc:
         raise HTTPException(
             status_code=409,
-            detail={"code": exc.code, "message": str(exc), **exc.detail},
+            detail={"code": exc.code, "message": str(exc), **jsonable_encoder(exc.detail)},
         ) from exc
     except SocialIngestValidationError as exc:
         raise HTTPException(status_code=400, detail={"code": exc.code, "message": str(exc)}) from exc
@@ -5182,7 +5335,7 @@ async def post_social_account_catalog_sync_recent_route(
     except SocialIngestConflictError as exc:
         raise HTTPException(
             status_code=409,
-            detail={"code": exc.code, "message": str(exc), **exc.detail},
+            detail={"code": exc.code, "message": str(exc), **jsonable_encoder(exc.detail)},
         ) from exc
     except SocialIngestValidationError as exc:
         raise HTTPException(status_code=400, detail={"code": exc.code, "message": str(exc)}) from exc
@@ -5249,7 +5402,7 @@ async def post_social_account_catalog_sync_newer_route(
     except SocialIngestConflictError as exc:
         raise HTTPException(
             status_code=409,
-            detail={"code": exc.code, "message": str(exc), **exc.detail},
+            detail={"code": exc.code, "message": str(exc), **jsonable_encoder(exc.detail)},
         ) from exc
     except SocialIngestValidationError as exc:
         raise HTTPException(status_code=400, detail={"code": exc.code, "message": str(exc)}) from exc
@@ -5319,7 +5472,7 @@ async def post_social_account_catalog_resume_tail_route(
     except SocialIngestConflictError as exc:
         raise HTTPException(
             status_code=409,
-            detail={"code": exc.code, "message": str(exc), **exc.detail},
+            detail={"code": exc.code, "message": str(exc), **jsonable_encoder(exc.detail)},
         ) from exc
     except SocialIngestValidationError as exc:
         raise HTTPException(status_code=400, detail={"code": exc.code, "message": str(exc)}) from exc

--- a/docs/db/schema.md
+++ b/docs/db/schema.md
@@ -94,7 +94,7 @@ See `docs/architecture.md` for the full TMDb enrichment pipeline.
 
 - `social.scrape_jobs`: Track scrape operations (platform, job_type, status, items_found).
 - `social.instagram_posts`: Instagram posts and reels (shortcode unique key).
-- `social.instagram_comments`: Instagram comments with reply support (parent_comment_id).
+- `social.instagram_comments`: Instagram comments with reply support (parent_comment_id), mirrored comment media fields, and hosted commenter-avatar storage.
 - `social.tiktok_posts`: TikTok videos (video_id unique key).
 - `social.tiktok_comments`: TikTok comments with reply support (parent_comment_id).
 - `social.youtube_videos`: YouTube videos (video_id unique key).

--- a/docs/observability/media_mirror_alerts.md
+++ b/docs/observability/media_mirror_alerts.md
@@ -1,0 +1,40 @@
+# Media Mirror Alerts
+
+Use this when Instagram media-mirror failures start accumulating faster than the retry worker can clear them.
+
+## What To Watch
+
+- Active `media_mirror` jobs stuck in `queued`, `retrying`, or `running`
+- Failed Instagram `media_mirror` jobs whose normalized reason is retryable:
+  - `request_timeout`
+  - `connection_error`
+  - `request_error`
+  - `http_429`
+  - `http_500`
+  - `http_502`
+  - `http_503`
+  - `http_504`
+- Failed Instagram `media_mirror` jobs whose normalized reason is non-retryable:
+  - `http_403_auth_or_expired`
+  - `http_404_not_found`
+  - `invalid_source_url`
+  - `asset_too_large`
+  - `asset_wrong_content_type`
+
+## Operator Flow
+
+1. Run the duplicate-job dry runs first:
+   - `python -m scripts.socials.retire_duplicate_instagram_media_mirror_jobs --dry-run`
+   - `python -m scripts.socials.retire_duplicate_instagram_comment_media_mirror_jobs --dry-run`
+2. If the failed backlog is dominated by permanent Instagram media errors, preview retirement:
+   - `python -m scripts.socials.retire_stale_instagram_media_mirror_failures --dry-run`
+3. Review the preview job IDs and confirm the failures are truly permanent.
+4. Apply retirement only after review:
+   - `python -m scripts.socials.retire_stale_instagram_media_mirror_failures --apply`
+5. Re-run the dry run to confirm the stale non-retryable backlog is gone.
+
+## Guardrails
+
+- These scripts retire obsolete queue rows by marking them `cancelled`; they do not delete history.
+- Run cleanup previews before adding or validating active-job uniqueness indexes.
+- If you see signed CDN URLs in logs or operator output, stop and fix redaction before sharing artifacts.

--- a/scripts/modal/diagnose_instagram_comments_remote.py
+++ b/scripts/modal/diagnose_instagram_comments_remote.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Run the Instagram comments fetch path inside Modal and print a compact diagnostic."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import modal
+
+from trr_backend.modal_jobs import _FUNCTION_IMAGE_BINDINGS, _secrets
+
+app = modal.App("trr-instagram-comments-diagnostic")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--account", default="thetraitorsus", help="Instagram handle used for browser/account context")
+    parser.add_argument("--shortcode", required=True, help="Instagram post shortcode to probe")
+    return parser.parse_args()
+
+
+@app.function(
+    image=_FUNCTION_IMAGE_BINDINGS["run_social_job"],
+    secrets=_secrets,
+    timeout=5 * 60,
+)
+def diagnose_remote_comments(shortcode: str, account_handle: str) -> dict[str, object]:
+    import asyncio
+
+    from trr_backend.socials.instagram.comments_scrapling.fetcher import (
+        InstagramCommentsScraplingFetcher,
+        _response_text,
+        _safe_location,
+        _status_code,
+    )
+    from trr_backend.socials.instagram.comments_scrapling.session import resolve_comments_scrapling_session
+    from trr_backend.socials.instagram.constants import COMMENTS_URL
+    from trr_backend.socials.instagram.permalink_metadata import _shortcode_to_media_id
+
+    async def _run() -> dict[str, object]:
+        session = resolve_comments_scrapling_session(
+            browser_account_id=account_handle,
+            caller_context=f"comments_scrapling:profile:{account_handle}",
+        )
+        fetcher = InstagramCommentsScraplingFetcher(
+            cookies=session.cookies,
+            raw_cookies=session.auth_session.cookies,
+            browser_account_id=session.browser_account_id,
+            proxy_config=None,
+        )
+        payload: dict[str, object] = {
+            "auth_session": {
+                "source": session.auth_session.source,
+                "validated": session.auth_session.validated,
+                "validation_reason": session.auth_session.validation_reason,
+                "validation_category": session.auth_session.validation_category,
+                "browser_account_id": session.auth_session.browser_account_id,
+                "session_account_id": session.auth_session.session_account_id,
+                "cookie_count": len(session.auth_session.cookies),
+                "fingerprint": (session.auth_session.metadata or {}).get("fingerprint"),
+            }
+        }
+        try:
+            await fetcher.warmup()
+            payload["warmup"] = {
+                "ok": True,
+                "runtime": dict(fetcher.runtime_metadata),
+            }
+            media_id = _shortcode_to_media_id(shortcode)
+            response = await fetcher._fetch_api(
+                COMMENTS_URL.format(media_id=media_id),
+                referer=f"https://www.instagram.com/p/{shortcode}/",
+                params={"can_support_threading": "true", "permalink_enabled": "false"},
+            )
+            payload["api"] = {
+                "status_code": _status_code(response),
+                "location": _safe_location(response),
+                "text_prefix": _response_text(response)[:200],
+                "headers_subset": {
+                    "content_type": response.headers.get("content-type"),
+                    "location": response.headers.get("location"),
+                },
+            }
+            payload["parsed"] = await fetcher._fetch_json_response(
+                COMMENTS_URL.format(media_id=media_id),
+                referer=f"https://www.instagram.com/p/{shortcode}/",
+                params={"can_support_threading": "true", "permalink_enabled": "false"},
+            )
+        except Exception as exc:  # noqa: BLE001
+            payload["error"] = {
+                "class": type(exc).__name__,
+                "message": str(exc),
+            }
+        finally:
+            await fetcher.aclose()
+        return payload
+
+    return asyncio.run(_run())
+
+
+def main() -> int:
+    args = parse_args()
+    with app.run():
+        payload = diagnose_remote_comments.remote(args.shortcode, args.account)
+    print(json.dumps(payload, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/modal/verify_modal_readiness.py
+++ b/scripts/modal/verify_modal_readiness.py
@@ -156,6 +156,12 @@ def expected_function_names() -> tuple[str, ...]:
         str(os.getenv("TRR_MODAL_GETTY_REMOTE_PROBE_FUNCTION") or DEFAULT_GETTY_REMOTE_PROBE_FUNCTION).strip()
         or DEFAULT_GETTY_REMOTE_PROBE_FUNCTION,
         str(os.getenv("TRR_MODAL_SOCIAL_JOB_FUNCTION") or "run_social_job").strip() or "run_social_job",
+        str(os.getenv("TRR_MODAL_SOCIAL_POSTS_JOB_FUNCTION") or "run_social_posts_job").strip()
+        or "run_social_posts_job",
+        str(os.getenv("TRR_MODAL_SOCIAL_MEDIA_JOB_FUNCTION") or "run_social_media_job").strip()
+        or "run_social_media_job",
+        str(os.getenv("TRR_MODAL_SOCIAL_COMMENTS_JOB_FUNCTION") or "run_social_comments_job").strip()
+        or "run_social_comments_job",
         str(os.getenv("TRR_MODAL_SOCIAL_RECOVERY_FUNCTION") or "sweep_social_dispatch_queue").strip()
         or "sweep_social_dispatch_queue",
         str(os.getenv("TRR_MODAL_VISION_FUNCTION") or "run_admin_vision").strip() or "run_admin_vision",

--- a/scripts/socials/backfill_instagram_profile_avatars.py
+++ b/scripts/socials/backfill_instagram_profile_avatars.py
@@ -80,7 +80,9 @@ class _AvatarBackfillPost:
             if isinstance(item, dict)
         ]
         self.hosted_owner_profile_pic_url = str(row.get("hosted_owner_profile_pic_url") or "").strip() or None
-        self.hosted_tagged_profile_pics = social_repo._as_json_string_map(row.get("hosted_tagged_profile_pics"))  # noqa: SLF001
+        self.hosted_tagged_profile_pics = social_repo._normalize_hosted_tagged_profile_pics(  # noqa: SLF001
+            row.get("hosted_tagged_profile_pics")
+        )
         self.profile_pic_mirror_status = str(row.get("profile_pic_mirror_status") or "").strip() or None
         self.profile_pic_mirror_error = str(row.get("profile_pic_mirror_error") or "").strip() or None
         self._raw_data = row.get("raw_data") if isinstance(row.get("raw_data"), dict) else {}

--- a/scripts/socials/repair_instagram_single_media_urls.py
+++ b/scripts/socials/repair_instagram_single_media_urls.py
@@ -151,6 +151,7 @@ def _repair_candidate_row(row: dict[str, Any]) -> dict[str, Any] | None:
         "id": str(row.get("id") or "").strip(),
         "shortcode": str(row.get("shortcode") or "").strip(),
         "old_media_urls": media_urls,
+        "legacy_media_urls": media_urls,
         "new_media_urls": [primary_url],
     }
 
@@ -196,11 +197,22 @@ def _apply_repairs(repairs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         result = pg.execute_returning(
             """
             update social.instagram_posts
-            set media_urls = %s::jsonb
+            set
+              media_urls = %s::jsonb,
+              raw_data = coalesce(raw_data, '{}'::jsonb) || %s::jsonb
             where id::text = %s
             returning id::text as id, shortcode
             """,
-            [media_urls_json, row_id],
+            [
+                media_urls_json,
+                json.dumps(
+                    {
+                        "legacy_media_urls": repair.get("legacy_media_urls") or [],
+                        "repair_reason": "single_media_repair",
+                    }
+                ),
+                row_id,
+            ],
         )
         updated.extend(result)
     return updated

--- a/scripts/socials/repair_social_hosted_urls.py
+++ b/scripts/socials/repair_social_hosted_urls.py
@@ -292,7 +292,9 @@ def _repair_platform(
         old_media_urls = _as_text_list(row.get("hosted_media_urls"))
         old_avatar_url = str(row.get("hosted_user_avatar_url") or "").strip()
         old_owner_avatar_url = str(row.get("hosted_owner_profile_pic_url") or "").strip()
-        old_tagged_profile_pics = _as_json_object(row.get("hosted_tagged_profile_pics"))
+        old_tagged_profile_pics = social_repo._normalize_hosted_tagged_profile_pics(  # noqa: SLF001
+            row.get("hosted_tagged_profile_pics")
+        )
         old_raw_data = _as_json_object(row.get("raw_data"))
 
         new_thumbnail_url, thumb_changed = _rewrite_to_cdn(old_thumbnail_url, cdn_base_url=cdn_base_url)
@@ -312,12 +314,16 @@ def _repair_platform(
         )
 
         tagged_profile_rewrites = 0
-        new_tagged_profile_pics: dict[str, str] = {}
+        new_tagged_profile_pics: dict[str, dict[str, object]] = {}
         for key, value in old_tagged_profile_pics.items():
-            rewritten, changed = _rewrite_to_cdn(str(value or "").strip(), cdn_base_url=cdn_base_url)
+            rewritten, changed = _rewrite_to_cdn(str(value.get("hosted_url") or "").strip(), cdn_base_url=cdn_base_url)
             if changed:
                 tagged_profile_rewrites += 1
-            new_tagged_profile_pics[str(key)] = rewritten
+            new_tagged_profile_pics[str(key)] = {
+                "hosted_url": rewritten,
+                "sha256": value.get("sha256"),
+                "mirrored_at": value.get("mirrored_at"),
+            }
 
         new_raw_data, media_asset_meta_rewrites = _rewrite_media_asset_meta(
             old_raw_data,

--- a/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from trr_backend.db import pg
+    from trr_backend.utils.env import load_env
+except ModuleNotFoundError:  # pragma: no cover - script execution convenience
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from trr_backend.db import pg
+    from trr_backend.utils.env import load_env
+
+
+DUPLICATE_ERROR_CODE = "duplicate_comment_media_mirror_job_retired"
+DUPLICATE_ERROR_CLASS = "DuplicateCommentMediaMirrorJobRetired"
+DUPLICATE_ERROR_MESSAGE = "duplicate_active_comment_media_mirror_job_retired"
+IDENTITY_SQL = """
+coalesce(
+  nullif(config->>'comment_db_id', ''),
+  case
+    when coalesce(config->>'post_id', '') <> '' and coalesce(config->>'comment_id', '') <> ''
+      then concat(config->>'post_id', ':', config->>'comment_id')
+    else null
+  end
+)
+""".strip()
+
+
+@dataclass(slots=True)
+class CleanupStats:
+    matched_rows: int = 0
+    retired_rows: int = 0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="retire_duplicate_instagram_comment_media_mirror_jobs",
+        description="Retire duplicate active Instagram comment_media_mirror jobs before uniqueness enforcement.",
+    )
+    parser.add_argument("--season-id", action="append", default=[], help="Optional season UUID filter.")
+    parser.add_argument("--show-id", action="append", default=[], help="Optional show UUID filter.")
+    parser.add_argument("--dry-run", action="store_true", help="Preview matching duplicate rows (default).")
+    parser.add_argument("--apply", action="store_true", help="Retire duplicate rows by marking them cancelled.")
+    parser.set_defaults(dry_run=True)
+    return parser.parse_args(argv)
+
+
+def _normalize_text_filters(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in values or []:
+        value = str(raw or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+    return normalized
+
+
+def _duplicate_comment_media_where_clause(*, season_ids: list[str], show_ids: list[str]) -> tuple[str, list[object]]:
+    filters = [
+        "platform = 'instagram'",
+        "status in ('queued', 'pending', 'retrying', 'running')",
+        "coalesce(config->>'stage', metadata->>'stage', job_type) = 'comment_media_mirror'",
+        f"({IDENTITY_SQL}) is not null",
+    ]
+    params: list[object] = []
+    if season_ids:
+        filters.append("season_id::text = any(%s)")
+        params.append(season_ids)
+    if show_ids:
+        filters.append("show_id::text = any(%s)")
+        params.append(show_ids)
+    return " and ".join(filters), params
+
+
+def _fetch_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
+    where_clause, params = _duplicate_comment_media_where_clause(season_ids=season_ids, show_ids=show_ids)
+    return pg.fetch_all(
+        f"""
+        with ranked as (
+          select
+            id::text as id,
+            season_id::text as season_id,
+            show_id::text as show_id,
+            config->>'comment_id' as comment_id,
+            config->>'comment_db_id' as comment_db_id,
+            config->>'post_id' as post_id,
+            {IDENTITY_SQL} as identity_key,
+            created_at,
+            first_value(id::text) over (
+              partition by platform, ({IDENTITY_SQL})
+              order by created_at desc, id desc
+            ) as keep_job_id,
+            row_number() over (
+              partition by platform, ({IDENTITY_SQL})
+              order by created_at desc, id desc
+            ) as row_num,
+            count(*) over (
+              partition by platform, ({IDENTITY_SQL})
+            ) as duplicate_count
+          from social.scrape_jobs
+          where {where_clause}
+        )
+        select
+          id,
+          season_id,
+          show_id,
+          comment_id,
+          comment_db_id,
+          post_id,
+          identity_key,
+          keep_job_id,
+          duplicate_count,
+          created_at
+        from ranked
+        where row_num > 1
+        order by identity_key asc, created_at desc, id desc
+        """,
+        params,
+    )
+
+
+def _retire_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
+    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+    duplicate_ids = [str(row.get("id") or "").strip() for row in matched_rows if str(row.get("id") or "").strip()]
+    if not duplicate_ids:
+        return []
+    payload = json.dumps({"duplicate_active_comment_media_mirror_job": True})
+    return pg.execute_returning(
+        """
+        update social.scrape_jobs
+        set
+          status = 'cancelled',
+          error_message = %s,
+          last_error_code = %s,
+          last_error_class = %s,
+          metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
+        where id::text = any(%s)
+        returning id::text as id
+        """,
+        [DUPLICATE_ERROR_MESSAGE, DUPLICATE_ERROR_CODE, DUPLICATE_ERROR_CLASS, payload, duplicate_ids],
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_env()
+    args = _parse_args(argv or sys.argv[1:])
+    season_ids = _normalize_text_filters(args.season_id)
+    show_ids = _normalize_text_filters(args.show_id)
+    dry_run = bool(args.dry_run and not args.apply)
+
+    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+    stats = CleanupStats(matched_rows=len(matched_rows), retired_rows=0)
+    if not dry_run and matched_rows:
+        stats.retired_rows = len(_retire_matches(season_ids=season_ids, show_ids=show_ids))
+
+    print(
+        json.dumps(
+            {
+                "dry_run": dry_run,
+                "season_ids": season_ids,
+                "show_ids": show_ids,
+                "totals": {"matched_rows": stats.matched_rows, "retired_rows": stats.retired_rows},
+                "preview_job_ids": [str(row.get("id") or "") for row in matched_rows[:10]],
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/socials/retire_duplicate_instagram_media_mirror_jobs.py
+++ b/scripts/socials/retire_duplicate_instagram_media_mirror_jobs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from trr_backend.db import pg
+    from trr_backend.utils.env import load_env
+except ModuleNotFoundError:  # pragma: no cover - script execution convenience
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from trr_backend.db import pg
+    from trr_backend.utils.env import load_env
+
+
+DUPLICATE_ERROR_CODE = "duplicate_media_mirror_job_retired"
+DUPLICATE_ERROR_CLASS = "DuplicateMediaMirrorJobRetired"
+DUPLICATE_ERROR_MESSAGE = "duplicate_active_media_mirror_job_retired"
+
+
+@dataclass(slots=True)
+class CleanupStats:
+    matched_rows: int = 0
+    retired_rows: int = 0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="retire_duplicate_instagram_media_mirror_jobs",
+        description="Retire duplicate active Instagram media_mirror jobs before uniqueness enforcement.",
+    )
+    parser.add_argument("--season-id", action="append", default=[], help="Optional season UUID filter.")
+    parser.add_argument("--show-id", action="append", default=[], help="Optional show UUID filter.")
+    parser.add_argument("--dry-run", action="store_true", help="Preview matching duplicate rows (default).")
+    parser.add_argument("--apply", action="store_true", help="Retire duplicate rows by marking them cancelled.")
+    parser.set_defaults(dry_run=True)
+    return parser.parse_args(argv)
+
+
+def _normalize_text_filters(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in values or []:
+        value = str(raw or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+    return normalized
+
+
+def _duplicate_media_where_clause(*, season_ids: list[str], show_ids: list[str]) -> tuple[str, list[object]]:
+    filters = [
+        "platform = 'instagram'",
+        "status in ('queued', 'pending', 'retrying', 'running')",
+        "coalesce(config->>'stage', metadata->>'stage', job_type) = 'media_mirror'",
+        "coalesce(config->>'post_id', '') <> ''",
+    ]
+    params: list[object] = []
+    if season_ids:
+        filters.append("season_id::text = any(%s)")
+        params.append(season_ids)
+    if show_ids:
+        filters.append("show_id::text = any(%s)")
+        params.append(show_ids)
+    return " and ".join(filters), params
+
+
+def _fetch_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
+    where_clause, params = _duplicate_media_where_clause(season_ids=season_ids, show_ids=show_ids)
+    return pg.fetch_all(
+        f"""
+        with ranked as (
+          select
+            id::text as id,
+            season_id::text as season_id,
+            show_id::text as show_id,
+            config->>'post_id' as post_id,
+            created_at,
+            first_value(id::text) over (
+              partition by platform, config->>'post_id'
+              order by created_at desc, id desc
+            ) as keep_job_id,
+            row_number() over (
+              partition by platform, config->>'post_id'
+              order by created_at desc, id desc
+            ) as row_num,
+            count(*) over (
+              partition by platform, config->>'post_id'
+            ) as duplicate_count
+          from social.scrape_jobs
+          where {where_clause}
+        )
+        select
+          id,
+          season_id,
+          show_id,
+          post_id,
+          keep_job_id,
+          duplicate_count,
+          created_at
+        from ranked
+        where row_num > 1
+        order by post_id asc, created_at desc, id desc
+        """,
+        params,
+    )
+
+
+def _retire_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
+    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+    duplicate_ids = [str(row.get("id") or "").strip() for row in matched_rows if str(row.get("id") or "").strip()]
+    if not duplicate_ids:
+        return []
+    payload = json.dumps({"duplicate_active_media_mirror_job": True})
+    return pg.execute_returning(
+        """
+        update social.scrape_jobs
+        set
+          status = 'cancelled',
+          error_message = %s,
+          last_error_code = %s,
+          last_error_class = %s,
+          metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
+        where id::text = any(%s)
+        returning id::text as id
+        """,
+        [DUPLICATE_ERROR_MESSAGE, DUPLICATE_ERROR_CODE, DUPLICATE_ERROR_CLASS, payload, duplicate_ids],
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_env()
+    args = _parse_args(argv or sys.argv[1:])
+    season_ids = _normalize_text_filters(args.season_id)
+    show_ids = _normalize_text_filters(args.show_id)
+    dry_run = bool(args.dry_run and not args.apply)
+
+    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+    stats = CleanupStats(matched_rows=len(matched_rows), retired_rows=0)
+    if not dry_run and matched_rows:
+        stats.retired_rows = len(_retire_matches(season_ids=season_ids, show_ids=show_ids))
+
+    print(
+        json.dumps(
+            {
+                "dry_run": dry_run,
+                "season_ids": season_ids,
+                "show_ids": show_ids,
+                "totals": {"matched_rows": stats.matched_rows, "retired_rows": stats.retired_rows},
+                "preview_job_ids": [str(row.get("id") or "") for row in matched_rows[:10]],
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/socials/retire_stale_instagram_media_mirror_failures.py
+++ b/scripts/socials/retire_stale_instagram_media_mirror_failures.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from trr_backend.db import pg
+    from trr_backend.utils.env import load_env
+except ModuleNotFoundError:  # pragma: no cover - script execution convenience
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from trr_backend.db import pg
+    from trr_backend.utils.env import load_env
+
+
+NON_RETRYABLE_ERRORS = {
+    "http_403_auth_or_expired",
+    "http_404_not_found",
+    "invalid_source_url",
+    "asset_too_large",
+    "asset_wrong_content_type",
+}
+KNOWN_REASON_PREFIXES = (
+    "download_failed:",
+    "upload_failed:",
+    "ytdlp_fallback_failed:",
+)
+OBSOLETE_ERROR_CODE = "obsolete_non_retryable_instagram_media_mirror_failure"
+OBSOLETE_ERROR_CLASS = "ObsoleteInstagramMediaMirrorFailure"
+OBSOLETE_ERROR_MESSAGE = "obsolete_non_retryable_instagram_media_mirror_failure"
+
+
+@dataclass(slots=True)
+class CleanupStats:
+    matched_rows: int = 0
+    retired_rows: int = 0
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="retire_stale_instagram_media_mirror_failures",
+        description="Retire stale, non-retryable failed Instagram media_mirror jobs without deleting queue history.",
+    )
+    parser.add_argument(
+        "--season-id",
+        action="append",
+        default=[],
+        help="Optional season UUID filter. Repeat to target multiple seasons.",
+    )
+    parser.add_argument(
+        "--show-id",
+        action="append",
+        default=[],
+        help="Optional show UUID filter. Repeat to target multiple shows.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview matching stale failure rows without mutating them (default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Retire the matching stale failures by marking them cancelled with obsolete-failure metadata.",
+    )
+    parser.set_defaults(dry_run=True)
+    return parser.parse_args(argv)
+
+
+def _normalize_text_filters(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in values or []:
+        value = str(raw or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+    return normalized
+
+
+def _normalize_failure_reason(reason: str | None) -> str:
+    normalized = str(reason or "").strip().lower()
+    while any(normalized.startswith(prefix) for prefix in KNOWN_REASON_PREFIXES):
+        normalized = normalized.split(":", 1)[1]
+    return normalized
+
+
+def _is_non_retryable_failure_reason(reason: str | None) -> bool:
+    return _normalize_failure_reason(reason) in NON_RETRYABLE_ERRORS
+
+
+def _base_where_clause(*, season_ids: list[str], show_ids: list[str]) -> tuple[str, list[object]]:
+    filters = [
+        "platform = 'instagram'",
+        "status = 'failed'",
+        "coalesce(config->>'stage', metadata->>'stage', job_type) = 'media_mirror'",
+    ]
+    params: list[object] = []
+    if season_ids:
+        filters.append("season_id::text = any(%s)")
+        params.append(season_ids)
+    if show_ids:
+        filters.append("show_id::text = any(%s)")
+        params.append(show_ids)
+    return " and ".join(filters), params
+
+
+def _fetch_candidates(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
+    where_clause, params = _base_where_clause(season_ids=season_ids, show_ids=show_ids)
+    return pg.fetch_all(
+        f"""
+        select
+          id::text as id,
+          season_id::text as season_id,
+          show_id::text as show_id,
+          created_at,
+          coalesce(last_error_code, '') as last_error_code,
+          coalesce(error_message, '') as error_message
+        from social.scrape_jobs
+        where {where_clause}
+        order by created_at asc, id asc
+        """,
+        params,
+    )
+
+
+def _fetch_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
+    matches: list[dict[str, object]] = []
+    for row in _fetch_candidates(season_ids=season_ids, show_ids=show_ids):
+        last_error_code = str(row.get("last_error_code") or "").strip()
+        error_message = str(row.get("error_message") or "").strip()
+        if _is_non_retryable_failure_reason(last_error_code) or _is_non_retryable_failure_reason(error_message):
+            matches.append(dict(row))
+    return matches
+
+
+def _retire_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
+    matches = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+    job_ids = [str(row.get("id") or "").strip() for row in matches if str(row.get("id") or "").strip()]
+    if not job_ids:
+        return []
+
+    payload = json.dumps(
+        {
+            "obsolete_non_retryable_media_mirror_failure": True,
+            "obsolete_failure_reason": "instagram_media_mirror_non_retryable",
+            "obsolete_failure_resolution": "retired_from_retry_backlog",
+        }
+    )
+    return pg.execute_returning(
+        """
+        update social.scrape_jobs
+        set
+          status = 'cancelled',
+          error_message = %s,
+          last_error_code = %s,
+          last_error_class = %s,
+          metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
+        where id::text = any(%s)
+        returning id::text as id,
+                  season_id::text as season_id,
+                  show_id::text as show_id
+        """,
+        [OBSOLETE_ERROR_MESSAGE, OBSOLETE_ERROR_CODE, OBSOLETE_ERROR_CLASS, payload, job_ids],
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_env()
+    args = _parse_args(argv or sys.argv[1:])
+    season_ids = _normalize_text_filters(args.season_id)
+    show_ids = _normalize_text_filters(args.show_id)
+    dry_run = bool(args.dry_run and not args.apply)
+
+    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+    stats = CleanupStats(matched_rows=len(matched_rows), retired_rows=0)
+    if not dry_run and matched_rows:
+        retired_rows = _retire_matches(season_ids=season_ids, show_ids=show_ids)
+        stats.retired_rows = len(retired_rows)
+
+    preview = [str(row.get("id") or "") for row in matched_rows[:10] if str(row.get("id") or "").strip()]
+    print(
+        json.dumps(
+            {
+                "dry_run": dry_run,
+                "season_ids": season_ids,
+                "show_ids": show_ids,
+                "non_retryable_errors": sorted(NON_RETRYABLE_ERRORS),
+                "replacement_error_message": OBSOLETE_ERROR_MESSAGE,
+                "totals": {
+                    "matched_rows": stats.matched_rows,
+                    "retired_rows": stats.retired_rows,
+                },
+                "preview_job_ids": preview,
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/socials/worker.py
+++ b/scripts/socials/worker.py
@@ -16,6 +16,7 @@ import threading
 import time
 from datetime import UTC, datetime
 
+from trr_backend.db import pg
 from trr_backend.repositories.social_sync_orchestrator import tick_sync_orchestrator
 from trr_backend.socials.control_plane import (
     _resolve_runtime_version_stamp,
@@ -180,6 +181,44 @@ def _resolve_int_env(name: str, default: int, *, minimum: int, maximum: int) -> 
     return max(minimum, min(maximum, parsed))
 
 
+def _resolve_optional_positive_int(
+    value: int | None,
+    *,
+    env_name: str,
+    minimum: int,
+    maximum: int,
+) -> int | None:
+    if value is not None:
+        return max(minimum, min(maximum, int(value)))
+    raw = (os.getenv(env_name) or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return None
+    return max(minimum, min(maximum, parsed))
+
+
+def _resolve_optional_positive_float(
+    value: float | None,
+    *,
+    env_name: str,
+    minimum: float,
+    maximum: float,
+) -> float | None:
+    if value is not None:
+        return max(minimum, min(maximum, float(value)))
+    raw = (os.getenv(env_name) or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return None
+    return max(minimum, min(maximum, parsed))
+
+
 def _default_claim_batch_size_for_stage(stage: str | None) -> int:
     # Queue claims mark jobs running up front; batching post claims creates false
     # stale-heartbeat jobs for the later entries while one worker processes the first.
@@ -188,13 +227,52 @@ def _default_claim_batch_size_for_stage(stage: str | None) -> int:
 
 def _claim_stage_candidates(stage: str | None) -> tuple[str | None, ...]:
     normalized_stage = (stage or "").strip().lower() or None
-    if normalized_stage == "comments":
-        # Keep comments draining first, but let otherwise-idle comments workers
-        # borrow post shards once the comment queue is empty.
-        return ("comments", "posts")
     if normalized_stage == "comments_scrapling":
         return ("comments_scrapling",)
+    if normalized_stage == "comments":
+        return ("comments", "posts")
     return (stage,)
+
+
+def _resolve_tandem_stage_groups(
+    *,
+    run_id: str,
+    platform: str | None,
+    posts_workers: int,
+    comments_workers: int,
+    media_workers: int,
+) -> list[tuple[str, str, int]]:
+    normalized_platform = (platform or "").strip().lower() or None
+    run_row = pg.fetch_one(
+        """
+        select config
+        from social.scrape_runs
+        where id = %s::uuid
+        limit 1
+        """,
+        [run_id],
+    ) or {}
+    run_config = _metadata_dict(run_row.get("config"))
+    run_platforms = [
+        str(item or "").strip().lower()
+        for item in list(run_config.get("platforms") or [])
+        if str(item or "").strip()
+    ]
+    effective_platform = normalized_platform or (run_platforms[0] if len(run_platforms) == 1 else None)
+    pipeline_ingest_mode = str(run_config.get("pipeline_ingest_mode") or "").strip().lower()
+
+    if pipeline_ingest_mode == "shared_account_catalog_backfill" and effective_platform == "instagram":
+        return [
+            ("shared_account_posts", "posts", posts_workers),
+            ("comments_scrapling", "comments", comments_workers),
+            ("media_mirror", "media", media_workers),
+        ]
+
+    return [
+        ("posts", "posts", posts_workers),
+        ("comments", "comments", comments_workers),
+        ("media_mirror", "media", media_workers),
+    ]
 
 
 def _claim_jobs_for_stage_candidates(
@@ -443,10 +521,28 @@ def parse_args() -> argparse.Namespace:
         help="Worker count for comments stage in --tandem mode (default: 1)",
     )
     parser.add_argument(
+        "--media-workers",
+        type=int,
+        default=1,
+        help="Worker count for media stage in --tandem mode (default: 1)",
+    )
+    parser.add_argument(
         "--platform",
         choices=list(SOCIAL_SUPPORTED_PLATFORMS),
         default=None,
         help="Optional platform filter when claiming jobs",
+    )
+    parser.add_argument(
+        "--max-jobs-per-invocation",
+        type=int,
+        default=None,
+        help="Optional queue-mode cap on processed jobs before the worker exits",
+    )
+    parser.add_argument(
+        "--max-run-seconds",
+        type=float,
+        default=None,
+        help="Optional queue-mode wall-clock cap before the worker exits",
     )
     return parser.parse_args()
 
@@ -473,6 +569,8 @@ def _spawn_child_worker(
     platform: str | None = None,
     run_id: str | None = None,
     once: bool = False,
+    max_jobs_per_invocation: int | None = None,
+    max_run_seconds: float | None = None,
 ) -> subprocess.Popen:
     cmd = [
         sys.executable,
@@ -489,6 +587,10 @@ def _spawn_child_worker(
         cmd.extend(["--interval", str(interval)])
         if once:
             cmd.append("--once")
+        if max_jobs_per_invocation is not None:
+            cmd.extend(["--max-jobs-per-invocation", str(max_jobs_per_invocation)])
+        if max_run_seconds is not None:
+            cmd.extend(["--max-run-seconds", str(max_run_seconds)])
     if stage:
         cmd.extend(["--stage", stage])
     if platform:
@@ -526,16 +628,39 @@ def _stop_process(proc: subprocess.Popen, *, force: bool) -> None:
             return
 
 
+def _resolve_child_wait_timeout_seconds(max_run_seconds: float | None = None) -> float:
+    if max_run_seconds is not None:
+        return max(30.0, float(max_run_seconds) + 30.0)
+    raw = (os.getenv("SOCIAL_WORKER_CHILD_WAIT_TIMEOUT_SECONDS") or "").strip()
+    try:
+        parsed = float(raw) if raw else 1830.0
+    except ValueError:
+        parsed = 1830.0
+    return max(30.0, min(86400.0, parsed))
+
+
 def _wait_for_children(
     children: list[subprocess.Popen],
     *,
     context_label: str,
+    wait_timeout_seconds: float | None = None,
     terminate_grace_seconds: float = 5.0,
 ) -> int:
     exit_code = 0
+    deadline = time.monotonic() + max(0.0, wait_timeout_seconds) if wait_timeout_seconds is not None else None
     try:
         for proc in children:
-            rc = _wait_process(proc)
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            rc = _wait_process(proc, timeout=remaining)
+            if rc is None and _poll_process(proc) is None:
+                exit_code = exit_code or 124
+                logger.error(
+                    "%s child wait timed out after %.1fs; terminating remaining workers",
+                    context_label,
+                    float(wait_timeout_seconds or 0.0),
+                )
+                _stop_process(proc, force=False)
+                break
             if rc is None:
                 continue
             if rc != 0 and exit_code == 0:
@@ -576,6 +701,18 @@ def main() -> int:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
     logger.info("Starting socials worker: worker_id=%s", worker_id)
+    max_jobs_per_invocation = _resolve_optional_positive_int(
+        getattr(args, "max_jobs_per_invocation", None),
+        env_name="SOCIAL_WORKER_MAX_JOBS_PER_INVOCATION",
+        minimum=1,
+        maximum=10_000,
+    )
+    max_run_seconds = _resolve_optional_positive_float(
+        getattr(args, "max_run_seconds", None),
+        env_name="SOCIAL_WORKER_MAX_RUN_SECONDS",
+        minimum=1.0,
+        maximum=86_400.0,
+    )
     if _requires_media_mirror_s3_preflight(stage=stage_filter, platform=platform_filter):
         try:
             ensure_media_mirror_s3_ready()
@@ -601,9 +738,15 @@ def main() -> int:
                     stage=stage_filter,
                     platform=platform_filter,
                     once=bool(args.once),
+                    max_jobs_per_invocation=max_jobs_per_invocation,
+                    max_run_seconds=max_run_seconds,
                 )
             )
-        return _wait_for_children(children, context_label="queue fanout")
+        return _wait_for_children(
+            children,
+            context_label="queue fanout",
+            wait_timeout_seconds=_resolve_child_wait_timeout_seconds(max_run_seconds),
+        )
 
     if platform_filter:
         worker_supported_platforms = [platform_filter]
@@ -628,24 +771,31 @@ def main() -> int:
                     "Recovered %d stale running job(s) before executing run_id=%s",
                     len(stale_jobs),
                     args.run_id,
-                )
+            )
             if args.tandem:
                 posts_workers = max(0, int(args.posts_workers))
                 comments_workers = max(0, int(args.comments_workers))
-                if posts_workers + comments_workers == 0:
+                media_workers = max(0, int(args.media_workers))
+                if posts_workers + comments_workers + media_workers == 0:
                     logger.error("No workers requested for tandem mode")
                     return 2
+                stage_groups = _resolve_tandem_stage_groups(
+                    run_id=args.run_id,
+                    platform=platform_filter,
+                    posts_workers=posts_workers,
+                    comments_workers=comments_workers,
+                    media_workers=media_workers,
+                )
                 logger.info(
-                    "Executing run_id=%s in tandem mode (posts=%d comments=%d)",
+                    "Executing run_id=%s in tandem mode (%s)",
                     args.run_id,
-                    posts_workers,
-                    comments_workers,
+                    ", ".join(f"{label}={count}" for _stage, label, count in stage_groups if count > 0),
                 )
                 children: list[subprocess.Popen] = []
 
-                def _spawn_group(stage: str, count: int) -> None:
+                def _spawn_group(stage: str, label: str, count: int) -> None:
                     for index in range(count):
-                        child_worker_id = f"{worker_id}:{stage}:p{index + 1}"
+                        child_worker_id = f"{worker_id}:{label}:p{index + 1}"
                         children.append(
                             _spawn_child_worker(
                                 worker_id=child_worker_id,
@@ -653,12 +803,19 @@ def main() -> int:
                                 stage=stage,
                                 platform=platform_filter,
                                 run_id=args.run_id,
+                                max_jobs_per_invocation=max_jobs_per_invocation,
+                                max_run_seconds=max_run_seconds,
                             )
                         )
 
-                _spawn_group("posts", posts_workers)
-                _spawn_group("comments", comments_workers)
-                return _wait_for_children(children, context_label="tandem run")
+                for stage_name, label, count in stage_groups:
+                    if count > 0:
+                        _spawn_group(stage_name, label, count)
+                return _wait_for_children(
+                    children,
+                    context_label="tandem run",
+                    wait_timeout_seconds=_resolve_child_wait_timeout_seconds(max_run_seconds),
+                )
             if args.parallel > 1:
                 logger.info(
                     "Executing run_id=%s with %d parallel workers",
@@ -675,9 +832,15 @@ def main() -> int:
                             stage=stage_filter,
                             platform=platform_filter,
                             run_id=args.run_id,
+                            max_jobs_per_invocation=max_jobs_per_invocation,
+                            max_run_seconds=max_run_seconds,
                         )
                     )
-                return _wait_for_children(children, context_label="parallel run")
+                return _wait_for_children(
+                    children,
+                    context_label="parallel run",
+                    wait_timeout_seconds=_resolve_child_wait_timeout_seconds(max_run_seconds),
+                )
             logger.info(
                 "Executing specific run_id=%s stage=%s platform=%s",
                 args.run_id,
@@ -722,7 +885,23 @@ def main() -> int:
         last_stale_recovery_at = 0.0
         last_summary_reconcile_at = 0.0
         last_sync_orchestrator_at = 0.0
+        queue_started_at = time.monotonic()
         while True:
+            if max_jobs_per_invocation is not None and processed >= max_jobs_per_invocation:
+                logger.info(
+                    "Worker max jobs reached: processed=%d max_jobs_per_invocation=%d",
+                    processed,
+                    max_jobs_per_invocation,
+                )
+                break
+            if max_run_seconds is not None and (time.monotonic() - queue_started_at) >= max_run_seconds:
+                logger.info(
+                    "Worker max runtime reached: processed=%d max_run_seconds=%.1f elapsed=%.1f",
+                    processed,
+                    max_run_seconds,
+                    time.monotonic() - queue_started_at,
+                )
+                break
             started = datetime.now(tz=UTC)
             now_mono = time.monotonic()
             if now_mono - last_stale_recovery_at >= stale_recovery_interval:

--- a/supabase/migrations/20260421124500_instagram_comment_hosted_author_profile_pic.sql
+++ b/supabase/migrations/20260421124500_instagram_comment_hosted_author_profile_pic.sql
@@ -1,0 +1,6 @@
+begin;
+
+alter table social.instagram_comments
+  add column if not exists hosted_author_profile_pic_url text;
+
+commit;

--- a/supabase/migrations/20260421130000_scrape_jobs_active_media_mirror_uniq.sql
+++ b/supabase/migrations/20260421130000_scrape_jobs_active_media_mirror_uniq.sql
@@ -1,0 +1,11 @@
+begin;
+
+create unique index if not exists scrape_jobs_active_media_mirror_uniq
+  on social.scrape_jobs (platform, (config->>'post_id'))
+  where status in ('queued', 'pending', 'retrying', 'running')
+    and coalesce(config->>'stage', metadata->>'stage', job_type) = 'media_mirror';
+
+comment on index social.scrape_jobs_active_media_mirror_uniq is
+  'At most one active media_mirror scrape job per (platform, post_id) across runs.';
+
+commit;

--- a/supabase/migrations/20260421130500_scrape_jobs_active_comment_media_mirror_uniq.sql
+++ b/supabase/migrations/20260421130500_scrape_jobs_active_comment_media_mirror_uniq.sql
@@ -1,0 +1,23 @@
+begin;
+
+create unique index if not exists scrape_jobs_active_comment_media_mirror_uniq
+  on social.scrape_jobs (
+    platform,
+    (
+      coalesce(
+        nullif(config->>'comment_db_id', ''),
+        case
+          when coalesce(config->>'post_id', '') <> '' and coalesce(config->>'comment_id', '') <> ''
+            then concat(config->>'post_id', ':', config->>'comment_id')
+          else null
+        end
+      )
+    )
+  )
+  where status in ('queued', 'pending', 'retrying', 'running')
+    and coalesce(config->>'stage', metadata->>'stage', job_type) = 'comment_media_mirror';
+
+comment on index social.scrape_jobs_active_comment_media_mirror_uniq is
+  'At most one active comment_media_mirror scrape job per Instagram comment identity across runs.';
+
+commit;

--- a/supabase/migrations/20260421131000_instagram_comments_post_comment_unique.sql
+++ b/supabase/migrations/20260421131000_instagram_comments_post_comment_unique.sql
@@ -1,0 +1,9 @@
+begin;
+
+alter table social.instagram_comments
+  drop constraint if exists instagram_comments_comment_id_key;
+
+alter table social.instagram_comments
+  add constraint instagram_comments_post_comment_unique unique (post_id, comment_id);
+
+commit;

--- a/supabase/migrations/20260421132000_instagram_comments_nullable_text_deleted_at.sql
+++ b/supabase/migrations/20260421132000_instagram_comments_nullable_text_deleted_at.sql
@@ -1,0 +1,13 @@
+begin;
+
+alter table social.instagram_comments
+  alter column text drop not null;
+
+alter table social.instagram_comments
+  add column if not exists deleted_at timestamptz null;
+
+create index if not exists instagram_comments_deleted_at_idx
+  on social.instagram_comments (deleted_at)
+  where deleted_at is not null;
+
+commit;

--- a/supabase/migrations/20260421133000_instagram_comments_parent_same_post_trigger.sql
+++ b/supabase/migrations/20260421133000_instagram_comments_parent_same_post_trigger.sql
@@ -1,0 +1,36 @@
+begin;
+
+create or replace function social.enforce_instagram_comment_parent_same_post()
+returns trigger as $$
+declare
+  parent_post_id uuid;
+begin
+  if new.parent_comment_id is null then
+    return new;
+  end if;
+
+  select post_id into parent_post_id
+  from social.instagram_comments
+  where id = new.parent_comment_id;
+
+  if parent_post_id is null then
+    raise exception 'parent_comment_id % not found', new.parent_comment_id;
+  end if;
+
+  if parent_post_id <> new.post_id then
+    raise exception 'parent_comment post_id (%) does not match child post_id (%)', parent_post_id, new.post_id;
+  end if;
+
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists instagram_comments_parent_same_post_tg on social.instagram_comments;
+
+create trigger instagram_comments_parent_same_post_tg
+before insert or update of parent_comment_id, post_id
+on social.instagram_comments
+for each row
+execute function social.enforce_instagram_comment_parent_same_post();
+
+commit;

--- a/supabase/migrations/20260421134000_hosted_tagged_profile_pics_object_shape.sql
+++ b/supabase/migrations/20260421134000_hosted_tagged_profile_pics_object_shape.sql
@@ -1,0 +1,6 @@
+begin;
+
+comment on column social.instagram_posts.hosted_tagged_profile_pics is
+  'Supports both legacy string values and object values with hosted_url, sha256, mirrored_at.';
+
+commit;

--- a/tests/api/routers/test_socials_season_analytics.py
+++ b/tests/api/routers/test_socials_season_analytics.py
@@ -312,6 +312,35 @@ def test_get_social_account_profile_summary(client: TestClient, monkeypatch: pyt
     summary_mock.assert_called_once_with(platform="instagram", account_handle="bravotv", detail="lite")
 
 
+def test_get_social_account_profile_summary_defaults_to_lite(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+
+    with patch(
+        "trr_backend.repositories.social_season_analytics.get_social_account_profile_summary",
+        return_value={
+            "platform": "instagram",
+            "account_handle": "bravotv",
+            "total_posts": 42,
+            "per_show_counts": [],
+            "per_season_counts": [],
+            "top_hashtags": [],
+            "top_collaborators": [],
+            "top_tags": [],
+            "source_status": [],
+        },
+    ) as summary_mock:
+        response = client.get(
+            "/api/v1/admin/socials/profiles/instagram/bravotv/summary",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    summary_mock.assert_called_once_with(platform="instagram", account_handle="bravotv", detail="lite")
+
+
 def test_get_social_account_profile_summary_returns_503_on_session_pool_saturation(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -675,14 +704,18 @@ def test_post_social_account_catalog_backfill(client: TestClient, monkeypatch: p
             return_value=None,
         ) as worker_guard:
             with patch(
-                "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+                "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
                 return_value=expected,
-            ) as mocked:
-                response = client.post(
-                    "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
-                    headers={"Authorization": f"Bearer {token}"},
-                    json={"backfill_scope": "full_history"},
-                )
+            ) as mocked_begin:
+                with patch(
+                    "api.routers.socials._start_catalog_backfill_finalize_in_background",
+                    return_value=None,
+                ) as mocked_finalize:
+                    response = client.post(
+                        "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
+                        headers={"Authorization": f"Bearer {token}"},
+                        json={"backfill_scope": "full_history"},
+                    )
 
     assert response.status_code == 200
     body = response.json()
@@ -697,9 +730,10 @@ def test_post_social_account_catalog_backfill(client: TestClient, monkeypatch: p
         required_execution_backend="modal",
         platform="instagram",
     )
-    assert mocked.call_args.kwargs["platform"] == "instagram"
-    assert mocked.call_args.kwargs["account_handle"] == "bravotv"
-    assert mocked.call_args.kwargs["selected_tasks"] == ["post_details", "comments", "media"]
+    assert mocked_begin.call_args.kwargs["platform"] == "instagram"
+    assert mocked_begin.call_args.kwargs["account_handle"] == "bravotv"
+    assert mocked_begin.call_args.kwargs["selected_tasks"] == ["post_details", "comments", "media"]
+    assert mocked_finalize.call_args.kwargs["run_id"] == "catalog-run-1"
 
 
 def test_post_social_account_catalog_backfill_forwards_selected_tasks(
@@ -715,7 +749,7 @@ def test_post_social_account_catalog_backfill_forwards_selected_tasks(
             return_value=None,
         ):
             with patch(
-                "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+                "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
                 return_value={
                     "run_id": "launch-run-1",
                     "status": "queued",
@@ -725,16 +759,36 @@ def test_post_social_account_catalog_backfill_forwards_selected_tasks(
                     "post_details_skipped_reason": "already_materialized",
                     "catalog_run_id": "catalog-run-1",
                     "comments_run_id": "comments-run-1",
-                },
-            ) as mocked:
-                response = client.post(
-                    "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
-                    headers={"Authorization": f"Bearer {token}"},
-                    json={
-                        "backfill_scope": "full_history",
-                        "selected_tasks": ["comments", "media", "post_details"],
+                    "attached_followups": {
+                        "comments": {
+                            "run_id": "comments-run-1",
+                            "state": "running",
+                            "status": "running",
+                            "source": "reused_run",
+                        },
+                        "media": {
+                            "attachment_id": "media-launch-group-1",
+                            "state": "pending",
+                            "status": "queued",
+                            "source": "catalog_media_mirror",
+                            "enqueued_job_ids": ["media-job-1"],
+                            "enqueued_job_count": 1,
+                        },
                     },
-                )
+                },
+            ) as mocked_begin:
+                with patch(
+                    "api.routers.socials._start_catalog_backfill_finalize_in_background",
+                    return_value=None,
+                ):
+                    response = client.post(
+                        "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
+                        headers={"Authorization": f"Bearer {token}"},
+                        json={
+                            "backfill_scope": "full_history",
+                            "selected_tasks": ["comments", "media", "post_details"],
+                        },
+                    )
 
     assert response.status_code == 200
     body = response.json()
@@ -743,7 +797,65 @@ def test_post_social_account_catalog_backfill_forwards_selected_tasks(
     assert body["comments_run_id"] == "comments-run-1"
     assert body["effective_selected_tasks"] == ["comments", "media"]
     assert body["post_details_skipped_reason"] == "already_materialized"
-    assert mocked.call_args.kwargs["selected_tasks"] == ["post_details", "comments", "media"]
+    assert body["attached_followups"]["comments"]["source"] == "reused_run"
+    assert body["attached_followups"]["media"]["attachment_id"] == "media-launch-group-1"
+    assert mocked_begin.call_args.kwargs["selected_tasks"] == ["post_details", "comments", "media"]
+
+
+def test_start_catalog_backfill_finalize_in_background_clears_account_profile_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.routers import socials as socials_router
+
+    finalized: list[dict[str, Any]] = []
+    cleared: list[str] = []
+
+    class _ImmediateThread:
+        def __init__(self, *, target: Any, daemon: bool | None = None, name: str | None = None) -> None:
+            self._target = target
+            self.daemon = daemon
+            self.name = name
+
+        def start(self) -> None:
+            self._target()
+
+    monkeypatch.setattr(socials_router, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        "trr_backend.repositories.social_season_analytics.finalize_social_account_catalog_backfill_launch",
+        lambda **kwargs: finalized.append(kwargs) or {"run_id": kwargs["run_id"], "status": "queued"},
+    )
+    monkeypatch.setattr(socials_router, "_clear_account_profile_caches", lambda: cleared.append("cleared"))
+
+    socials_router._start_catalog_backfill_finalize_in_background(
+        platform="instagram",
+        account_handle="bravotv",
+        run_id="catalog-run-1",
+        source_scope="bravo",
+        date_start=None,
+        date_end=None,
+        initiated_by="admin@example.com",
+        allow_local_dev_inline_bypass=False,
+        execution_preference="auto",
+        selected_tasks=["post_details", "comments", "media"],
+        launch_group_id="launch-group-1",
+    )
+
+    assert finalized == [
+        {
+            "platform": "instagram",
+            "account_handle": "bravotv",
+            "run_id": "catalog-run-1",
+            "source_scope": "bravo",
+            "date_start": None,
+            "date_end": None,
+            "initiated_by": "admin@example.com",
+            "allow_local_dev_inline_bypass": False,
+            "execution_preference": "auto",
+            "selected_tasks": ["post_details", "comments", "media"],
+            "launch_group_id": "launch-group-1",
+        }
+    ]
+    assert cleared == ["cleared"]
 
 
 def test_post_social_account_catalog_backfill_rejects_empty_selected_tasks(
@@ -776,26 +888,30 @@ def test_post_social_account_catalog_backfill_ignores_date_bounds_for_full_histo
             return_value=None,
         ):
             with patch(
-                "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+                "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
                 return_value={
                     "run_id": "catalog-run-full-history",
                     "status": "queued",
                     "ingest_mode": "shared_account_catalog_backfill",
                 },
-            ) as mocked:
-                response = client.post(
-                    "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
-                    headers={"Authorization": f"Bearer {token}"},
-                    json={
-                        "backfill_scope": "full_history",
-                        "date_start": "2026-01-01T00:00:00Z",
-                        "date_end": "2026-01-08T00:00:00Z",
-                    },
-                )
+            ) as mocked_begin:
+                with patch(
+                    "api.routers.socials._start_catalog_backfill_finalize_in_background",
+                    return_value=None,
+                ):
+                    response = client.post(
+                        "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
+                        headers={"Authorization": f"Bearer {token}"},
+                        json={
+                            "backfill_scope": "full_history",
+                            "date_start": "2026-01-01T00:00:00Z",
+                            "date_end": "2026-01-08T00:00:00Z",
+                        },
+                    )
 
     assert response.status_code == 200
-    assert mocked.call_args.kwargs["date_start"] is None
-    assert mocked.call_args.kwargs["date_end"] is None
+    assert mocked_begin.call_args.kwargs["date_start"] is None
+    assert mocked_begin.call_args.kwargs["date_end"] is None
 
 
 def test_post_social_account_catalog_backfill_forwards_bounded_window_dates(
@@ -811,26 +927,30 @@ def test_post_social_account_catalog_backfill_forwards_bounded_window_dates(
             return_value=None,
         ):
             with patch(
-                "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+                "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
                 return_value={
                     "run_id": "catalog-run-windowed",
                     "status": "queued",
                     "ingest_mode": "shared_account_catalog_backfill",
                 },
-            ) as mocked:
-                response = client.post(
-                    "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
-                    headers={"Authorization": f"Bearer {token}"},
-                    json={
-                        "backfill_scope": "bounded_window",
-                        "date_start": "2026-01-01T00:00:00Z",
-                        "date_end": "2026-01-08T00:00:00Z",
-                    },
-                )
+            ) as mocked_begin:
+                with patch(
+                    "api.routers.socials._start_catalog_backfill_finalize_in_background",
+                    return_value=None,
+                ):
+                    response = client.post(
+                        "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
+                        headers={"Authorization": f"Bearer {token}"},
+                        json={
+                            "backfill_scope": "bounded_window",
+                            "date_start": "2026-01-01T00:00:00Z",
+                            "date_end": "2026-01-08T00:00:00Z",
+                        },
+                    )
 
     assert response.status_code == 200
-    assert mocked.call_args.kwargs["date_start"] == datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
-    assert mocked.call_args.kwargs["date_end"] == datetime(2026, 1, 8, 23, 59, 59, tzinfo=UTC)
+    assert mocked_begin.call_args.kwargs["date_start"] == datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    assert mocked_begin.call_args.kwargs["date_end"] == datetime(2026, 1, 8, 23, 59, 59, tzinfo=UTC)
 
 
 def test_get_social_account_catalog_post_detail_route(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1105,13 +1225,17 @@ def test_post_social_account_catalog_backfill_prefers_modal_when_available_even_
             return_value=None,
         ) as worker_guard,
         patch(
-            "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+            "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
             return_value={
                 "run_id": "catalog-run-modal-1",
                 "status": "queued",
                 "ingest_mode": "shared_account_catalog_backfill",
             },
         ) as mocked_start,
+        patch(
+            "api.routers.socials._start_catalog_backfill_finalize_in_background",
+            return_value=None,
+        ) as mocked_finalize,
     ):
         response = client.post(
             "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
@@ -1131,8 +1255,8 @@ def test_post_social_account_catalog_backfill_prefers_modal_when_available_even_
     assert body["requires_modal_executor"] is True
     worker_guard.assert_called_once()
     mocked_background.assert_not_called()
-    assert mocked_start.call_args.kwargs["inline_worker_id"] is None
     assert mocked_start.call_args.kwargs["allow_local_dev_inline_bypass"] is False
+    mocked_finalize.assert_called_once()
 
 
 def test_post_social_account_catalog_backfill_prefer_local_inline_forces_inline_when_available(
@@ -1194,7 +1318,9 @@ def test_post_social_account_catalog_backfill_prefer_local_inline_returns_valida
             "trr_backend.repositories.social_season_analytics.assert_worker_available_when_queue_enabled",
             return_value=None,
         ) as worker_guard,
-        patch("trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill") as mocked_start,
+        patch(
+            "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill"
+        ) as mocked_start,
     ):
         response = client.post(
             "/api/v1/admin/socials/profiles/tiktok/bravotv/catalog/backfill",
@@ -1336,7 +1462,9 @@ def test_post_social_account_catalog_backfill_returns_modal_dispatch_unavailable
                 "modal_environment": "main",
             },
         ),
-        patch("trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill") as mocked_start,
+        patch(
+            "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill"
+        ) as mocked_start,
     ):
         response = client.post(
             "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
@@ -1370,7 +1498,7 @@ def test_post_social_account_catalog_backfill_returns_conflict_for_active_profil
             return_value=None,
         ),
         patch(
-            "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+            "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
             side_effect=SocialIngestConflictError(
                 "SOCIAL_ACCOUNT_CATALOG_RUN_ALREADY_ACTIVE",
                 "Catalog run run-active-1 is already running for @bravotv.",
@@ -1387,6 +1515,52 @@ def test_post_social_account_catalog_backfill_returns_conflict_for_active_profil
     assert response.status_code == 409
     assert response.json()["detail"]["code"] == "SOCIAL_ACCOUNT_CATALOG_RUN_ALREADY_ACTIVE"
     assert response.json()["detail"]["run_id"] == "run-active-1"
+
+
+def test_post_social_account_catalog_backfill_conflict_serializes_datetime_detail(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from datetime import UTC, datetime
+
+    from trr_backend.repositories.social_season_analytics import SocialIngestConflictError
+
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+
+    with (
+        patch("trr_backend.repositories.social_season_analytics.is_queue_enabled", return_value=True),
+        patch(
+            "trr_backend.repositories.social_season_analytics.assert_worker_available_when_queue_enabled",
+            return_value=None,
+        ),
+        patch(
+            "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
+            side_effect=SocialIngestConflictError(
+                "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE",
+                "Comments scrape run comments-run-1 is already active for @bravotv.",
+                detail={
+                    "run_id": "comments-run-1",
+                    "job_id": "job-1",
+                    "status": "queued",
+                    "created_at": datetime(2026, 4, 21, 19, 1, 49, tzinfo=UTC),
+                    "started_at": None,
+                    "completed_at": None,
+                },
+            ),
+        ),
+    ):
+        response = client.post(
+            "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"backfill_scope": "full_history"},
+        )
+
+    assert response.status_code == 409
+    body = response.json()
+    assert body["detail"]["code"] == "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE"
+    assert body["detail"]["run_id"] == "comments-run-1"
+    assert body["detail"]["created_at"] == "2026-04-21T19:01:49+00:00"
 
 
 def test_post_social_account_catalog_sync_recent(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1904,23 +2078,16 @@ def test_post_social_account_catalog_run_cancel(client: TestClient, monkeypatch:
     run_id = str(uuid4())
     expected = {
         "run_id": run_id,
-        "status": "cancelled",
-        "summary": {"total_jobs": 5, "failed_jobs": 1},
+        "status": "cancelling",
+        "accepted": True,
     }
 
     with (
         patch(
-            "trr_backend.repositories.social_season_analytics.cancel_social_account_catalog_run",
+            "trr_backend.repositories.social_season_analytics.request_cancel_social_account_catalog_run",
             return_value=expected,
         ) as mocked,
-        # The cancel route schedules `reconcile_cancelled_shared_run` as a background
-        # task. FastAPI's TestClient runs background tasks synchronously after the
-        # response, and the real implementation tries to open a live DB pool — which
-        # blows up in CI with no DATABASE_URL configured. Stub it to a no-op.
-        patch(
-            "trr_backend.repositories.social_season_analytics.reconcile_cancelled_shared_run",
-            return_value=None,
-        ),
+        patch("api.routers.socials._cancel_catalog_run_in_background", return_value=None) as background_mock,
     ):
         response = client.post(
             f"/api/v1/admin/socials/profiles/instagram/bravotv/catalog/runs/{run_id}/cancel",
@@ -1928,10 +2095,11 @@ def test_post_social_account_catalog_run_cancel(client: TestClient, monkeypatch:
         )
 
     assert response.status_code == 200
-    assert response.json()["status"] == "cancelled"
+    assert response.json()["status"] == "cancelling"
     assert mocked.call_args.kwargs["platform"] == "instagram"
     assert mocked.call_args.kwargs["account_handle"] == "bravotv"
     assert mocked.call_args.kwargs["run_id"] == run_id
+    background_mock.assert_called_once()
 
 
 def test_post_social_account_catalog_run_dismiss(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/db/test_pg_pool.py
+++ b/tests/db/test_pg_pool.py
@@ -440,6 +440,38 @@ def test_resolve_pool_sizing_clamps_local_session_pooler_overrides(monkeypatch: 
     assert sizing["maxconn_source"] == "clamped:session_pooler_default"
 
 
+def test_resolve_pool_sizing_clamps_modal_session_pooler_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("APP_ENV", raising=False)
+    monkeypatch.setenv("MODAL_TASK_ID", "ta-123")
+    monkeypatch.setenv("TRR_DB_POOL_MINCONN", "4")
+    monkeypatch.setenv("TRR_DB_POOL_MAXCONN", "16")
+
+    sizing = pg._resolve_pool_sizing("postgresql://postgres.ref:pw@aws-1-us-east-1.pooler.supabase.com:5432/postgres")
+
+    assert sizing["requested_minconn"] == 4
+    assert sizing["requested_maxconn"] == 16
+    assert sizing["minconn"] == 1
+    assert sizing["maxconn"] == 4
+    assert sizing["modal_session_pooler_override_clamped"] is True
+    assert sizing["minconn_source"] == "clamped:modal_session_pooler_default"
+    assert sizing["maxconn_source"] == "clamped:modal_session_pooler_default"
+
+
+def test_resolve_pool_sizing_keeps_local_clamp_outside_modal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APP_ENV", "development")
+    monkeypatch.delenv("MODAL_TASK_ID", raising=False)
+    monkeypatch.delenv("MODAL_ENVIRONMENT", raising=False)
+    monkeypatch.setenv("TRR_DB_POOL_MINCONN", "4")
+    monkeypatch.setenv("TRR_DB_POOL_MAXCONN", "16")
+
+    sizing = pg._resolve_pool_sizing("postgresql://postgres.ref:pw@aws-1-us-east-1.pooler.supabase.com:5432/postgres")
+
+    assert sizing["minconn"] == 4
+    assert sizing["maxconn"] == 16
+    assert sizing["modal_session_pooler_override_clamped"] is False
+    assert sizing["session_pooler_override_clamped"] is False
+
+
 def test_fetch_one_retries_once_on_ssl_connection_closed_fault(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {"fetch": 0, "reset": 0}
 
@@ -661,8 +693,8 @@ def test_build_pool_for_session_mode_supavisor_uses_conservative_defaults(monkey
 
     pg._build_pool_for_url("postgresql://postgres.ref:pw@aws-1-us-east-1.pooler.supabase.com:5432/postgres")
 
-    assert captured["minconn"] == 1
-    assert captured["maxconn"] == 2
+    assert captured["minconn"] == 4
+    assert captured["maxconn"] == 16
     options = captured["options"]
     assert "-c idle_in_transaction_session_timeout=60000" in options
     assert "-c statement_timeout=30000" in options

--- a/tests/repositories/test_enqueue_platform_comment_media_mirror_job_dedupes.py
+++ b/tests/repositories/test_enqueue_platform_comment_media_mirror_job_dedupes.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from datetime import date
+
+from trr_backend.repositories import social_season_analytics as social_repo
+
+
+@contextmanager
+def _fake_db_cursor(conn=None):  # noqa: ANN001
+    yield object()
+
+
+def test_enqueue_platform_comment_media_mirror_job_is_global_across_runs_for_same_comment(monkeypatch) -> None:
+    created_ids: list[str | None] = []
+    state = {"job_id": None}
+    lock = threading.Lock()
+    seen_insert_sql: list[str] = []
+
+    def _fake_fetch_one_with_cursor(_cur, sql, params):  # noqa: ANN001
+        normalized_sql = " ".join(str(sql).lower().split())
+        if "insert into social.scrape_jobs" in normalized_sql:
+            seen_insert_sql.append(normalized_sql)
+            with lock:
+                if state["job_id"] is None:
+                    state["job_id"] = "job-1"
+                    return {"id": "job-1"}
+            return None
+        if "from social.scrape_jobs" in normalized_sql:
+            return {"id": state["job_id"]}
+        raise AssertionError(sql)
+
+    monkeypatch.setattr(social_repo.pg, "db_cursor", _fake_db_cursor)
+    monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", _fake_fetch_one_with_cursor)
+    monkeypatch.setattr(social_repo, "_column_exists", lambda _schema, _table, column: column == "media_urls")
+    monkeypatch.setattr(social_repo, "_platform_comment_media_needs_mirror", lambda _platform, _row: True)
+    monkeypatch.setattr(social_repo, "_update_platform_comment_media_mirror_fields", lambda **_kwargs: None)
+    monkeypatch.setattr(social_repo, "_increment_run_counters_on_job_create", lambda **_kwargs: None)
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+
+    context = social_repo.SeasonContext(  # noqa: SLF001
+        season_id="season-1",
+        show_id="show-1",
+        show_name="Test Show",
+        season_number=6,
+        anchor_date=date(2025, 1, 1),
+    )
+    comment_row = {
+        "id": "",
+        "comment_id": "comment-1",
+        "post_id": "post-1",
+        "media_urls": ["https://cdn.example.com/comment.jpg"],
+    }
+
+    def _go(run_id: str) -> None:
+        created_ids.append(
+            social_repo._enqueue_platform_comment_media_mirror_job(  # noqa: SLF001
+                context,
+                platform="instagram",
+                run_id=run_id,
+                source_scope="bravo",
+                account="bravotv",
+                comment_row=comment_row,
+                parent_job_id=None,
+            )
+        )
+
+    threads = [
+        threading.Thread(target=_go, args=("11111111-1111-1111-1111-111111111111",)),
+        threading.Thread(target=_go, args=("22222222-2222-2222-2222-222222222222",)),
+        threading.Thread(target=_go, args=("33333333-3333-3333-3333-333333333333",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len({job_id for job_id in created_ids if job_id}) == 1
+    assert any("nullif(config->>'comment_db_id', '')" in sql for sql in seen_insert_sql)
+    assert any("concat(config->>'post_id', ':', config->>'comment_id')" in sql for sql in seen_insert_sql)

--- a/tests/repositories/test_enqueue_platform_media_mirror_job_dedupes.py
+++ b/tests/repositories/test_enqueue_platform_media_mirror_job_dedupes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from datetime import date
+
+from trr_backend.repositories import social_season_analytics as social_repo
+
+
+@contextmanager
+def _fake_db_cursor(conn=None):  # noqa: ANN001
+    yield object()
+
+
+def test_enqueue_platform_media_mirror_job_is_global_across_runs_for_same_post(monkeypatch) -> None:
+    created_ids: list[str | None] = []
+    state = {"job_id": None}
+    lock = threading.Lock()
+
+    def _fake_fetch_one_with_cursor(_cur, sql, params):  # noqa: ANN001
+        normalized_sql = " ".join(str(sql).lower().split())
+        if "insert into social.scrape_jobs" in normalized_sql:
+            with lock:
+                if state["job_id"] is None:
+                    state["job_id"] = "job-1"
+                    return {"id": "job-1"}
+            return None
+        if "from social.scrape_jobs" in normalized_sql:
+            return {"id": state["job_id"]}
+        raise AssertionError(sql)
+
+    monkeypatch.setattr(social_repo.pg, "db_cursor", _fake_db_cursor)
+    monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", _fake_fetch_one_with_cursor)
+    monkeypatch.setattr(social_repo, "_platform_post_needs_media_mirror", lambda _platform, _row: True)
+    monkeypatch.setattr(social_repo, "_update_platform_post_media_mirror_fields", lambda **_kwargs: None)
+    monkeypatch.setattr(social_repo, "_increment_run_counters_on_job_create", lambda **_kwargs: None)
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+
+    context = social_repo.SeasonContext(  # noqa: SLF001
+        season_id="season-1",
+        show_id="show-1",
+        show_name="Test Show",
+        season_number=6,
+        anchor_date=date(2025, 1, 1),
+    )
+    post_row = {"id": "post-1", "shortcode": "abc123"}
+
+    def _go(run_id: str) -> None:
+        created_ids.append(
+            social_repo._enqueue_platform_media_mirror_job(  # noqa: SLF001
+                context,
+                platform="instagram",
+                run_id=run_id,
+                source_scope="bravo",
+                account="bravotv",
+                post_row=post_row,
+                week_index=None,
+                parent_job_id=None,
+            )
+        )
+
+    threads = [
+        threading.Thread(target=_go, args=("11111111-1111-1111-1111-111111111111",)),
+        threading.Thread(target=_go, args=("22222222-2222-2222-2222-222222222222",)),
+        threading.Thread(target=_go, args=("33333333-3333-3333-3333-333333333333",)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len({job_id for job_id in created_ids if job_id}) == 1

--- a/tests/repositories/test_instagram_comment_identity_contract.py
+++ b/tests/repositories/test_instagram_comment_identity_contract.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from trr_backend.repositories import social_season_analytics as social_repo
+
+
+def test_upsert_instagram_comment_tree_uses_composite_conflict_cols(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _Comment:
+        comment_id = "same-comment"
+        username = "alpha"
+        user_id = "user-1"
+        text = "one"
+        likes = 0
+        is_reply = False
+        reply_count = 0
+        created_at = None
+        replies: list[object] = []
+        media_urls: list[str] = []
+
+        def to_dict(self) -> dict[str, object]:
+            return {"comment_id": self.comment_id}
+
+    def _fake_pg_upsert(table: str, payload: dict[str, object], *, conflict_col, conn=None):  # noqa: ANN001
+        captured["table"] = table
+        captured["payload"] = dict(payload)
+        captured["conflict_col"] = conflict_col
+        return {"id": "row-1", "comment_id": payload["comment_id"]}
+
+    monkeypatch.setattr(social_repo, "_pg_upsert", _fake_pg_upsert)
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda table: table == "instagram_comments")
+    monkeypatch.setattr(social_repo, "_column_exists", lambda _schema, _table, _column: False)
+
+    context = social_repo.SeasonContext(  # noqa: SLF001
+        season_id="season-1",
+        show_id="show-1",
+        show_name="Test Show",
+        season_number=6,
+        anchor_date=social_repo.date(2025, 1, 1),
+    )
+
+    written = social_repo._upsert_instagram_comment_tree(  # noqa: SLF001
+        context,
+        job_id=None,
+        run_id="run-1",
+        account="alpha",
+        post_id="post-1",
+        comment=_Comment(),
+        enable_media_followups=False,
+    )
+
+    assert written == 1
+    assert captured["table"] == "instagram_comments"
+    assert captured["conflict_col"] == ["post_id", "comment_id"]
+    assert captured["payload"]["post_id"] == "post-1"
+    assert captured["payload"]["comment_id"] == "same-comment"
+
+
+def test_platform_comment_context_row_for_media_mirror_uses_post_scoped_identity_for_instagram(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_fetch_one(sql, params):  # noqa: ANN001
+        captured["sql"] = sql
+        captured["params"] = params
+        return {"season_id": "season-1"}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+
+    social_repo._platform_comment_context_row_for_media_mirror(  # noqa: SLF001
+        "instagram",
+        comment_id="comment-1",
+        comment_db_id="",
+        post_id="33333333-3333-3333-3333-333333333333",
+    )
+
+    sql = str(captured["sql"]).lower()
+    assert "c.comment_id = %s and c.post_id = nullif(%s, '')::uuid" in sql
+    assert captured["params"] == [
+        "",
+        "",
+        "comment-1",
+        "33333333-3333-3333-3333-333333333333",
+        "comment-1",
+        "33333333-3333-3333-3333-333333333333",
+    ]
+
+
+def test_enqueue_platform_comment_media_mirror_job_uses_post_scoped_lookup_for_instagram(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def _fake_db_cursor(conn=None):  # noqa: ANN001
+        yield object()
+
+    def _fake_fetch_one_with_cursor(_cur, sql, params):  # noqa: ANN001
+        captured["sql"] = sql
+        captured["params"] = params
+        return {"id": "job-1"}
+
+    monkeypatch.setattr(social_repo.pg, "db_cursor", _fake_db_cursor)
+    monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", _fake_fetch_one_with_cursor)
+    monkeypatch.setattr(social_repo, "_column_exists", lambda _schema, _table, column: column == "media_urls")
+    monkeypatch.setattr(social_repo, "_platform_comment_media_needs_mirror", lambda _platform, _row: True)
+
+    context = social_repo.SeasonContext(  # noqa: SLF001
+        season_id="season-1",
+        show_id="show-1",
+        show_name="Test Show",
+        season_number=6,
+        anchor_date=social_repo.date(2025, 1, 1),
+    )
+
+    mirror_job_id = social_repo._enqueue_platform_comment_media_mirror_job(  # noqa: SLF001
+        context,
+        platform="instagram",
+        run_id="44444444-4444-4444-4444-444444444444",
+        source_scope="bravo",
+        account="bravotv",
+        comment_row={
+            "id": "55555555-5555-5555-5555-555555555555",
+            "comment_id": "comment-1",
+            "post_id": "66666666-6666-6666-6666-666666666666",
+            "media_urls": ["https://cdn.example.com/comment.jpg"],
+        },
+        parent_job_id=None,
+    )
+
+    assert mirror_job_id == "job-1"
+    assert "config->>'post_id' = %s" in str(captured["sql"]).lower()
+    assert captured["params"] == [
+        "instagram",
+        social_repo.COMMENT_MEDIA_MIRROR_STAGE,
+        "comment-1",
+        "66666666-6666-6666-6666-666666666666",
+        "44444444-4444-4444-4444-444444444444",
+        "44444444-4444-4444-4444-444444444444",
+    ]

--- a/tests/repositories/test_instagram_media_mirror_pagination_and_keys.py
+++ b/tests/repositories/test_instagram_media_mirror_pagination_and_keys.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from trr_backend.repositories import social_season_analytics as social_repo
+
+
+def test_build_mirror_source_key_uses_post_uuid_in_unknown_instagram_fallback() -> None:
+    first = social_repo._build_mirror_source_key(  # noqa: SLF001
+        "instagram",
+        type("P", (), {"id": "11111111-1111-1111-1111-111111111111", "shortcode": ""})(),
+        source_urls=["https://cdn.test/a.jpg"],
+    )
+    second = social_repo._build_mirror_source_key(  # noqa: SLF001
+        "instagram",
+        type("P", (), {"id": "22222222-2222-2222-2222-222222222222", "shortcode": ""})(),
+        source_urls=["https://cdn.test/a.jpg"],
+    )
+
+    assert first != second

--- a/tests/repositories/test_media_assets_mirroring.py
+++ b/tests/repositories/test_media_assets_mirroring.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from trr_backend.repositories import media_assets
+from trr_backend.repositories import social_season_analytics as social_repo
+
 
 def test_is_allowed_domain_valid() -> None:
     """Test domain allowlist validation for allowed domains."""
@@ -311,3 +314,44 @@ def test_update_asset_with_mirror_result_persists_dimensions() -> None:
     payload = call_args[0][0]
     assert payload["width"] == 1000
     assert payload["height"] == 1500
+
+
+def test_download_and_upload_redacts_signed_instagram_cdn_urls() -> None:
+    assert social_repo.redact_signed_url("https://cdn.test/file.jpg?oh=abc&oe=def") == "https://cdn.test/file.jpg"  # noqa: SLF001
+
+
+def test_is_retryable_mirror_reason_strips_nested_prefixes() -> None:
+    assert social_repo._is_retryable_mirror_reason("download_failed:ytdlp_fallback_failed:http_503") is True  # noqa: SLF001
+    assert social_repo._is_retryable_mirror_reason("invalid_source_url") is False  # noqa: SLF001
+
+
+def test_ensure_media_mirror_s3_ready_requires_write_access(monkeypatch) -> None:
+    client = MagicMock()
+    monkeypatch.setattr(
+        "trr_backend.media.s3_mirror.get_s3_config",
+        lambda: MagicMock(bucket="bucket"),
+    )
+    monkeypatch.setattr(
+        "trr_backend.media.s3_mirror.get_object_storage_client",
+        lambda: client,
+    )
+
+    social_repo.ensure_media_mirror_s3_ready()  # noqa: SLF001
+
+    client.head_bucket.assert_called_once_with(Bucket="bucket")
+    client.put_object.assert_called_once()
+    client.delete_object.assert_called_once()
+
+
+def test_update_asset_with_hosted_fields_requires_hosted_triplet() -> None:
+    db = MagicMock()
+
+    with pytest.raises(ValueError, match="hosted_bucket"):
+        media_assets.update_asset_with_hosted_fields(
+            db,
+            "asset-1",
+            hosted_bucket="",
+            hosted_key="key",
+            hosted_url="https://cdn.test/x.jpg",
+            hosted_bytes=12,
+        )

--- a/tests/repositories/test_pg_upsert_many_composite_conflict.py
+++ b/tests/repositories/test_pg_upsert_many_composite_conflict.py
@@ -18,3 +18,25 @@ def test_pg_upsert_many_accepts_composite_conflict_cols(monkeypatch) -> None:
     )
 
     assert "on conflict (post_id, comment_id)" in str(captured["sql"]).lower()
+
+
+def test_pg_upsert_many_dedupes_duplicate_composite_conflicts_before_insert(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_execute_values_returning(sql, values, conn=None):  # noqa: ANN001
+        captured["sql"] = sql
+        captured["values"] = values
+        return []
+
+    monkeypatch.setattr(social_repo.pg, "execute_values_returning", _fake_execute_values_returning)
+
+    social_repo._pg_upsert_many(  # noqa: SLF001
+        "instagram_comments",
+        [
+            {"post_id": "p1", "comment_id": "c1", "text": "first"},
+            {"post_id": "p1", "comment_id": "c1", "text": "second"},
+        ],
+        conflict_col=["post_id", "comment_id"],
+    )
+
+    assert captured["values"] == [("p1", "c1", "second")]

--- a/tests/repositories/test_pg_upsert_many_composite_conflict.py
+++ b/tests/repositories/test_pg_upsert_many_composite_conflict.py
@@ -1,0 +1,20 @@
+from trr_backend.repositories import social_season_analytics as social_repo
+
+
+def test_pg_upsert_many_accepts_composite_conflict_cols(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_execute_values_returning(sql, values, conn=None):  # noqa: ANN001
+        captured["sql"] = sql
+        captured["values"] = values
+        return []
+
+    monkeypatch.setattr(social_repo.pg, "execute_values_returning", _fake_execute_values_returning)
+
+    social_repo._pg_upsert_many(  # noqa: SLF001
+        "instagram_comments",
+        [{"post_id": "p1", "comment_id": "c1", "text": "hello"}],
+        conflict_col=["post_id", "comment_id"],
+    )
+
+    assert "on conflict (post_id, comment_id)" in str(captured["sql"]).lower()

--- a/tests/repositories/test_social_dispatch_stage_claims.py
+++ b/tests/repositories/test_social_dispatch_stage_claims.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from trr_backend.repositories import social_season_analytics as repo
+
+
+def test_stage_claim_candidates_do_not_let_comments_workers_borrow_posts() -> None:
+    assert repo._stage_claim_candidates("comments") == ("comments",)  # noqa: SLF001
+    assert repo._stage_claim_candidates("comments_scrapling") == ("comments_scrapling",)  # noqa: SLF001
+    assert repo._stage_claim_candidates("shared_account_posts") == ("shared_account_posts",)  # noqa: SLF001
+
+
+def test_effective_runtime_version_tracks_stage_specific_modal_function(monkeypatch) -> None:
+    monkeypatch.setattr(
+        repo,
+        "_resolve_authoritative_catalog_runtime_version",
+        lambda *, required_execution_backend=None: {
+            "execution_backend": required_execution_backend,
+            "label": "modal",
+            "modal_function": "run_social_job",
+        },
+    )
+
+    comments_runtime = repo._resolve_effective_runtime_version(  # noqa: SLF001
+        required_execution_backend="modal",
+        stage="comments_scrapling",
+    )
+    media_runtime = repo._resolve_effective_runtime_version(  # noqa: SLF001
+        required_execution_backend="modal",
+        stage="media_mirror",
+    )
+    posts_runtime = repo._resolve_effective_runtime_version(  # noqa: SLF001
+        required_execution_backend="modal",
+        stage="shared_account_posts",
+    )
+
+    assert comments_runtime["modal_function"] == "run_social_comments_job"
+    assert media_runtime["modal_function"] == "run_social_media_job"
+    assert posts_runtime["modal_function"] == "run_social_posts_job"

--- a/tests/repositories/test_social_mirror_repairs.py
+++ b/tests/repositories/test_social_mirror_repairs.py
@@ -35,6 +35,22 @@ def _ingest_options() -> IngestOptions:
     )
 
 
+def test_normalize_hosted_tagged_profile_pics_accepts_string_and_object_values() -> None:
+    payload = social_repo._normalize_hosted_tagged_profile_pics(  # noqa: SLF001
+        {
+            "andy": "https://cdn.test/a.jpg",
+            "cohen": {
+                "hosted_url": "https://cdn.test/c.jpg",
+                "sha256": "abc",
+                "mirrored_at": "2026-04-21T00:00:00+00:00",
+            },
+        }
+    )
+
+    assert payload["andy"]["hosted_url"] == "https://cdn.test/a.jpg"
+    assert payload["cohen"]["sha256"] == "abc"
+
+
 def test_get_post_comments_instagram_filters_missing_comments_and_includes_media_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/repositories/test_social_season_analytics.py
+++ b/tests/repositories/test_social_season_analytics.py
@@ -4,10 +4,11 @@ import inspect
 import json
 import subprocess
 import time
+from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
 from datetime import UTC, date, datetime, timedelta
 from types import SimpleNamespace
-from typing import Any, Mapping
+from typing import Any
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -433,7 +434,9 @@ def test_instagram_social_account_profile_dataset_rows_skips_collaborator_query_
     monkeypatch.setattr(
         social_repo,
         "_fetch_instagram_collaborator_catalog_rows",
-        lambda *_args, **_kwargs: pytest.fail("collaborator catalog rows should not load once owner-backed rows fill the limit"),
+        lambda *_args, **_kwargs: pytest.fail(
+            "collaborator catalog rows should not load once owner-backed rows fill the limit"
+        ),
     )
     monkeypatch.setattr(
         social_repo,
@@ -4899,6 +4902,69 @@ def test_start_social_account_comments_scrape_reuses_lock_connection_for_active_
     assert exc_info.value.detail["run_id"] == "comments-run-active-1"
 
 
+def test_start_social_account_comments_scrape_uses_modal_execution_backend_without_dedicated_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_runs: list[dict[str, Any]] = []
+    created_jobs: list[dict[str, Any]] = []
+    dispatch_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None, **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one_with_cursor",
+        lambda *_args, **kwargs: {"locked": True}
+        if "pg_try_advisory_lock" in (kwargs.get("query") or (_args[1] if len(_args) > 1 else ""))
+        else {"unlocked": True},
+    )
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: [{}])
+    monkeypatch.setattr(social_repo, "get_active_social_account_comments_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+    monkeypatch.setattr(social_repo, "is_modal_remote_executor_enabled", lambda: True)
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_social_account_comment_target_shortcodes",
+        lambda *_args, **_kwargs: ["C123"],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_run",
+        lambda *_args, **kwargs: created_runs.append(dict(kwargs.get("config") or {})) or "comments-run-1",
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs.get("config") or {})) or "comments-job-1",
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "dispatch_due_social_jobs",
+        lambda **kwargs: dispatch_calls.append(dict(kwargs)) or {"dispatched_job_ids": []},
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "assert_worker_available_when_queue_enabled",
+        lambda **_kwargs: None,
+    )
+
+    payload = social_repo.start_social_account_comments_scrape(
+        "instagram",
+        "bravotv",
+        mode="profile",
+        refresh_policy="all_saved_posts",
+    )
+
+    assert payload["run_id"] == "comments-run-1"
+    assert payload["required_worker_lane"] is None
+    assert payload["required_execution_backend"] == "modal"
+    assert created_runs[0]["required_worker_lane"] is None
+    assert created_runs[0]["required_execution_backend"] == "modal"
+    assert created_jobs[0]["required_worker_lane"] is None
+    assert created_jobs[0]["required_execution_backend"] == "modal"
+    assert dispatch_calls == [{"run_id": "comments-run-1"}]
+
+
 def test_ingest_shared_accounts_instagram_details_refresh_only_creates_direct_posts_job(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5090,7 +5156,9 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
     )
 
     assert payload["launch_group_id"] == "launch-group-1"
-    assert payload["selected_tasks"] == social_repo._normalize_social_account_catalog_backfill_selected_tasks(selected_tasks)
+    assert payload["selected_tasks"] == social_repo._normalize_social_account_catalog_backfill_selected_tasks(
+        selected_tasks
+    )
     assert payload["effective_selected_tasks"] == effective_selected_tasks
     assert payload["catalog_bootstrap_required"] is False
     assert payload["comments_deferred_until_catalog_complete"] is False
@@ -5114,12 +5182,29 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
         assert comments_calls[0]["launch_group_id"] == "launch-group-1"
         if expect_catalog:
             assert merged_config_updates[-1]["comments_run_id"] == "comments-run-1"
+            assert merged_config_updates[-1]["attached_followups"]["comments"] == {
+                "run_id": "comments-run-1",
+                "state": "pending",
+                "status": "queued",
+                "source": "new_run",
+            }
     else:
         assert payload["comments_run_id"] is None
         assert comments_calls == []
     if expect_catalog:
         assert merged_config_updates[-1]["selected_tasks"] == payload["selected_tasks"]
         assert merged_config_updates[-1]["effective_selected_tasks"] == effective_selected_tasks
+        if "media" in effective_selected_tasks:
+            expected_media_source = "comments_media_followups" if expect_comments else "catalog_media_mirror"
+            assert payload["attached_followups"]["media"] == {
+                "attachment_id": "media-launch-group-1",
+                "state": "pending",
+                "status": "queued",
+                "source": expected_media_source,
+                "enqueued_job_ids": [],
+                "enqueued_job_count": 0,
+            }
+            assert merged_config_updates[-1]["attached_followups"]["media"] == payload["attached_followups"]["media"]
     else:
         assert merged_config_updates == []
 
@@ -5168,6 +5253,20 @@ def test_launch_social_account_catalog_backfill_instagram_defaults_selected_task
     assert payload["catalog_run_id"] == "catalog-run-default"
     assert payload["comments_run_id"] == "comments-run-default"
     assert payload["comments_deferred_until_catalog_complete"] is False
+    assert payload["attached_followups"]["comments"] == {
+        "run_id": "comments-run-default",
+        "state": "pending",
+        "status": "queued",
+        "source": "new_run",
+    }
+    assert payload["attached_followups"]["media"] == {
+        "attachment_id": "media-launch-group-default",
+        "state": "pending",
+        "status": "queued",
+        "source": "comments_media_followups",
+        "enqueued_job_ids": [],
+        "enqueued_job_count": 0,
+    }
     assert len(catalog_calls) == 1
     assert catalog_calls[0]["details_refresh_skip_detail_fetch"] is True
     assert catalog_calls[0]["details_refresh_skip_media_followups"] is False
@@ -5175,6 +5274,161 @@ def test_launch_social_account_catalog_backfill_instagram_defaults_selected_task
     assert merged_config_updates[-1]["selected_tasks"] == ["post_details", "comments", "media"]
     assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
     assert merged_config_updates[-1]["comments_run_id"] == "comments-run-default"
+    assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
+
+
+def test_begin_social_account_catalog_backfill_launch_returns_pending_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "launch-group-1")
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        social_repo,
+        "_reserve_social_account_catalog_launch",
+        lambda **_kwargs: {
+            "run_id": "catalog-run-pending-1",
+            "lock_wait_ms": 2.5,
+            "lock_held_ms": 7.5,
+        },
+    )
+
+    payload = social_repo.begin_social_account_catalog_backfill_launch(
+        "instagram",
+        "bravotv",
+        source_scope="bravo",
+        selected_tasks=["comments", "media", "post_details"],
+    )
+
+    assert payload["run_id"] == "catalog-run-pending-1"
+    assert payload["catalog_run_id"] == "catalog-run-pending-1"
+    assert payload["launch_group_id"] == "launch-group-1"
+    assert payload["status"] == "queued"
+    assert payload["launch_state"] == "pending"
+    assert payload["launch_task_resolution_pending"] is True
+    assert payload["selected_tasks"] == ["post_details", "comments", "media"]
+    assert payload["effective_selected_tasks"] == ["post_details", "comments", "media"]
+
+
+def test_finalize_social_account_catalog_backfill_launch_reuses_existing_run_and_launch_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _launch(platform: str, account_handle: str, **kwargs: Any) -> dict[str, Any]:
+        captured["platform"] = platform
+        captured["account_handle"] = account_handle
+        captured["kwargs"] = kwargs
+        return {"run_id": kwargs["existing_catalog_run_id"], "comments_run_id": "comments-run-1"}
+
+    monkeypatch.setattr(social_repo, "launch_social_account_catalog_backfill", _launch)
+
+    result = social_repo.finalize_social_account_catalog_backfill_launch(
+        "instagram",
+        "bravotv",
+        run_id="catalog-run-1",
+        launch_group_id="launch-group-1",
+        selected_tasks=["post_details", "comments", "media"],
+    )
+
+    assert result["run_id"] == "catalog-run-1"
+    assert captured["platform"] == "instagram"
+    assert captured["account_handle"] == "bravotv"
+    assert captured["kwargs"]["existing_catalog_run_id"] == "catalog-run-1"
+    assert captured["kwargs"]["launch_group_id_override"] == "launch-group-1"
+    assert captured["kwargs"]["selected_tasks"] == ["post_details", "comments", "media"]
+
+
+def test_start_social_account_catalog_backfill_uses_existing_run_id_after_reservation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ingest_calls: list[dict[str, Any]] = []
+    merged_config_updates: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+    monkeypatch.setattr(
+        social_repo,
+        "assert_worker_available_when_queue_enabled",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_latest_account_frontier",
+        lambda *_args, **_kwargs: {"exhausted": True, "next_cursor": None},
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "ingest_shared_accounts",
+        lambda **kwargs: ingest_calls.append(kwargs) or {"run_id": kwargs["existing_run_id"], "status": "queued"},
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_merge_catalog_run_config",
+        lambda *, run_id, metadata_updates: (
+            merged_config_updates.append({"run_id": run_id, **metadata_updates})
+            or {"id": run_id, "status": "queued", "config": metadata_updates}
+        ),
+    )
+
+    payload = social_repo.start_social_account_catalog_backfill(
+        "instagram",
+        "bravotv",
+        source_scope="bravo",
+        existing_run_id="catalog-run-existing-1",
+    )
+
+    assert payload["run_id"] == "catalog-run-existing-1"
+    assert len(ingest_calls) == 1
+    assert ingest_calls[0]["existing_run_id"] == "catalog-run-existing-1"
+    assert merged_config_updates[-1]["run_id"] == "catalog-run-existing-1"
+    assert merged_config_updates[-1]["launch_state"] == "ready"
+
+
+def test_start_social_account_catalog_backfill_reserves_run_before_heavy_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call_order: list[str] = []
+
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        social_repo,
+        "_reserve_social_account_catalog_launch",
+        lambda **_kwargs: call_order.append("reserve")
+        or {"run_id": "catalog-run-reserved-1", "lock_wait_ms": 1.0, "lock_held_ms": 3.0},
+    )
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+    monkeypatch.setattr(
+        social_repo,
+        "assert_worker_available_when_queue_enabled",
+        lambda **_kwargs: call_order.append("worker_guard"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_latest_account_frontier",
+        lambda *_args, **_kwargs: call_order.append("frontier") or {"exhausted": True, "next_cursor": None},
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "ingest_shared_accounts",
+        lambda **kwargs: call_order.append("ingest") or {"run_id": kwargs["existing_run_id"], "status": "queued"},
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_merge_catalog_run_config",
+        lambda *, run_id, metadata_updates: {"id": run_id, "status": "queued", "config": metadata_updates},
+    )
+
+    payload = social_repo.start_social_account_catalog_backfill(
+        "instagram",
+        "bravotv",
+        source_scope="bravo",
+        date_start=datetime(2026, 1, 1, tzinfo=UTC),
+        date_end=datetime(2026, 1, 8, tzinfo=UTC),
+    )
+
+    assert payload["run_id"] == "catalog-run-reserved-1"
+    assert call_order == ["reserve", "worker_guard", "ingest"]
 
 
 def test_launch_social_account_catalog_backfill_instagram_bootstraps_when_catalog_rows_exceed_materialized_posts(
@@ -5233,6 +5487,22 @@ def test_launch_social_account_catalog_backfill_instagram_bootstraps_when_catalo
     assert catalog_calls[0]["social_account_post_details_only"] is False
     assert comments_calls == []
     assert merged_updates[-1]["deferred_comments_followup"]["state"] == "pending"
+    assert merged_updates[-1]["attached_followups"] == {
+        "comments": {
+            "run_id": None,
+            "state": "pending",
+            "status": "pending",
+            "source": "deferred_after_catalog",
+        },
+        "media": {
+            "attachment_id": "media-launch-group-coverage",
+            "state": "pending",
+            "status": "queued",
+            "source": "catalog_media_mirror",
+            "enqueued_job_ids": [],
+            "enqueued_job_count": 0,
+        },
+    }
 
 
 def test_launch_social_account_catalog_backfill_instagram_skips_detail_hydration_when_materialized_coverage_is_complete(
@@ -5288,6 +5558,99 @@ def test_launch_social_account_catalog_backfill_instagram_skips_detail_hydration
     assert merged_config_updates[-1]["selected_tasks"] == ["post_details", "comments", "media"]
     assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
     assert merged_config_updates[-1]["comments_run_id"] == "comments-run-1"
+    assert merged_config_updates[-1]["attached_followups"] == {
+        "comments": {
+            "run_id": "comments-run-1",
+            "state": "pending",
+            "status": "queued",
+            "source": "new_run",
+        },
+        "media": {
+            "attachment_id": "media-launch-group-ready",
+            "state": "pending",
+            "status": "queued",
+            "source": "comments_media_followups",
+            "enqueued_job_ids": [],
+            "enqueued_job_count": 0,
+        },
+    }
+
+
+def test_launch_social_account_catalog_backfill_reuses_active_comments_run_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog_calls: list[dict[str, Any]] = []
+    merged_config_updates: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "launch-group-existing-comments")
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(
+        social_repo,
+        "start_social_account_catalog_backfill",
+        lambda platform, account_handle, **kwargs: (
+            catalog_calls.append({"platform": platform, "account_handle": account_handle, **kwargs})
+            or {"run_id": "catalog-run-1", "status": "queued"}
+        ),
+    )
+
+    def _raise_active_comments(*_args: Any, **_kwargs: Any) -> Any:
+        raise social_repo.SocialIngestConflictError(
+            "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE",
+            "Comments scrape run comments-run-existing is already active for @bravotv.",
+            detail={"run_id": "comments-run-existing", "status": "running"},
+        )
+
+    monkeypatch.setattr(social_repo, "start_social_account_comments_scrape", _raise_active_comments)
+    monkeypatch.setattr(
+        social_repo,
+        "_enqueue_instagram_account_media_repair_jobs",
+        lambda **_kwargs: {
+            "enqueued_job_ids": ["media-job-1", "media-job-2"],
+            "enqueued_job_count": 2,
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_merge_catalog_run_config",
+        lambda *, run_id, metadata_updates: (
+            merged_config_updates.append({"run_id": run_id, **metadata_updates})
+            or {"id": run_id, "status": "queued", "config": metadata_updates}
+        ),
+    )
+
+    payload = social_repo.launch_social_account_catalog_backfill(
+        "instagram",
+        "bravotv",
+        source_scope="bravo",
+        selected_tasks=["post_details", "comments", "media"],
+    )
+
+    assert payload["catalog_run_id"] == "catalog-run-1"
+    assert payload["comments_run_id"] == "comments-run-existing"
+    assert payload["comments_status"] == "running"
+    assert payload["comments_deferred_until_catalog_complete"] is False
+    assert payload["attached_followups"] == {
+        "comments": {
+            "run_id": "comments-run-existing",
+            "state": "running",
+            "status": "running",
+            "source": "reused_run",
+        },
+        "media": {
+            "attachment_id": "media-launch-group-existing-comments",
+            "state": "pending",
+            "status": "queued",
+            "source": "catalog_media_mirror",
+            "enqueued_job_ids": ["media-job-1", "media-job-2"],
+            "enqueued_job_count": 2,
+        },
+    }
+    assert len(catalog_calls) == 1
+    assert merged_config_updates[-1]["comments_run_id"] == "comments-run-existing"
+    assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
+    assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
 
 
 def test_find_instagram_post_for_comments_reuses_passed_connection(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -5369,7 +5732,8 @@ def test_materialize_instagram_post_for_comments_uses_catalog_row_and_conn(monke
     monkeypatch.setattr(
         comments_persistence,
         "find_instagram_post_for_comments",
-        lambda **kwargs: find_calls.append(kwargs) or (None if len(find_calls) == 1 else {"id": "post-1", "season_id": "season-1"}),
+        lambda **kwargs: find_calls.append(kwargs)
+        or (None if len(find_calls) == 1 else {"id": "post-1", "season_id": "season-1"}),
     )
     monkeypatch.setattr(
         social_repo,
@@ -5379,7 +5743,8 @@ def test_materialize_instagram_post_for_comments_uses_catalog_row_and_conn(monke
     monkeypatch.setattr(
         social_repo,
         "get_season_context",
-        lambda season_id, **kwargs: context_calls.append({"season_id": season_id, "kwargs": kwargs}) or SimpleNamespace(
+        lambda season_id, **kwargs: context_calls.append({"season_id": season_id, "kwargs": kwargs})
+        or SimpleNamespace(
             season_id=season_id,
             show_id="show-1",
         ),
@@ -6904,7 +7269,9 @@ def test_assert_social_account_profile_exists_accepts_instagram_collaborator_cat
     monkeypatch.setattr(
         social_repo,
         "_social_account_profile_total_posts",
-        lambda *_args, **_kwargs: pytest.fail("instagram collaborator evidence should short-circuit before owner totals"),
+        lambda *_args, **_kwargs: pytest.fail(
+            "instagram collaborator evidence should short-circuit before owner totals"
+        ),
     )
 
     payload = social_repo._assert_social_account_profile_exists("instagram", "bravodailydish")
@@ -7006,12 +7373,28 @@ def test_get_social_account_profile_summary_includes_catalog_fields(monkeypatch:
     monkeypatch.setattr(
         social_repo,
         "_instagram_social_account_comments_saved_summary",
-        lambda *_args, **_kwargs: {"saved_posts": 4, "total_posts": 8},
+        lambda *_args, **_kwargs: {
+            "saved_comments": 41,
+            "retrieved_comments": 429,
+            "saved_comment_posts": 8,
+            "retrieved_comment_posts": 12,
+            "saved_comment_media_files": 7,
+        },
     )
     monkeypatch.setattr(
         social_repo,
         "_instagram_social_account_media_target_counts",
-        lambda *_args, **_kwargs: {"saved_files": 9, "total_files": 12},
+        lambda *_args, **_kwargs: {
+            "saved_files": 1289,
+            "total_files": 1400,
+            "saved_post_media_files": 1200,
+            "total_post_media_files": 1300,
+            "saved_comment_media_files": 60,
+            "total_comment_media_files": 75,
+            "saved_avatar_files": 55,
+            "saved_reel_still_files": 29,
+            "total_reel_still_files": 29,
+        },
     )
     monkeypatch.setattr(
         social_repo,
@@ -7040,7 +7423,13 @@ def test_get_social_account_profile_summary_includes_catalog_fields(monkeypatch:
     assert payload["live_catalog_total_views"] == 6789
     assert payload["live_catalog_hashtag_instances"] == 19
     assert payload["live_catalog_unique_hashtags"] == 1
-    assert payload["comments_saved_summary"] == {"saved_posts": 4, "total_posts": 8}
+    assert payload["comments_saved_summary"] == {
+        "saved_comments": 41,
+        "retrieved_comments": 429,
+        "saved_comment_posts": 8,
+        "retrieved_comment_posts": 12,
+        "saved_comment_media_files": 7,
+    }
     assert payload["comments_coverage"] == {
         "available_posts": 12,
         "eligible_posts": 8,
@@ -7049,7 +7438,136 @@ def test_get_social_account_profile_summary_includes_catalog_fields(monkeypatch:
         "last_comments_run_at": datetime(2026, 2, 3, tzinfo=UTC),
         "last_comments_run_status": "completed",
     }
-    assert payload["media_coverage"] == {"saved_files": 9, "total_files": 12}
+    assert payload["media_coverage"] == {
+        "saved_files": 1289,
+        "total_files": 1400,
+        "saved_post_media_files": 1200,
+        "total_post_media_files": 1300,
+        "saved_comment_media_files": 60,
+        "total_comment_media_files": 75,
+        "saved_avatar_files": 55,
+        "saved_reel_still_files": 29,
+        "total_reel_still_files": 29,
+    }
+
+
+def test_instagram_social_account_comments_saved_summary_clamps_retrieved_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: {
+            "saved_comments": 12,
+            "saved_comment_posts": 4,
+            "saved_comment_media_files": 3,
+            "retrieved_comments": 8,
+            "retrieved_comment_posts": 2,
+        },
+    )
+
+    payload = social_repo._instagram_social_account_comments_saved_summary("thetraitorsus")
+
+    assert payload == {
+        "saved_comments": 12,
+        "retrieved_comments": 12,
+        "saved_comment_posts": 4,
+        "retrieved_comment_posts": 4,
+        "saved_comment_media_files": 3,
+    }
+
+
+def test_instagram_social_account_media_target_counts_counts_comment_media_and_reel_stills(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda table: table == "instagram_comments")
+
+    def _fake_fetch_all(sql: str, _params: list[object]) -> list[dict[str, object]]:
+        if "from social.instagram_posts p" in sql:
+            return [
+                {
+                    "post_format": "carousel",
+                    "thumbnail_url": "https://img.example.com/carousel-cover.jpg",
+                    "media_urls": [
+                        "https://img.example.com/carousel-1.jpg",
+                        "https://img.example.com/carousel-2.jpg",
+                    ],
+                    "hosted_thumbnail_url": "https://cdn.example.com/carousel-cover.jpg",
+                    "hosted_media_urls": [
+                        "https://cdn.example.com/carousel-1.jpg",
+                        "https://cdn.example.com/carousel-2.jpg",
+                    ],
+                    "hosted_owner_profile_pic_url": "https://cdn.example.com/owner.jpg",
+                    "hosted_tagged_profile_pics": {
+                        "friend": "https://cdn.example.com/friend.jpg",
+                    },
+                },
+                {
+                    "post_format": "reel",
+                    "thumbnail_url": "https://img.example.com/reel-cover.jpg",
+                    "media_urls": ["https://video.example.com/reel.mp4"],
+                    "hosted_thumbnail_url": "https://cdn.example.com/reel-cover.jpg",
+                    "hosted_media_urls": ["https://cdn.example.com/reel.mp4"],
+                    "hosted_owner_profile_pic_url": "",
+                    "hosted_tagged_profile_pics": {},
+                },
+            ]
+        if "from social.instagram_comments c" in sql:
+            return [
+                {
+                    "media_urls": ["https://img.example.com/comment-gif.gif"],
+                    "hosted_media_urls": ["https://cdn.example.com/comment-gif.gif"],
+                    "hosted_author_profile_pic_url": "https://cdn.example.com/commenter.jpg",
+                }
+            ]
+        raise AssertionError(f"Unexpected query: {sql}")
+
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+
+    payload = social_repo._instagram_social_account_media_target_counts("thetraitorsus")
+
+    assert payload == {
+        "saved_files": 5,
+        "total_files": 5,
+        "saved_post_media_files": 3,
+        "total_post_media_files": 3,
+        "saved_comment_media_files": 1,
+        "total_comment_media_files": 1,
+        "saved_avatar_files": 3,
+        "saved_reel_still_files": 1,
+        "total_reel_still_files": 1,
+    }
+
+
+def test_update_instagram_comment_hosted_author_profile_pics_updates_normalized_usernames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executed: list[tuple[str, list[object]]] = []
+
+    class _Cursor:
+        def execute(self, sql: str, params: list[object]) -> None:
+            executed.append((sql, params))
+
+    @contextmanager
+    def _fake_cursor(*_args: object, **_kwargs: object):
+        yield _Cursor()
+
+    monkeypatch.setattr(social_repo, "_column_exists", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(social_repo.pg, "db_cursor", _fake_cursor)
+
+    social_repo._update_instagram_comment_hosted_author_profile_pics(
+        post_id="3d0d9f36-0fbe-4c4e-9690-5d0e3c56f8d9",
+        hosted_author_profile_pics={
+            "@NatalieeAnd": "https://cdn.example.com/natalie.jpg",
+            "reply_author": "https://cdn.example.com/reply.jpg",
+            "": "https://cdn.example.com/ignored.jpg",
+        },
+    )
+
+    assert [params for _sql, params in executed] == [
+        ["https://cdn.example.com/natalie.jpg", "3d0d9f36-0fbe-4c4e-9690-5d0e3c56f8d9", "natalieeand"],
+        ["https://cdn.example.com/reply.jpg", "3d0d9f36-0fbe-4c4e-9690-5d0e3c56f8d9", "reply_author"],
+    ]
 
 
 def test_get_social_account_profile_summary_uses_instagram_live_total_posts_with_source_snapshot(
@@ -7424,16 +7942,6 @@ def test_get_social_account_profile_summary_lite_skips_heavy_detail_branches(
     monkeypatch.setattr(social_repo, "_catalog_recent_runs", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(social_repo, "_social_account_profile_optional_identity_fields", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(social_repo, "_avatar_registry_lookup_any", lambda **_kwargs: {})
-    monkeypatch.setattr(
-        social_repo,
-        "_instagram_social_account_comments_saved_summary",
-        lambda *_args, **_kwargs: {"saved_posts": 1, "total_posts": 2},
-    )
-    monkeypatch.setattr(
-        social_repo,
-        "_instagram_social_account_media_target_counts",
-        lambda *_args, **_kwargs: {"saved_files": 4, "total_files": 6},
-    )
 
     def _should_not_run(*_args, **_kwargs):
         raise AssertionError("heavy summary helper should not run for detail='lite'")
@@ -7444,14 +7952,16 @@ def test_get_social_account_profile_summary_lite_skips_heavy_detail_branches(
     monkeypatch.setattr(social_repo, "_social_account_profile_grouped_counts", _should_not_run)
     monkeypatch.setattr(social_repo, "_serialize_social_account_profile_post_buckets", _should_not_run)
     monkeypatch.setattr(social_repo, "_build_social_account_profile_entity_aggregates", _should_not_run)
+    monkeypatch.setattr(social_repo, "_instagram_social_account_comments_saved_summary", _should_not_run)
+    monkeypatch.setattr(social_repo, "_instagram_social_account_media_target_counts", _should_not_run)
 
     payload = social_repo.get_social_account_profile_summary("instagram", "bravotv", detail="lite")
 
     assert payload["summary_detail"] == "lite"
     assert payload["total_posts"] == 3
-    assert payload["comments_saved_summary"] == {"saved_posts": 1, "total_posts": 2}
+    assert payload["comments_saved_summary"] is None
     assert payload["comments_coverage"] is None
-    assert payload["media_coverage"] == {"saved_files": 4, "total_files": 6}
+    assert payload["media_coverage"] is None
     assert payload["per_show_counts"] == []
     assert payload["per_season_counts"] == []
     assert payload["top_hashtags"] == []
@@ -8899,18 +9409,20 @@ def test_catalog_recent_runs_queries_all_account_stages(monkeypatch: pytest.Monk
 
     assert payload == []
     normalized_sql = " ".join(str(captured["sql"]).split()).lower()
-    assert "distinct on (run_id)" in normalized_sql
+    assert "with scoped_runs as" in normalized_sql
+    assert "from social.scrape_runs r" in normalized_sql
+    assert "exists (" in normalized_sql
     assert "nullif(j.metadata->>'account', '')" in normalized_sql
-    assert "shared_account_discovery" in normalized_sql
-    assert "shared_account_posts" in normalized_sql
-    assert "post_classify" in normalized_sql
     assert "failure_dismissed_at" in normalized_sql
     assert "r.status as run_status" in normalized_sql
-    assert "end as status" in normalized_sql
+    assert "coalesce(nullif(lower(coalesce(run_status, '')), ''), latest_job.job_status) as status" in normalized_sql
     assert "{_run_failure_not_dismissed_sql('r')}" not in captured["sql"]
-    assert captured["params"][0] == "instagram"
-    assert captured["params"][1] == "bravotv"
-    assert captured["params"][2] == list(social_repo.ACCOUNT_PROFILE_CATALOG_RECENT_RUN_STAGES)
+    assert captured["params"][0] == social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE
+    assert captured["params"][1] == "instagram"
+    assert captured["params"][2] == "bravotv"
+    assert captured["params"][3] == list(social_repo.ACCOUNT_PROFILE_CATALOG_RECENT_RUN_STAGES)
+    assert captured["params"][6] == list(social_repo.ACCOUNT_PROFILE_CATALOG_RECENT_RUN_STAGES)
+    assert captured["params"][9] == list(social_repo.ACCOUNT_PROFILE_CATALOG_RECENT_RUN_STAGES)
 
 
 def test_catalog_recent_runs_preserves_cancelled_run_status(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -13981,10 +14493,16 @@ def test_upsert_instagram_comment_tree_reappearance_clears_missing(monkeypatch) 
         def to_dict(self) -> dict[str, object]:
             return {"comment_id": self.comment_id}
 
-    def _fake_upsert(table: str, payload: dict[str, object], *, conflict_col: str, conn: object | None = None):
+    def _fake_upsert(
+        table: str,
+        payload: dict[str, object],
+        *,
+        conflict_col: str | list[str],
+        conn: object | None = None,
+    ):
         captured_payload.update(payload)
         assert table == "instagram_comments"
-        assert conflict_col == "comment_id"
+        assert conflict_col == ["post_id", "comment_id"]
         return {"id": "row-1"}
 
     monkeypatch.setattr(social_repo, "_pg_upsert", _fake_upsert)
@@ -14009,6 +14527,7 @@ def test_upsert_instagram_comment_tree_reappearance_clears_missing(monkeypatch) 
     )
 
     assert written == 1
+    assert captured_payload["post_id"] == "post-1"
     assert captured_payload["is_missing"] is False
     assert captured_payload["missing_at"] is None
     assert captured_payload["last_seen_run_id"] == "run-1"
@@ -15033,6 +15552,30 @@ def test_recover_stale_running_jobs_updates_worker_state_and_run_summaries(monke
     assert "worker_id = null" in sql_text
 
 
+def test_recover_stale_running_jobs_uses_exponential_power_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_sql: dict[str, object] = {}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", lambda *_args, **_kwargs: {"has_stale": True})
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_all",
+        lambda sql, params: captured_sql.update({"sql": sql, "params": list(params)}) or [],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_clear_worker_heartbeat_for_job",
+        lambda **_kwargs: None,
+    )
+
+    social_repo.recover_stale_running_jobs(run_id=None, stage=None, stale_after_seconds=300)
+
+    sql_text = str(captured_sql.get("sql") or "")
+    assert "power(2, greatest(0, j.attempt_count - 1))" in sql_text
+    assert "2 ^" not in sql_text
+    assert "power(2, greatest(0, j.attempt_count - 1))" in sql_text
+    assert "2 ^" not in sql_text
+
+
 def test_resolve_social_job_stale_seconds_youtube_stage_overrides(monkeypatch) -> None:
     monkeypatch.setenv("SOCIAL_JOB_STALE_SECONDS", "300")
     monkeypatch.setenv("SOCIAL_JOB_STALE_SECONDS_YOUTUBE_POSTS", "900")
@@ -15165,6 +15708,63 @@ def test_finish_job_retrying_releases_claim_ownership(monkeypatch: pytest.Monkey
     assert increments
     assert increments[0]["new_status"] == "retrying"
     assert cleared == []
+
+
+def test_finish_job_ignores_statement_timeout_during_run_counter_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    touched: dict[str, Any] = {"cleared": [], "touched": [], "partitions": [], "invalidated": 0}
+
+    def _fake_fetch_one(sql: str, params: list[object]) -> dict[str, Any]:
+        if "update social.scrape_jobs" in sql:
+            return {
+                "id": "job-1",
+                "run_id": "run-1",
+                "prior_status": "running",
+                "prior_items_found": 5,
+                "stage": "shared_account_posts",
+            }
+        if "to_regclass" in sql:
+            return {"exists": True}
+        return {}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(
+        social_repo,
+        "_increment_run_counters_on_job_finish",
+        lambda **_kwargs: (_ for _ in ()).throw(Exception("canceling statement due to statement timeout")),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_clear_worker_heartbeat_for_job",
+        lambda *, job_id, status="idle", metadata=None: touched["cleared"].append((job_id, status, metadata)),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_touch_worker_heartbeat_for_job",
+        lambda *, job_id, status="working", metadata=None: touched["touched"].append((job_id, status, metadata)),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_update_shared_account_partition_status_for_job",
+        lambda *, job_id, status, metadata_updates=None: touched["partitions"].append(
+            (job_id, status, metadata_updates)
+        ),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_invalidate_queue_status_cache",
+        lambda: touched.__setitem__("invalidated", int(touched["invalidated"]) + 1),
+    )
+
+    social_repo._finish_job(
+        "job-1",
+        status="completed",
+        items_found=11,
+        metadata={"stage": "shared_account_posts"},
+    )
+
+    assert touched["cleared"] == [("job-1", "idle", {"source": "job_finish", "job_status": "completed"})]
+    assert touched["partitions"] == [("job-1", "completed", {"source": "job_finish", "job_status": "completed"})]
+    assert touched["invalidated"] == 1
 
 
 def test_claim_next_jobs_uses_batch_limit_and_run_fairness(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -15316,6 +15916,7 @@ def test_dispatch_due_social_jobs_modal_dispatches_eligible_jobs(monkeypatch: py
     ]
     metadata_updates: list[tuple[str, dict[str, Any]]] = []
     dispatcher_heartbeats: list[dict[str, Any]] = []
+    dispatch_calls: list[tuple[str, str | None]] = []
 
     monkeypatch.setattr(social_repo, "recover_dispatch_blocked_no_progress_jobs", lambda **_kwargs: [])
     monkeypatch.setattr(
@@ -15348,7 +15949,9 @@ def test_dispatch_due_social_jobs_modal_dispatches_eligible_jobs(monkeypatch: py
     monkeypatch.setattr(
         social_repo,
         "dispatch_social_job",
-        lambda *, job_id: {"dispatched": True, "reason": None, "call_id": f"call-{job_id}"},
+        lambda *, job_id, stage=None: (
+            dispatch_calls.append((job_id, stage)) or {"dispatched": True, "reason": None, "call_id": f"call-{job_id}"}
+        ),
     )
 
     result = social_repo.dispatch_due_social_jobs(run_id="run-1", limit=2)
@@ -15356,6 +15959,7 @@ def test_dispatch_due_social_jobs_modal_dispatches_eligible_jobs(monkeypatch: py
     assert result["dispatched_job_ids"] == ["job-1", "job-2"]
     assert result["dispatch_attempts"] == 2
     assert metadata_updates
+    assert dispatch_calls == [("job-1", "posts"), ("job-2", "comments")]
     assert any(update[1].get("remote_invocation_id") == "call-job-1" for update in metadata_updates)
     assert dispatcher_heartbeats
 
@@ -15451,7 +16055,7 @@ def test_dispatch_due_social_jobs_uses_env_dispatch_limit(monkeypatch: pytest.Mo
     monkeypatch.setattr(
         social_repo,
         "dispatch_social_job",
-        lambda *, job_id: (
+        lambda *, job_id, stage=None: (
             dispatched_job_ids.append(job_id) or {"dispatched": True, "reason": None, "call_id": f"call-{job_id}"}
         ),
     )
@@ -15527,7 +16131,7 @@ def test_dispatch_due_social_jobs_catalog_mode_honors_platform_cap(monkeypatch: 
     monkeypatch.setattr(
         social_repo,
         "dispatch_social_job",
-        lambda *, job_id: (
+        lambda *, job_id, stage=None: (
             dispatched_job_ids.append(job_id) or {"dispatched": True, "reason": None, "call_id": f"call-{job_id}"}
         ),
     )
@@ -15589,7 +16193,7 @@ def test_dispatch_due_social_jobs_catalog_mode_honors_run_cap(monkeypatch: pytes
     monkeypatch.setattr(
         social_repo,
         "dispatch_social_job",
-        lambda *, job_id: {"dispatched": True, "reason": None, "call_id": f"call-{job_id}"},
+        lambda *, job_id, stage=None: {"dispatched": True, "reason": None, "call_id": f"call-{job_id}"},
     )
 
     result = social_repo.dispatch_due_social_jobs(run_id="run-catalog", limit=1)
@@ -15656,7 +16260,7 @@ def test_dispatch_due_social_jobs_keeps_modal_required_instagram_catalog_jobs_di
     monkeypatch.setattr(
         social_repo,
         "dispatch_social_job",
-        lambda *, job_id: (
+        lambda *, job_id, stage=None: (
             dispatched_job_ids.append(job_id) or {"dispatched": True, "reason": None, "call_id": f"call-{job_id}"}
         ),
     )
@@ -15736,7 +16340,9 @@ def test_dispatch_due_social_jobs_skips_redispatch_when_modal_call_is_pending(
     monkeypatch.setattr(
         social_repo,
         "dispatch_social_job",
-        lambda *, job_id: dispatched_job_ids.append(job_id) or {"dispatched": True, "call_id": f"call-{job_id}"},
+        lambda *, job_id, stage=None: (
+            dispatched_job_ids.append(job_id) or {"dispatched": True, "call_id": f"call-{job_id}"}
+        ),
     )
 
     result = social_repo.dispatch_due_social_jobs(run_id="run-1", limit=1)
@@ -24474,7 +25080,11 @@ def test_finalize_run_status_completes_scrape_complete_catalog_run_with_classify
         "_set_run_status",
         lambda run_id, status: set_status_calls.append((run_id, status)),
     )
-    monkeypatch.setattr(run_lifecycle, "_run_job_status_breakdown", lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0})
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_run_job_status_breakdown",
+        lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0},
+    )
     monkeypatch.setattr(social_repo, "_column_exists", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(social_repo, "_shared_catalog_fetch_has_terminal_error", lambda *_args, **_kwargs: False)
 
@@ -24521,7 +25131,11 @@ def test_finalize_run_status_fails_catalog_run_when_fetch_stage_completed_with_t
         "_set_run_status",
         lambda run_id, status: set_status_calls.append((run_id, status)),
     )
-    monkeypatch.setattr(run_lifecycle, "_run_job_status_breakdown", lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0})
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_run_job_status_breakdown",
+        lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0},
+    )
     monkeypatch.setattr(social_repo, "_column_exists", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(social_repo, "_maybe_enqueue_shared_catalog_classify_jobs_after_fetch", lambda **_kwargs: 0)
     monkeypatch.setattr(social_repo, "_shared_catalog_fetch_has_terminal_error", lambda _run_id: True)
@@ -24578,8 +25192,14 @@ def test_finalize_run_status_starts_deferred_comments_followup_without_ui(monkey
 
     monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
     monkeypatch.setattr(run_lifecycle, "_update_run_summary", lambda *_args, **_kwargs: summary)
-    monkeypatch.setattr(run_lifecycle, "_run_job_status_breakdown", lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0})
-    monkeypatch.setattr(run_lifecycle, "_set_run_status", lambda _run_id, status: set_status_calls.append((_run_id, status)))
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_run_job_status_breakdown",
+        lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0},
+    )
+    monkeypatch.setattr(
+        run_lifecycle, "_set_run_status", lambda _run_id, status: set_status_calls.append((_run_id, status))
+    )
     monkeypatch.setattr(social_repo, "_column_exists", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(social_repo, "_maybe_enqueue_shared_catalog_classify_jobs_after_fetch", lambda **_kwargs: 0)
     monkeypatch.setattr(social_repo, "_shared_catalog_fetch_has_terminal_error", lambda *_args, **_kwargs: False)
@@ -24596,7 +25216,11 @@ def test_finalize_run_status_starts_deferred_comments_followup_without_ui(monkey
             }
         ),
     )
-    monkeypatch.setattr(run_lifecycle, "_merge_run_config", lambda _run_id, *, config_updates: merged_configs.append(config_updates) or config_updates)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_merge_run_config",
+        lambda _run_id, *, config_updates: merged_configs.append(config_updates) or config_updates,
+    )
 
     result = social_repo._finalize_run_status(run_id, force_recompute=True)
 
@@ -24608,6 +25232,12 @@ def test_finalize_run_status_starts_deferred_comments_followup_without_ui(monkey
     assert started[0]["allow_local_dev_inline_bypass"] is True
     assert started[0]["comments_enable_media_followups"] is True
     assert merged_configs[-1]["deferred_comments_followup"]["comments_run_id"] == "comments-run-1"
+    assert merged_configs[-1]["attached_followups"]["comments"] == {
+        "run_id": "comments-run-1",
+        "state": "pending",
+        "status": "queued",
+        "source": "deferred_after_catalog",
+    }
 
 
 def test_finalize_run_status_records_deferred_comments_runtime_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -24651,7 +25281,11 @@ def test_finalize_run_status_records_deferred_comments_runtime_version(monkeypat
 
     monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
     monkeypatch.setattr(run_lifecycle, "_update_run_summary", lambda *_args, **_kwargs: summary)
-    monkeypatch.setattr(run_lifecycle, "_run_job_status_breakdown", lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0})
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_run_job_status_breakdown",
+        lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0},
+    )
     monkeypatch.setattr(run_lifecycle, "_set_run_status", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(social_repo, "_column_exists", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(social_repo, "_maybe_enqueue_shared_catalog_classify_jobs_after_fetch", lambda **_kwargs: 0)
@@ -24666,7 +25300,11 @@ def test_finalize_run_status_records_deferred_comments_runtime_version(monkeypat
             "created_by_runtime_version": {"execution_backend": "local", "commit_sha": "abc123"},
         },
     )
-    monkeypatch.setattr(run_lifecycle, "_merge_run_config", lambda _run_id, *, config_updates: merged_configs.append(config_updates) or config_updates)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_merge_run_config",
+        lambda _run_id, *, config_updates: merged_configs.append(config_updates) or config_updates,
+    )
 
     social_repo._finalize_run_status(run_id, force_recompute=True)
 
@@ -24674,6 +25312,12 @@ def test_finalize_run_status_records_deferred_comments_runtime_version(monkeypat
     assert followup["comments_run_id"] == "comments-run-1"
     assert followup["runtime_version"] == {"execution_backend": "modal", "modal_image": "im-latest"}
     assert followup["created_by_runtime_version"] == {"execution_backend": "local", "commit_sha": "abc123"}
+    assert merged_configs[-1]["attached_followups"]["comments"] == {
+        "run_id": "comments-run-1",
+        "state": "pending",
+        "status": "queued",
+        "source": "deferred_after_catalog",
+    }
 
 
 def test_instagram_backfill_with_media_and_comments_materializes_posts_before_followups(
@@ -24757,7 +25401,11 @@ def test_instagram_backfill_with_media_and_comments_materializes_posts_before_fo
             },
         },
     )
-    monkeypatch.setattr(run_lifecycle, "_run_job_status_breakdown", lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0})
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_run_job_status_breakdown",
+        lambda _run_id: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0},
+    )
     monkeypatch.setattr(run_lifecycle, "_set_run_status", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(social_repo, "_column_exists", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(social_repo, "_maybe_enqueue_shared_catalog_classify_jobs_after_fetch", lambda **_kwargs: 0)
@@ -24767,7 +25415,11 @@ def test_instagram_backfill_with_media_and_comments_materializes_posts_before_fo
         "start_social_account_comments_scrape",
         lambda *_args, **_kwargs: _assert_materialized_comments_start(events, materialized_state),
     )
-    monkeypatch.setattr(run_lifecycle, "_merge_run_config", lambda _run_id, *, config_updates: run_config_state.update(config_updates) or config_updates)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_merge_run_config",
+        lambda _run_id, *, config_updates: run_config_state.update(config_updates) or config_updates,
+    )
 
     social_repo._finalize_run_status(str(payload["catalog_run_id"]), force_recompute=True)
 
@@ -24778,6 +25430,8 @@ def _assert_materialized_comments_start(events: list[str], materialized_state: M
     assert materialized_state["count"] == 2
     events.append("comments_start")
     return {"run_id": "comments-run-1", "status": "queued"}
+
+
 def test_catalog_recent_runs_marks_scrape_complete_classify_backlog_completed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -26455,6 +27109,44 @@ def test_cancel_social_account_catalog_run_validates_account_membership(monkeypa
 
     assert payload["status"] == "cancelled"
     assert cancel_calls == [(run_id, "admin@example.com")]
+
+
+def test_request_cancel_social_account_catalog_run_marks_run_and_jobs_cancelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "22222222-2222-2222-2222-222222222222"
+    fetch_one_calls: list[tuple[str, list[Any] | None]] = []
+    execute_calls: list[tuple[str, list[Any] | None]] = []
+
+    monkeypatch.setattr(
+        social_repo,
+        "_load_social_account_catalog_run_row",
+        lambda **_kwargs: {"id": run_id},
+    )
+
+    def _fake_fetch_one(sql: str, params: list[Any] | None = None):  # noqa: ANN001
+        fetch_one_calls.append((" ".join(sql.split()).lower(), params))
+        return {"id": run_id, "status": "cancelling"}
+
+    def _fake_execute(sql: str, params: list[Any] | None = None):  # noqa: ANN001
+        execute_calls.append((" ".join(sql.split()).lower(), params))
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(social_repo.pg, "execute", _fake_execute)
+    monkeypatch.setattr(social_repo, "_invalidate_queue_status_cache", lambda: None)
+
+    payload = social_repo.request_cancel_social_account_catalog_run(
+        platform="instagram",
+        account_handle="bravotv",
+        run_id=run_id,
+        cancelled_by="admin@example.com",
+    )
+
+    assert payload["run_id"] == run_id
+    assert payload["status"] == "cancelling"
+    assert payload["accepted"] is True
+    assert any("update social.scrape_runs" in sql for sql, _params in fetch_one_calls)
+    assert any("update social.scrape_jobs" in sql for sql, _params in execute_calls)
 
 
 def test_cancel_shared_run_invalidates_queue_status_cache(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30226,6 +30918,55 @@ def test_claim_next_jobs_prefers_instagram_auth_workers_when_available(
     assert "j.platform <> 'instagram'" in sql
     assert params[0] == "w1"
     assert params[1] == 77
+
+
+def test_claim_next_jobs_reclaims_stale_worker_ownership_sql(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_fetch_all(sql: str, params: list[object]):
+        captured["sql"] = sql
+        captured["params"] = list(params)
+        return []
+
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+    monkeypatch.setattr(social_repo, "_resolve_run_in_flight_cap", lambda: 4)
+    monkeypatch.setenv("SOCIAL_WORKER_HEARTBEAT_STALE_SECONDS", "77")
+
+    social_repo._claim_next_jobs(worker_id="worker-2", run_id=None, stage="comments_scrapling", platform="instagram")
+
+    sql = str(captured["sql"]).lower()
+    params = list(captured["params"])
+
+    assert "stale_worker_window" in sql
+    assert "owning_worker.status = 'stopped'" in sql
+    assert "owning_worker.last_seen_at < now() - (select max_staleness from stale_worker_window)" in sql
+    assert "or not exists (" in sql
+    assert params[0] == "worker-2"
+    assert params[1] == 77
+
+
+def test_claim_next_jobs_reclaims_stale_worker_ownership(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_fetch_all(sql: str, params: list[object]):
+        captured["sql"] = sql
+        captured["params"] = list(params)
+        return []
+
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+    monkeypatch.setattr(social_repo, "_resolve_run_in_flight_cap", lambda: 4)
+    monkeypatch.setenv("SOCIAL_WORKER_HEARTBEAT_STALE_SECONDS", "91")
+
+    social_repo._claim_next_jobs(worker_id="worker-1", limit=1)
+
+    sql = str(captured["sql"]).lower()
+    params = list(captured["params"])
+
+    assert "stale_worker_window" in sql
+    assert "owning_worker.last_seen_at < now() - (select max_staleness from stale_worker_window)" in sql
+    assert "owning_worker.status = 'stopped'" in sql
+    assert "or not exists (" in sql
+    assert params[1] == 91
 
 
 def test_claim_next_jobs_filters_runtime_pinned_jobs_to_matching_runtime(

--- a/tests/scripts/test_backfill_instagram_profile_avatars.py
+++ b/tests/scripts/test_backfill_instagram_profile_avatars.py
@@ -148,7 +148,13 @@ def test_main_apply_persists_backfilled_avatar_fields(monkeypatch, capsys) -> No
         "_mirror_instagram_profile_pics_for_post",
         lambda *_args, **_kwargs: {
             "hosted_owner_profile_pic_url": "https://cdn.test/avatar.jpg",
-            "hosted_tagged_profile_pics": {"andycohen": "https://cdn.test/andy.jpg"},
+            "hosted_tagged_profile_pics": {
+                "andycohen": {
+                    "hosted_url": "https://cdn.test/andy.jpg",
+                    "sha256": None,
+                    "mirrored_at": "2026-04-21T00:00:00+00:00",
+                }
+            },
             "profile_pic_mirror_status": "mirrored",
             "profile_pic_mirror_error": None,
         },
@@ -186,7 +192,13 @@ def test_main_apply_persists_backfilled_avatar_fields(monkeypatch, capsys) -> No
             "job_id": None,
             "account": "bravotv",
             "hosted_owner_profile_pic_url": "https://cdn.test/avatar.jpg",
-            "hosted_tagged_profile_pics": {"andycohen": "https://cdn.test/andy.jpg"},
+            "hosted_tagged_profile_pics": {
+                "andycohen": {
+                    "hosted_url": "https://cdn.test/andy.jpg",
+                    "sha256": None,
+                    "mirrored_at": "2026-04-21T00:00:00+00:00",
+                }
+            },
             "profile_pic_mirror_status": "mirrored",
         }
     ]

--- a/tests/scripts/test_repair_instagram_single_media_urls.py
+++ b/tests/scripts/test_repair_instagram_single_media_urls.py
@@ -55,6 +55,21 @@ def test_repair_candidate_row_skips_rows_already_normalized() -> None:
     assert repair is None
 
 
+def test_repair_candidate_row_archives_legacy_media_urls() -> None:
+    repair = repair_script._repair_candidate_row(  # noqa: SLF001
+        {
+            "id": "1",
+            "shortcode": "repair-me",
+            "media_type": "image",
+            "post_format": "post",
+            "media_urls": ["https://example.com/one.jpg", "https://example.com/two.jpg"],
+            "raw_data": {},
+        }
+    )
+
+    assert repair["legacy_media_urls"] == ["https://example.com/one.jpg", "https://example.com/two.jpg"]
+
+
 def test_main_dry_run_reports_repairs_without_updating(monkeypatch) -> None:
     candidate_rows = [
         {
@@ -153,6 +168,10 @@ def test_main_apply_updates_only_rows_needing_repair(monkeypatch) -> None:
             "id": "row-1",
             "shortcode": "repair-me",
             "old_media_urls": [
+                "https://example.com/primary.jpg",
+                "https://example.com/secondary.jpg",
+            ],
+            "legacy_media_urls": [
                 "https://example.com/primary.jpg",
                 "https://example.com/secondary.jpg",
             ],

--- a/tests/scripts/test_repair_social_hosted_urls.py
+++ b/tests/scripts/test_repair_social_hosted_urls.py
@@ -142,7 +142,13 @@ def test_repair_platform_apply_updates_rows(monkeypatch: pytest.MonkeyPatch) -> 
         "https://pub.example.r2.dev/social/instagram/a/media-02.jpg",
     ]
     tagged_profile_pics = json.loads(str(update_params[4]))
-    assert tagged_profile_pics == {"bravo": "https://pub.example.r2.dev/social/instagram/profile-pics/bravo/a.jpg"}
+    assert tagged_profile_pics == {
+        "bravo": {
+            "hosted_url": "https://pub.example.r2.dev/social/instagram/profile-pics/bravo/a.jpg",
+            "sha256": None,
+            "mirrored_at": None,
+        }
+    }
 
 
 def test_parse_platforms_rejects_invalid_platforms() -> None:

--- a/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import scripts.socials.retire_duplicate_instagram_comment_media_mirror_jobs as mod
+
+
+def _base_args(**overrides):
+    values = {"season_id": [], "show_id": [], "dry_run": False, "apply": False}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_main_apply_retires_duplicate_comment_media_rows(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(mod, "load_env", lambda: None)
+    monkeypatch.setattr(mod, "_parse_args", lambda _argv: _base_args(apply=True, show_id=["show-1"]))
+    monkeypatch.setattr(
+        mod,
+        "_fetch_matches",
+        lambda **_kwargs: [{"id": "job-1", "identity_key": "post-1:comment-1"}],
+    )
+    retire_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        mod,
+        "_retire_matches",
+        lambda **kwargs: retire_calls.append(kwargs) or [{"id": "job-1"}],
+    )
+
+    assert mod.main([]) == 0
+    assert retire_calls == [{"season_ids": [], "show_ids": ["show-1"]}]
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["dry_run"] is False
+    assert payload["show_ids"] == ["show-1"]
+    assert payload["totals"] == {"matched_rows": 1, "retired_rows": 1}
+
+
+def test_retire_matches_marks_duplicate_comment_media_jobs_cancelled(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_fetch_matches",
+        lambda **_kwargs: [{"id": "job-1", "identity_key": "post-1:comment-1"}],
+    )
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        mod.pg,
+        "execute_returning",
+        lambda query, params=None: calls.append({"query": query, "params": list(params or [])}) or [{"id": "job-1"}],
+    )
+
+    rows = mod._retire_matches(season_ids=["season-1"], show_ids=[])
+
+    assert rows == [{"id": "job-1"}]
+    assert len(calls) == 1
+    assert "status = 'cancelled'" in calls[0]["query"]
+    assert calls[0]["params"][0] == mod.DUPLICATE_ERROR_MESSAGE
+    assert calls[0]["params"][1] == mod.DUPLICATE_ERROR_CODE
+    assert calls[0]["params"][2] == mod.DUPLICATE_ERROR_CLASS
+    assert json.loads(calls[0]["params"][3]) == {"duplicate_active_comment_media_mirror_job": True}
+    assert calls[0]["params"][4] == ["job-1"]
+    assert "concat(config->>'post_id', ':', config->>'comment_id')" in mod.IDENTITY_SQL

--- a/tests/scripts/test_retire_duplicate_instagram_media_mirror_jobs.py
+++ b/tests/scripts/test_retire_duplicate_instagram_media_mirror_jobs.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import scripts.socials.retire_duplicate_instagram_media_mirror_jobs as mod
+
+
+def _base_args(**overrides):
+    values = {"season_id": [], "show_id": [], "dry_run": False, "apply": False}
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_main_dry_run_reports_duplicate_rows_without_retiring(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(mod, "load_env", lambda: None)
+    monkeypatch.setattr(mod, "_parse_args", lambda _argv: _base_args(dry_run=True, season_id=["season-1"]))
+    monkeypatch.setattr(
+        mod,
+        "_fetch_matches",
+        lambda **_kwargs: [{"id": "job-1", "post_id": "post-1"}, {"id": "job-2", "post_id": "post-1"}],
+    )
+    monkeypatch.setattr(mod, "_retire_matches", lambda **_kwargs: (_ for _ in ()).throw(AssertionError("no retire")))
+
+    assert mod.main([]) == 0
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["dry_run"] is True
+    assert payload["season_ids"] == ["season-1"]
+    assert payload["totals"] == {"matched_rows": 2, "retired_rows": 0}
+    assert payload["preview_job_ids"] == ["job-1", "job-2"]
+
+
+def test_retire_matches_marks_duplicate_jobs_cancelled(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_fetch_matches",
+        lambda **_kwargs: [{"id": "job-1", "post_id": "post-1"}, {"id": "job-2", "post_id": "post-1"}],
+    )
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        mod.pg,
+        "execute_returning",
+        lambda query, params=None: calls.append({"query": query, "params": list(params or [])}) or [{"id": "job-1"}],
+    )
+
+    rows = mod._retire_matches(season_ids=["season-1"], show_ids=["show-1"])
+
+    assert rows == [{"id": "job-1"}]
+    assert len(calls) == 1
+    assert "status = 'cancelled'" in calls[0]["query"]
+    assert calls[0]["params"][0] == mod.DUPLICATE_ERROR_MESSAGE
+    assert calls[0]["params"][1] == mod.DUPLICATE_ERROR_CODE
+    assert calls[0]["params"][2] == mod.DUPLICATE_ERROR_CLASS
+    assert json.loads(calls[0]["params"][3]) == {"duplicate_active_media_mirror_job": True}
+    assert calls[0]["params"][4] == ["job-1", "job-2"]

--- a/tests/scripts/test_retire_stale_instagram_media_mirror_failures.py
+++ b/tests/scripts/test_retire_stale_instagram_media_mirror_failures.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import scripts.socials.retire_stale_instagram_media_mirror_failures as mod
+
+
+def _base_args(**overrides):
+    values = {
+        "season_id": [],
+        "show_id": [],
+        "dry_run": False,
+        "apply": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_fetch_matches_keeps_non_retryable_failures_and_skips_retryable() -> None:
+    rows = [
+        {"id": "job-1", "last_error_code": "", "error_message": "invalid_source_url"},
+        {"id": "job-2", "last_error_code": "", "error_message": "download_failed:ytdlp_fallback_failed:http_503"},
+        {"id": "job-3", "last_error_code": "asset_wrong_content_type", "error_message": ""},
+    ]
+
+    mod._fetch_candidates = lambda **_kwargs: rows  # type: ignore[method-assign]
+
+    matches = mod._fetch_matches(season_ids=[], show_ids=[])
+
+    assert [row["id"] for row in matches] == ["job-1", "job-3"]
+
+
+def test_main_dry_run_reports_matching_rows_without_retiring(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(mod, "load_env", lambda: None)
+    monkeypatch.setattr(mod, "_parse_args", lambda _argv: _base_args(dry_run=True, season_id=["season-1"]))
+    monkeypatch.setattr(
+        mod,
+        "_fetch_matches",
+        lambda **_kwargs: [
+            {"id": "job-1", "season_id": "season-1", "show_id": "show-1"},
+            {"id": "job-2", "season_id": "season-1", "show_id": "show-1"},
+        ],
+    )
+    retire_called = False
+
+    def _unexpected_retire(**_kwargs):
+        nonlocal retire_called
+        retire_called = True
+        raise AssertionError("dry-run must not retire rows")
+
+    monkeypatch.setattr(mod, "_retire_matches", _unexpected_retire)
+
+    assert mod.main([]) == 0
+    assert retire_called is False
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["dry_run"] is True
+    assert payload["season_ids"] == ["season-1"]
+    assert payload["totals"] == {"matched_rows": 2, "retired_rows": 0}
+    assert payload["preview_job_ids"] == ["job-1", "job-2"]
+
+
+def test_main_apply_retires_matching_rows(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(mod, "load_env", lambda: None)
+    monkeypatch.setattr(mod, "_parse_args", lambda _argv: _base_args(apply=True, show_id=["show-1"]))
+    monkeypatch.setattr(
+        mod,
+        "_fetch_matches",
+        lambda **_kwargs: [
+            {"id": "job-1", "season_id": "season-1", "show_id": "show-1"},
+            {"id": "job-2", "season_id": "season-1", "show_id": "show-1"},
+        ],
+    )
+    retire_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        mod,
+        "_retire_matches",
+        lambda **kwargs: retire_calls.append(kwargs) or [{"id": "job-1"}, {"id": "job-2"}],
+    )
+
+    assert mod.main([]) == 0
+    assert retire_calls == [{"season_ids": [], "show_ids": ["show-1"]}]
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["dry_run"] is False
+    assert payload["totals"] == {"matched_rows": 2, "retired_rows": 2}
+    assert payload["replacement_error_message"] == mod.OBSOLETE_ERROR_MESSAGE
+
+
+def test_retire_matches_updates_only_selected_ids(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mod,
+        "_fetch_matches",
+        lambda **_kwargs: [
+            {"id": "job-1", "error_message": "invalid_source_url"},
+            {"id": "job-3", "error_message": "asset_wrong_content_type"},
+        ],
+    )
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        mod.pg,
+        "execute_returning",
+        lambda query, params=None: calls.append({"query": query, "params": list(params or [])}) or [{"id": "job-1"}],
+    )
+
+    rows = mod._retire_matches(season_ids=["season-1"], show_ids=["show-1"])
+
+    assert rows == [{"id": "job-1"}]
+    assert len(calls) == 1
+    query = calls[0]["query"]
+    params = calls[0]["params"]
+    assert "status = 'cancelled'" in query
+    assert "where id::text = any(%s)" in query.lower()
+    assert params[0] == mod.OBSOLETE_ERROR_MESSAGE
+    assert params[1] == mod.OBSOLETE_ERROR_CODE
+    assert params[2] == mod.OBSOLETE_ERROR_CLASS
+    assert json.loads(params[3]) == {
+        "obsolete_non_retryable_media_mirror_failure": True,
+        "obsolete_failure_reason": "instagram_media_mirror_non_retryable",
+        "obsolete_failure_resolution": "retired_from_retry_backlog",
+    }
+    assert params[4] == ["job-1", "job-3"]

--- a/tests/scripts/test_social_worker.py
+++ b/tests/scripts/test_social_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from types import SimpleNamespace
 
 import scripts.socials.worker as worker
@@ -754,7 +755,7 @@ def test_default_claim_batch_size_for_posts_is_single_claim() -> None:
     assert worker._default_claim_batch_size_for_stage("comments") == 2
 
 
-def test_claim_stage_candidates_allow_comments_workers_to_borrow_posts() -> None:
+def test_claim_stage_candidates_comments_workers_fall_back_to_posts() -> None:
     assert worker._claim_stage_candidates("comments") == ("comments", "posts")  # noqa: SLF001
     assert worker._claim_stage_candidates("posts") == ("posts",)  # noqa: SLF001
 
@@ -843,3 +844,36 @@ def test_parse_args_accepts_shared_pipeline_stages(monkeypatch) -> None:
 
     assert args.stage == "post_classify"
     assert args.once is True
+
+
+def test_wait_for_children_times_out_and_terminates_hung_child(monkeypatch) -> None:
+    events: list[str] = []
+
+    class _HungProc:
+        def wait(self, timeout=None):  # noqa: ANN001
+            if timeout is None or timeout > 0:
+                raise subprocess.TimeoutExpired(cmd="hung", timeout=timeout)
+            raise subprocess.TimeoutExpired(cmd="hung", timeout=timeout)
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            events.append("terminate")
+
+        def kill(self):
+            events.append("kill")
+
+    exit_code = worker._wait_for_children(  # noqa: SLF001
+        [_HungProc()],
+        context_label="queue fanout",
+        wait_timeout_seconds=0.1,
+        terminate_grace_seconds=0.1,
+    )
+
+    assert exit_code == 124
+    assert events == ["terminate", "kill"]
+
+
+def test_resolve_child_wait_timeout_adds_grace_to_max_run_seconds() -> None:
+    assert worker._resolve_child_wait_timeout_seconds(180.0) == 210.0  # noqa: SLF001

--- a/tests/scripts/test_verify_modal_readiness.py
+++ b/tests/scripts/test_verify_modal_readiness.py
@@ -38,12 +38,18 @@ def test_expected_function_names_includes_reddit_runtime_probe(monkeypatch: pyte
     monkeypatch.delenv("TRR_MODAL_REDDIT_RUNTIME_PROBE_FUNCTION", raising=False)
     monkeypatch.delenv("TRR_MODAL_SOCIAL_AUTH_PROBE_FUNCTION", raising=False)
     monkeypatch.delenv("TRR_MODAL_GETTY_REMOTE_PROBE_FUNCTION", raising=False)
+    monkeypatch.delenv("TRR_MODAL_SOCIAL_POSTS_JOB_FUNCTION", raising=False)
+    monkeypatch.delenv("TRR_MODAL_SOCIAL_MEDIA_JOB_FUNCTION", raising=False)
+    monkeypatch.delenv("TRR_MODAL_SOCIAL_COMMENTS_JOB_FUNCTION", raising=False)
 
     function_names = cli.expected_function_names()
 
     assert "probe_reddit_refresh_runtime" in function_names
     assert "probe_social_remote_auth" in function_names
     assert "probe_getty_remote_access" in function_names
+    assert "run_social_posts_job" in function_names
+    assert "run_social_media_job" in function_names
+    assert "run_social_comments_job" in function_names
 
 
 def test_verify_modal_readiness_passes_when_all_resources_exist(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/socials/instagram/posts_scrapling/test_fetcher_retry.py
+++ b/tests/socials/instagram/posts_scrapling/test_fetcher_retry.py
@@ -42,12 +42,34 @@ def _make_fetcher():
             raw_cookies={"sessionid": "x", "csrftoken": "y", "ds_user_id": "1"},
             browser_account_id="t",
         )
-        fetcher._rebuild_http_client()
+        asyncio.run(fetcher._rebuild_http_client())
         return fetcher
 
 
 _SLEEP_TARGET = "trr_backend.socials.instagram.posts_scrapling.fetcher.asyncio.sleep"
 _URL = "https://www.instagram.com/graphql/query"
+
+
+class _TrackingClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def test_rebuild_http_client_closes_previous_client(monkeypatch) -> None:
+    fetcher = _make_fetcher()
+    old = _TrackingClient()
+    fetcher._http_client = old
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.posts_scrapling.fetcher.httpx.AsyncClient",
+        lambda **_kwargs: _TrackingClient(),
+    )
+
+    asyncio.run(fetcher._rebuild_http_client())
+
+    assert old.closed is True
 
 
 # 1 — 429 then 200 succeeds
@@ -158,6 +180,17 @@ def test_timeout_exhausts_retries() -> None:
     assert result["retryable"] is True
     assert result["reason"] == "transport_timeout"
     assert fetcher._fetch_graphql.await_count == InstagramPostsScraplingFetcher._MAX_TRANSIENT_RETRIES + 1
+
+
+def test_rebuild_http_client_closes_existing_async_client() -> None:
+    fetcher = _make_fetcher()
+    stale_client = AsyncMock()
+    fetcher._http_client = stale_client
+
+    asyncio.run(fetcher._rebuild_http_client())
+
+    stale_client.aclose.assert_awaited_once()
+    assert fetcher._http_client is not stale_client
 
 
 # 8 — Redirect to /accounts/login → auth_failed, non-retryable

--- a/tests/socials/test_crawlee_runtime.py
+++ b/tests/socials/test_crawlee_runtime.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from trr_backend.socials.crawlee_runtime import runtime
+from trr_backend.socials.crawlee_runtime.auth_preflight import AuthPreflightResult
+from trr_backend.socials.crawlee_runtime.config import CrawleeRuntimeConfig
+
+
+def _runtime_config(*, max_retries: int = 3) -> CrawleeRuntimeConfig:
+    return CrawleeRuntimeConfig(
+        enabled=True,
+        platform="instagram",
+        max_concurrency=1,
+        max_retries=max_retries,
+        auth_strict=False,
+        enabled_platforms=("instagram",),
+        force_legacy_platforms=(),
+    )
+
+
+def _auth_result() -> AuthPreflightResult:
+    return AuthPreflightResult(
+        ok=True,
+        platform="instagram",
+        auth_mode="cookies",
+        auth_source="tests",
+        missing=(),
+        account_ref="@codexhuli",
+    )
+
+
+def test_execute_with_internal_retry_uses_one_second_first_backoff(monkeypatch) -> None:
+    sleep_calls: list[float] = []
+
+    monkeypatch.setattr(runtime.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+    attempts = {"count": 0}
+
+    def _stage_runner():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise TimeoutError("timed out")
+        return 1, 0, {"ok": True}
+
+    runtime._execute_with_internal_retry(
+        platform="instagram",
+        stage="posts",
+        request_mode="queue",
+        request_key="req-1",
+        runtime_config=_runtime_config(max_retries=2),
+        auth_preflight=_auth_result(),
+        stage_runner=_stage_runner,
+        crawlee_status=runtime._CrawleeImportStatus(available=True, version="test"),
+    )
+
+    assert sleep_calls == [1]
+
+
+def test_run_coroutine_cancels_timed_out_coroutine() -> None:
+    state = {"done": False}
+
+    async def _slow() -> None:
+        await asyncio.sleep(0.2)
+        state["done"] = True
+
+    async def _invoke() -> None:
+        with pytest.raises(TimeoutError):
+            runtime._run_coroutine(_slow(), join_timeout_seconds=0.05)
+
+    asyncio.run(_invoke())
+    time.sleep(0.1)
+
+    assert state["done"] is False

--- a/tests/socials/test_instagram_comments_scrapling_pagination.py
+++ b/tests/socials/test_instagram_comments_scrapling_pagination.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from trr_backend.socials.instagram.scraper import InstagramScraper
+
+
+def _mock_json_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.headers = {"content-type": "application/json"}
+    response.status_code = 200
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_fetch_comments_stops_on_repeated_cursor(monkeypatch) -> None:
+    scraper = InstagramScraper.__new__(InstagramScraper)
+    scraper.last_comment_fetch_reason = None
+    scraper.comments_auth_failed = False
+    scraper._request_cookies = lambda: {}
+    scraper._get_headers = lambda *_args, **_kwargs: {}
+    scraper._shortcode_to_media_id = lambda shortcode: f"{shortcode}_media"
+    scraper._rate_limit_with_lock = lambda *_args, **_kwargs: None
+    scraper._parse_comment = lambda *_args, **_kwargs: MagicMock(reply_count=0, replies=[])
+
+    responses = iter(
+        [
+            _mock_json_response(
+                {
+                    "status": "ok",
+                    "comments": [{"id": "c1", "text": "hi"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                }
+            ),
+            _mock_json_response(
+                {
+                    "status": "ok",
+                    "comments": [{"id": "c2", "text": "hi"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                }
+            ),
+        ]
+    )
+    scraper._get = lambda *_args, **_kwargs: next(responses)
+
+    comments = scraper.fetch_comments("ABC123", fetch_replies=False, delay=0)
+
+    assert len(comments) == 2
+    assert scraper.last_comment_fetch_reason == "pagination_repeated_cursor"
+
+
+def test_fetch_comment_replies_stops_on_page_cap(monkeypatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES", "1")
+    scraper = InstagramScraper.__new__(InstagramScraper)
+    scraper.last_comment_fetch_reason = None
+    scraper.comments_auth_failed = False
+    scraper._request_cookies = lambda: {}
+    scraper._get_headers = lambda *_args, **_kwargs: {}
+    scraper._rate_limit_with_lock = lambda *_args, **_kwargs: None
+    scraper._parse_comment = lambda *_args, **_kwargs: MagicMock()
+
+    responses = iter(
+        [
+            _mock_json_response(
+                {
+                    "status": "ok",
+                    "child_comments": [{"id": "r1"}],
+                    "has_more_tail_child_comments": True,
+                    "next_min_child_cursor": "reply-2",
+                }
+            ),
+            _mock_json_response(
+                {
+                    "status": "ok",
+                    "child_comments": [{"id": "r2"}],
+                    "has_more_tail_child_comments": True,
+                    "next_min_child_cursor": "reply-3",
+                }
+            ),
+        ]
+    )
+    scraper._get = lambda *_args, **_kwargs: next(responses)
+
+    replies = scraper._fetch_comment_replies(
+        "media-1",
+        "comment-1",
+        "ABC123",
+        "https://www.instagram.com/p/ABC123/",
+        delay=0,
+    )
+
+    assert len(replies) == 1
+    assert scraper.last_comment_fetch_reason == "pagination_page_cap_reached"

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -7,6 +7,7 @@ Mocks target `_fetch_api` (httpx path) for JSON tests, not the old `_fetch`
 from __future__ import annotations
 
 import asyncio
+from contextlib import nullcontext
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,6 +18,15 @@ from trr_backend.socials.instagram.comments_scrapling.fetcher import (
     InstagramCommentsFetchResult,
     InstagramCommentsScraplingFetcher,
 )
+from trr_backend.socials.instagram.scraper import InstagramComment
+
+
+class _TrackingClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
 
 
 def _build_fetcher() -> InstagramCommentsScraplingFetcher:
@@ -28,8 +38,83 @@ def _build_fetcher() -> InstagramCommentsScraplingFetcher:
             browser_account_id="testaccount",
         )
         # Pre-build httpx client so tests don't need warmup.
-        fetcher._rebuild_http_client()
+        asyncio.run(fetcher._rebuild_http_client())
         return fetcher
+
+
+def test_rebuild_http_client_closes_previous_client(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    old = _TrackingClient()
+    fetcher._http_client = old
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.httpx.AsyncClient",
+        lambda **_kwargs: _TrackingClient(),
+    )
+
+    asyncio.run(fetcher._rebuild_http_client())
+
+    assert old.closed is True
+
+
+def test_fetch_comments_preserves_reply_failure_across_later_pages(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            InstagramComment(
+                comment_id="c1",
+                text="one",
+                username="alpha",
+                user_id="1",
+                created_at=1,
+                date_time="1970-01-01T00:00:01+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=1,
+            )
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-2",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [],
+                    "has_more_comments": False,
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+    fetcher._fetch_comment_replies = AsyncMock(
+        return_value=InstagramCommentsFetchResult(
+            comments=[],
+            fetch_failed=True,
+            auth_failed=False,
+            fetch_reason="reply_timeout",
+            request_count=1,
+            retryable=True,
+        )
+    )
+
+    result = asyncio.run(fetcher.fetch_comments_for_shortcode("ABC123", max_comments=10, fetch_replies=True))
+
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "reply_timeout"
 
 
 def _mock_httpx_response(
@@ -181,6 +266,17 @@ def test_httpx_timeout_exception_is_retryable() -> None:
 
     assert result["failed"] is False
     assert fetcher._fetch_api.await_count == 2
+
+
+def test_rebuild_http_client_closes_existing_async_client() -> None:
+    fetcher = _build_fetcher()
+    stale_client = AsyncMock()
+    fetcher._http_client = stale_client
+
+    asyncio.run(fetcher._rebuild_http_client())
+
+    stale_client.aclose.assert_awaited_once()
+    assert fetcher._http_client is not stale_client
 
 
 # ---------------------------------------------------------------------------
@@ -406,6 +502,7 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
     monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
     job = {
         "id": "job-1",
@@ -433,9 +530,9 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
 
 
 def test_job_runner_marks_uncapped_success_complete(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
     from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
-    from trr_backend.repositories import social_season_analytics as repo
 
     captured_is_complete: list[bool] = []
 
@@ -481,6 +578,7 @@ def test_job_runner_marks_uncapped_success_complete(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
     job = {
         "id": "job-1",
@@ -505,9 +603,9 @@ def test_job_runner_marks_uncapped_success_complete(monkeypatch: pytest.MonkeyPa
 
 
 def test_job_runner_keeps_capped_success_incomplete_when_local_cap_is_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
     from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
-    from trr_backend.repositories import social_season_analytics as repo
 
     captured_is_complete: list[bool] = []
 
@@ -557,6 +655,7 @@ def test_job_runner_keeps_capped_success_incomplete_when_local_cap_is_hit(monkey
     monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
     job = {
         "id": "job-1",
@@ -582,9 +681,9 @@ def test_job_runner_keeps_capped_success_incomplete_when_local_cap_is_hit(monkey
 
 
 def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
     from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
-    from trr_backend.repositories import social_season_analytics as repo
 
     finish_calls: list[dict[str, Any]] = []
 
@@ -634,6 +733,7 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
     monkeypatch.setattr(repo, "_finish_job", fake_finish_job)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
     job = {
         "id": "job-1",
@@ -657,3 +757,152 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
     metadata = finish_calls[-1]["metadata"]
     assert metadata["fetch_counters"]["request_count"] == 4
     assert metadata["fetcher_runtime"]["request_count"] == 4
+
+
+def test_job_runner_reuses_one_db_connection_for_all_post_persists(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    persist_conns: list[object] = []
+    shared_conn = object()
+
+    def fake_persist(*, conn: object, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_conns.append(conn)
+        return PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 2
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(shared_conn))
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "completed"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert persist_conns == [shared_conn, shared_conn]
+
+
+def test_job_runner_returns_degraded_summary_when_final_job_read_hits_db_saturation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    class _FakeFetcher:
+        _request_count = 2
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(
+        jr,
+        "persist_instagram_comments_for_post",
+        lambda **_kwargs: PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        ),
+    )
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=jr.pg.DatabaseServiceUnavailableError("db saturated"),
+    ):
+        payload = jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert payload["id"] == "job-1"
+    assert payload["status"] == "completed"
+    assert payload["metadata"]["degraded_summary"] is True

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -502,7 +502,7 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
     monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
-    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
 
     job = {
         "id": "job-1",
@@ -578,7 +578,7 @@ def test_job_runner_marks_uncapped_success_complete(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
-    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
 
     job = {
         "id": "job-1",
@@ -655,7 +655,7 @@ def test_job_runner_keeps_capped_success_incomplete_when_local_cap_is_hit(monkey
     monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
-    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
 
     job = {
         "id": "job-1",
@@ -733,7 +733,7 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
     monkeypatch.setattr(repo, "_finish_job", fake_finish_job)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
-    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
 
     job = {
         "id": "job-1",
@@ -759,13 +759,103 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
     assert metadata["fetcher_runtime"]["request_count"] == 4
 
 
+def test_job_runner_persists_partial_success_when_auth_failed_but_comments_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    persist_calls: list[dict[str, Any]] = []
+    finish_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, shortcode: str, is_complete: bool, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append({"shortcode": shortcode, "is_complete": is_complete})
+        return PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=22,
+            comments_upserted=22,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 3
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(
+                comments=[object()] * 22,
+                fetch_failed=False,
+                auth_failed=True,
+                fetch_reason=None,
+                request_count=3,
+                retryable=False,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(
+        repo,
+        "_finish_job",
+        lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}),
+    )
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "fetch_replies": True,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "completed"},
+    ):
+        payload = jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert payload["status"] == "completed"
+    assert persist_calls == [{"shortcode": "SHORT1", "is_complete": False}]
+    assert finish_calls[-1]["status"] == "completed"
+    assert finish_calls[-1]["items_found"] == 23
+
+
 def test_job_runner_reuses_one_db_connection_for_all_post_persists(monkeypatch: pytest.MonkeyPatch) -> None:
     from trr_backend.repositories import social_season_analytics as repo
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
     from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
 
     persist_conns: list[object] = []
-    shared_conn = object()
+    shared_conn = MagicMock()
 
     def fake_persist(*, conn: object, **_kwargs: Any) -> PersistedInstagramComments:
         persist_conns.append(conn)
@@ -833,6 +923,79 @@ def test_job_runner_reuses_one_db_connection_for_all_post_persists(monkeypatch: 
     assert persist_conns == [shared_conn, shared_conn]
 
 
+def test_job_runner_commits_each_post_persist(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    shared_conn = MagicMock()
+
+    class _FakeFetcher:
+        _request_count = 2
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(
+        jr,
+        "persist_instagram_comments_for_post",
+        lambda **_kwargs: PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        ),
+    )
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(shared_conn))
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "completed"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert shared_conn.commit.call_count == 2
+
+
 def test_job_runner_returns_degraded_summary_when_final_job_read_hits_db_saturation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -882,7 +1045,7 @@ def test_job_runner_returns_degraded_summary_when_final_job_read_hits_db_saturat
     monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
-    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
 
     job = {
         "id": "job-1",

--- a/tests/socials/test_instagram_profile_page_context_cache_threadsafety.py
+++ b/tests/socials/test_instagram_profile_page_context_cache_threadsafety.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import threading
+
+from trr_backend.socials.instagram.scraper import InstagramScraper
+
+
+def test_profile_page_context_cache_mutations_are_locked() -> None:
+    scraper = InstagramScraper.__new__(InstagramScraper)
+    scraper._profile_page_context_cache = {}
+    scraper._context_cache_lock = threading.RLock()
+
+    failures: list[Exception] = []
+
+    def _hammer() -> None:
+        try:
+            for idx in range(200):
+                scraper._set_profile_page_context_cache_entry("bravotv", {"cursor": str(idx)})
+                scraper._get_profile_page_context_cache_entry("bravotv")
+                if idx % 50 == 0:
+                    scraper._clear_profile_page_context_cache()
+                if idx % 75 == 0:
+                    scraper._pop_profile_page_context_cache_entry("bravotv")
+        except Exception as exc:  # noqa: BLE001
+            failures.append(exc)
+
+    threads = [threading.Thread(target=_hammer) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert failures == []

--- a/tests/socials/test_instagram_scraper_concurrent_comments.py
+++ b/tests/socials/test_instagram_scraper_concurrent_comments.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from trr_backend.socials.instagram.scraper import ConcurrentCommentFetchResult, InstagramScraper
+
+
+class _BoomScraper(InstagramScraper):
+    def fetch_comments(self, shortcode, **kwargs):  # type: ignore[override]
+        del kwargs
+        if shortcode == "bad":
+            raise RuntimeError("rate_limited")
+        return []
+
+
+def test_concurrent_fetch_returns_comments_and_errors() -> None:
+    scraper = _BoomScraper.__new__(_BoomScraper)
+    scraper._concurrent_rate_limit_lock = None
+
+    result = scraper.fetch_comments_concurrent(
+        ["ok", "bad"],
+        max_comments=10,
+        fetch_replies=False,
+        delay=0,
+        fast_mode=False,
+        max_workers=2,
+    )
+
+    assert isinstance(result, ConcurrentCommentFetchResult)
+    assert result.comments["ok"] == []
+    assert result.errors["bad"] == "RuntimeError: rate_limited"
+    assert result.had_failures is True

--- a/tests/test_modal_dispatch.py
+++ b/tests/test_modal_dispatch.py
@@ -120,6 +120,40 @@ def test_inspect_modal_function_call_returns_unknown_on_inspection_failure(
     assert payload["error"] == "boom"
 
 
+def test_modal_social_job_function_name_for_stage_routes_three_backfill_lanes() -> None:
+    assert modal_dispatch.modal_social_job_function_name_for_stage("shared_account_posts") == "run_social_posts_job"
+    assert modal_dispatch.modal_social_job_function_name_for_stage("media_mirror") == "run_social_media_job"
+    assert modal_dispatch.modal_social_job_function_name_for_stage("comments_scrapling") == "run_social_comments_job"
+
+
+def test_modal_social_job_function_names_dedupes_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(modal_dispatch, "modal_social_job_function_name", lambda: "run_social_job")
+    monkeypatch.setattr(modal_dispatch, "modal_social_posts_job_function_name", lambda: "run_social_job")
+    monkeypatch.setattr(modal_dispatch, "modal_social_media_job_function_name", lambda: "run_social_media_job")
+    monkeypatch.setattr(modal_dispatch, "modal_social_comments_job_function_name", lambda: "run_social_comments_job")
+
+    assert modal_dispatch.modal_social_job_function_names() == [
+        "run_social_job",
+        "run_social_media_job",
+        "run_social_comments_job",
+    ]
+
+
+def test_dispatch_social_job_uses_stage_specific_function(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_spawn_named_modal_function(**kwargs):
+        captured.update(kwargs)
+        return {"dispatched": True, "call_id": "fc-123"}
+
+    monkeypatch.setattr(modal_dispatch, "_spawn_named_modal_function", _fake_spawn_named_modal_function)
+
+    modal_dispatch.dispatch_social_job(job_id="job-1", stage="comments_scrapling")
+
+    assert captured["function_name"] == "run_social_comments_job"
+    assert captured["kwargs"] == {"job_id": "job-1"}
+
+
 def test_inspect_modal_function_call_only_requires_modal_app_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_modal_jobs.py
+++ b/tests/test_modal_jobs.py
@@ -270,6 +270,9 @@ def test_build_social_image_base_adds_browser_runtime_when_requested() -> None:
 
 def test_run_social_job_uses_browser_capable_image_binding() -> None:
     assert modal_jobs._FUNCTION_IMAGE_BINDINGS["run_social_job"] is modal_jobs._browser_image
+    assert modal_jobs._FUNCTION_IMAGE_BINDINGS["run_social_posts_job"] is modal_jobs._browser_image
+    assert modal_jobs._FUNCTION_IMAGE_BINDINGS["run_social_media_job"] is modal_jobs._browser_image
+    assert modal_jobs._FUNCTION_IMAGE_BINDINGS["run_social_comments_job"] is modal_jobs._browser_image
     assert modal_jobs._FUNCTION_IMAGE_BINDINGS["run_socialblade_scrape"] is modal_jobs._browser_image
 
 
@@ -288,7 +291,7 @@ def test_heartbeat_remote_executors_reports_social_auth_capabilities(
     )
     monkeypatch.setitem(
         sys.modules,
-        "trr_backend.repositories.social_season_analytics",
+        "trr_backend.socials.control_plane",
         types.SimpleNamespace(
             is_queue_enabled=lambda: True,
             get_worker_auth_capabilities=lambda: {"instagram_authenticated": True, "twitter_authenticated": False},

--- a/trr_backend/db/pg.py
+++ b/trr_backend/db/pg.py
@@ -38,6 +38,8 @@ DEFAULT_POOL_MINCONN = 2
 DEFAULT_POOL_MAXCONN = 24
 DEFAULT_SESSION_POOLER_MINCONN = 4
 DEFAULT_SESSION_POOLER_MAXCONN = 16
+DEFAULT_MODAL_SESSION_POOLER_MINCONN = 1
+DEFAULT_MODAL_SESSION_POOLER_MAXCONN = 4
 DEFAULT_POOL_ACQUIRE_ATTEMPTS = 8
 DEFAULT_POOL_ACQUIRE_SLEEP_MS = 50
 DEFAULT_QUERY_TRANSIENT_ATTEMPTS = 3
@@ -101,6 +103,10 @@ def _is_local_or_dev_runtime() -> bool:
     if normalized & {"local", "dev", "development", "test"}:
         return True
     return bool(os.getenv("PYTEST_CURRENT_TEST"))
+
+
+def _is_modal_container_runtime() -> bool:
+    return bool((os.getenv("MODAL_TASK_ID") or "").strip() or (os.getenv("MODAL_ENVIRONMENT") or "").strip())
 
 
 def _sslmode_for_url(url: str) -> str | None:
@@ -227,6 +233,7 @@ def _resolve_pool_sizing(url: str) -> dict[str, Any]:
     minconn_source = "env:TRR_DB_POOL_MINCONN" if minconn_overridden else "default"
     maxconn_source = "env:TRR_DB_POOL_MAXCONN" if maxconn_overridden else "default"
     session_pooler_override_clamped = False
+    modal_session_pooler_override_clamped = False
     if session_pooler and _is_local_or_dev_runtime():
         if minconn > DEFAULT_SESSION_POOLER_MINCONN:
             minconn = DEFAULT_SESSION_POOLER_MINCONN
@@ -236,11 +243,22 @@ def _resolve_pool_sizing(url: str) -> dict[str, Any]:
             maxconn = DEFAULT_SESSION_POOLER_MAXCONN
             maxconn_source = "clamped:session_pooler_default"
             session_pooler_override_clamped = True
+    if session_pooler and _is_modal_container_runtime():
+        if minconn > DEFAULT_MODAL_SESSION_POOLER_MINCONN:
+            minconn = DEFAULT_MODAL_SESSION_POOLER_MINCONN
+            minconn_source = "clamped:modal_session_pooler_default"
+            modal_session_pooler_override_clamped = True
+        if maxconn > DEFAULT_MODAL_SESSION_POOLER_MAXCONN:
+            maxconn = DEFAULT_MODAL_SESSION_POOLER_MAXCONN
+            maxconn_source = "clamped:modal_session_pooler_default"
+            modal_session_pooler_override_clamped = True
     maxconn = max(minconn, maxconn)
     return {
         "session_pooler": session_pooler,
         "default_minconn": default_minconn,
         "default_maxconn": default_maxconn,
+        "modal_default_minconn": DEFAULT_MODAL_SESSION_POOLER_MINCONN,
+        "modal_default_maxconn": DEFAULT_MODAL_SESSION_POOLER_MAXCONN,
         "minconn": minconn,
         "maxconn": maxconn,
         "requested_minconn": requested_minconn,
@@ -248,6 +266,7 @@ def _resolve_pool_sizing(url: str) -> dict[str, Any]:
         "minconn_source": minconn_source,
         "maxconn_source": maxconn_source,
         "session_pooler_override_clamped": session_pooler_override_clamped,
+        "modal_session_pooler_override_clamped": modal_session_pooler_override_clamped,
         "using_tiny_session_defaults": (
             session_pooler
             and not minconn_overridden
@@ -569,11 +588,29 @@ def _get_pool() -> ThreadedConnectionPool:
                         sizing["maxconn"],
                     )
                 elif sizing["session_pooler"] and (
-                    bool(sizing.get("session_pooler_override_clamped"))
+                    bool(sizing.get("modal_session_pooler_override_clamped"))
+                    or bool(sizing.get("session_pooler_override_clamped"))
                     or int(sizing["minconn"]) > DEFAULT_SESSION_POOLER_MINCONN
                     or int(sizing["maxconn"]) > DEFAULT_SESSION_POOLER_MAXCONN
                 ):
-                    if bool(sizing.get("session_pooler_override_clamped")):
+                    if bool(sizing.get("modal_session_pooler_override_clamped")):
+                        logger.warning(
+                            (
+                                "[db-pool] clamped_modal_session_pool_override source=%s host=%s port=%s "
+                                "requested_minconn=%s requested_maxconn=%s effective_minconn=%s "
+                                "effective_maxconn=%s modal_default_minconn=%s modal_default_maxconn=%s"
+                            ),
+                            candidate_detail["source"],
+                            candidate_detail["host"],
+                            candidate_detail["port"],
+                            sizing["requested_minconn"],
+                            sizing["requested_maxconn"],
+                            sizing["minconn"],
+                            sizing["maxconn"],
+                            sizing["modal_default_minconn"],
+                            sizing["modal_default_maxconn"],
+                        )
+                    elif bool(sizing.get("session_pooler_override_clamped")):
                         logger.warning(
                             (
                                 "[db-pool] clamped_session_pool_override source=%s host=%s port=%s "

--- a/trr_backend/modal_dispatch.py
+++ b/trr_backend/modal_dispatch.py
@@ -81,6 +81,53 @@ def modal_social_job_function_name() -> str:
     return str(os.getenv("TRR_MODAL_SOCIAL_JOB_FUNCTION") or "run_social_job").strip()
 
 
+def modal_social_posts_job_function_name() -> str:
+    return str(os.getenv("TRR_MODAL_SOCIAL_POSTS_JOB_FUNCTION") or "run_social_posts_job").strip()
+
+
+def modal_social_media_job_function_name() -> str:
+    return str(os.getenv("TRR_MODAL_SOCIAL_MEDIA_JOB_FUNCTION") or "run_social_media_job").strip()
+
+
+def modal_social_comments_job_function_name() -> str:
+    return str(os.getenv("TRR_MODAL_SOCIAL_COMMENTS_JOB_FUNCTION") or "run_social_comments_job").strip()
+
+
+def modal_social_job_function_name_for_stage(stage: str | None) -> str:
+    normalized_stage = str(stage or "").strip().lower()
+    if normalized_stage in {"comments", "comments_scrapling"}:
+        return modal_social_comments_job_function_name() or modal_social_job_function_name()
+    if normalized_stage in {"media_mirror", "comment_media_mirror"}:
+        return modal_social_media_job_function_name() or modal_social_job_function_name()
+    if normalized_stage in {
+        "",
+        "any",
+        "posts",
+        "shared_account_discovery",
+        "shared_account_posts",
+        "post_classify",
+        "season_materialize",
+        "analytics_refresh",
+    }:
+        return modal_social_posts_job_function_name() or modal_social_job_function_name()
+    return modal_social_job_function_name()
+
+
+def modal_social_job_function_names() -> list[str]:
+    names = [
+        modal_social_job_function_name(),
+        modal_social_posts_job_function_name(),
+        modal_social_media_job_function_name(),
+        modal_social_comments_job_function_name(),
+    ]
+    deduped: list[str] = []
+    for name in names:
+        normalized = str(name or "").strip()
+        if normalized and normalized not in deduped:
+            deduped.append(normalized)
+    return deduped
+
+
 def modal_social_recovery_function_name() -> str:
     return str(os.getenv("TRR_MODAL_SOCIAL_RECOVERY_FUNCTION") or "sweep_social_dispatch_queue").strip()
 
@@ -114,6 +161,9 @@ def modal_dispatch_config() -> dict[str, str]:
         "reddit_refresh_function": modal_reddit_refresh_function_name(),
         "reddit_runtime_probe_function": modal_reddit_runtime_probe_function_name(),
         "social_job_function": modal_social_job_function_name(),
+        "social_posts_job_function": modal_social_posts_job_function_name(),
+        "social_media_job_function": modal_social_media_job_function_name(),
+        "social_comments_job_function": modal_social_comments_job_function_name(),
         "social_recovery_function": modal_social_recovery_function_name(),
         "socialblade_function": modal_socialblade_function_name(),
     }
@@ -540,9 +590,9 @@ def dispatch_reddit_refresh(*, run_id: str) -> bool:
     return bool(result.get("dispatched"))
 
 
-def dispatch_social_job(*, job_id: str) -> dict[str, Any]:
+def dispatch_social_job(*, job_id: str, stage: str | None = None) -> dict[str, Any]:
     return _spawn_named_modal_function(
-        function_name=modal_social_job_function_name(),
+        function_name=modal_social_job_function_name_for_stage(stage),
         log_label="social ingest",
         kwargs={"job_id": job_id},
         dispatcher_name="social",

--- a/trr_backend/modal_jobs.py
+++ b/trr_backend/modal_jobs.py
@@ -170,6 +170,9 @@ _CANONICAL_MODAL_RUNTIME_DEFAULTS: Final[dict[str, str]] = {
     "TRR_MODAL_GOOGLE_NEWS_FUNCTION": "run_google_news_sync",
     "TRR_MODAL_REDDIT_REFRESH_FUNCTION": "run_reddit_refresh",
     "TRR_MODAL_SOCIAL_JOB_FUNCTION": "run_social_job",
+    "TRR_MODAL_SOCIAL_POSTS_JOB_FUNCTION": "run_social_posts_job",
+    "TRR_MODAL_SOCIAL_MEDIA_JOB_FUNCTION": "run_social_media_job",
+    "TRR_MODAL_SOCIAL_COMMENTS_JOB_FUNCTION": "run_social_comments_job",
     "TRR_MODAL_SOCIAL_RECOVERY_FUNCTION": "sweep_social_dispatch_queue",
     "TRR_MODAL_SOCIAL_AUTH_PROBE_FUNCTION": "probe_social_remote_auth",
     "TRR_MODAL_GETTY_REMOTE_PROBE_FUNCTION": "probe_getty_remote_access",
@@ -216,6 +219,9 @@ _vision_image = (
 _browser_image = _build_social_image_base(include_browser_runtime=True)
 _FUNCTION_IMAGE_BINDINGS: Final[dict[str, object]] = {
     "run_social_job": _browser_image,
+    "run_social_posts_job": _browser_image,
+    "run_social_media_job": _browser_image,
+    "run_social_comments_job": _browser_image,
     "run_socialblade_scrape": _browser_image,
     "run_admin_vision": _vision_image,
 }
@@ -481,6 +487,58 @@ def probe_getty_remote_access() -> dict[str, object]:
     return _probe_getty_remote_access()
 
 
+def _execute_social_job(job_id: str, *, worker_prefix: str) -> dict[str, object]:
+    from trr_backend.socials.control_plane import claim_and_process_social_job
+
+    worker_id = f"{worker_prefix}:{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+    result = claim_and_process_social_job(job_id=job_id, worker_id=worker_id)
+    return {
+        "job_id": job_id,
+        "claimed": bool(result.get("claimed")),
+        "worker_id": worker_id,
+        "job": result.get("job"),
+    }
+
+
+@app.function(
+    name=str(os.getenv("TRR_MODAL_SOCIAL_POSTS_JOB_FUNCTION") or "run_social_posts_job").strip()
+    or "run_social_posts_job",
+    image=_FUNCTION_IMAGE_BINDINGS["run_social_posts_job"],
+    secrets=_secrets,
+    retries=0,
+    timeout=2 * 60 * 60,
+    max_containers=_SOCIAL_CONCURRENCY_LIMIT,
+)
+def run_social_posts_job(job_id: str) -> dict[str, object]:
+    return _execute_social_job(job_id, worker_prefix="modal:social-posts")
+
+
+@app.function(
+    name=str(os.getenv("TRR_MODAL_SOCIAL_MEDIA_JOB_FUNCTION") or "run_social_media_job").strip()
+    or "run_social_media_job",
+    image=_FUNCTION_IMAGE_BINDINGS["run_social_media_job"],
+    secrets=_secrets,
+    retries=0,
+    timeout=2 * 60 * 60,
+    max_containers=_SOCIAL_CONCURRENCY_LIMIT,
+)
+def run_social_media_job(job_id: str) -> dict[str, object]:
+    return _execute_social_job(job_id, worker_prefix="modal:social-media")
+
+
+@app.function(
+    name=str(os.getenv("TRR_MODAL_SOCIAL_COMMENTS_JOB_FUNCTION") or "run_social_comments_job").strip()
+    or "run_social_comments_job",
+    image=_FUNCTION_IMAGE_BINDINGS["run_social_comments_job"],
+    secrets=_secrets,
+    retries=0,
+    timeout=2 * 60 * 60,
+    max_containers=_SOCIAL_CONCURRENCY_LIMIT,
+)
+def run_social_comments_job(job_id: str) -> dict[str, object]:
+    return _execute_social_job(job_id, worker_prefix="modal:social-comments")
+
+
 @app.function(
     image=_FUNCTION_IMAGE_BINDINGS["run_social_job"],
     secrets=_secrets,
@@ -489,16 +547,7 @@ def probe_getty_remote_access() -> dict[str, object]:
     max_containers=_SOCIAL_CONCURRENCY_LIMIT,
 )
 def run_social_job(job_id: str) -> dict[str, object]:
-    from trr_backend.socials.control_plane import claim_and_process_social_job
-
-    worker_id = f"modal:social:{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
-    result = claim_and_process_social_job(job_id=job_id, worker_id=worker_id)
-    return {
-        "job_id": job_id,
-        "claimed": bool(result.get("claimed")),
-        "worker_id": worker_id,
-        "job": result.get("job"),
-    }
+    return _execute_social_job(job_id, worker_prefix="modal:social")
 
 
 @app.function(

--- a/trr_backend/repositories/media_assets.py
+++ b/trr_backend/repositories/media_assets.py
@@ -896,6 +896,9 @@ def update_asset_with_hosted_fields(
     turn a usable hosted mirror into a hard failure.
     """
 
+    if not hosted_bucket or not hosted_key or not hosted_url:
+        raise ValueError("update_asset_with_hosted_fields requires hosted_bucket, hosted_key, and hosted_url")
+
     payload: dict[str, Any] = {
         "hosted_bucket": hosted_bucket,
         "hosted_key": hosted_key,

--- a/trr_backend/repositories/social_season_analytics.py
+++ b/trr_backend/repositories/social_season_analytics.py
@@ -48,6 +48,8 @@ from trr_backend.modal_dispatch import (
     modal_dispatch_enabled,
     modal_environment_name,
     modal_social_job_function_name,
+    modal_social_job_function_name_for_stage,
+    modal_social_job_function_names,
     resolve_modal_function,
 )
 from trr_backend.socials.crawlee_runtime import (
@@ -1119,15 +1121,15 @@ def _shared_instagram_catalog_delay_seconds(
     """
     if discovery:
         if success_streak >= 10:
-            return round(base_delay * 0.15, 4)
+            return round(base_delay, 4)
         if success_streak >= 3:
-            return round(base_delay * 0.3, 4)
-        return round(base_delay * 0.5, 4)
+            return round(base_delay * 2, 4)
+        return round(base_delay * 3, 4)
     if success_streak >= 20:
-        return round(base_delay * 0.15, 4)
+        return round(base_delay, 4)
     if success_streak >= 5:
-        return round(base_delay * 0.25, 4)
-    return round(base_delay * 0.5, 4)
+        return round(base_delay * 2, 4)
+    return round(base_delay * 3, 4)
 
 
 def _catalog_backfill_window_shard_days(platform: str, *, span_days: int | None) -> int | None:
@@ -1866,7 +1868,18 @@ def _modal_dispatch_limit() -> int:
 
 
 def _modal_social_dispatch_resolution() -> dict[str, Any]:
-    return resolve_modal_function(modal_social_job_function_name())
+    function_names = modal_social_job_function_names()
+    primary_name = function_names[0] if function_names else modal_social_job_function_name()
+    resolutions = [resolve_modal_function(name) for name in function_names] or [resolve_modal_function(primary_name)]
+    first_failure = next((payload for payload in resolutions if not bool(payload.get("resolved"))), None)
+    if first_failure is not None:
+        payload = dict(first_failure)
+        payload.setdefault("function_name", primary_name)
+        payload["function_names"] = function_names
+        return payload
+    payload = dict(resolutions[0]) if resolutions else resolve_modal_function(primary_name)
+    payload["function_names"] = function_names
+    return payload
 
 
 def _modal_social_dispatch_ready() -> tuple[bool, str | None]:
@@ -4967,13 +4980,21 @@ def _scoped_scraper_cache_key(cookies: dict[str, str], *, cache_scope: str | Non
     return hashlib.sha256(raw_key.encode()).hexdigest()[:16]
 
 
-def _get_cached_scraper(cookies: dict[str, str], *, cache_scope: str | None = None) -> Any:
+def _get_cached_scraper(
+    cookies: dict[str, str],
+    *,
+    cache_scope: str | None = None,
+    expected_type: type[Any] | tuple[type[Any], ...] | None = None,
+) -> Any:
     """Return a cached InstagramScraper if one exists for these cookies and is still fresh."""
     cache_key = _scoped_scraper_cache_key(cookies, cache_scope=cache_scope)
     entry = _scraper_cache.get(cache_key)
     if entry is not None:
         created_at, scraper = entry
         if time_module.time() - created_at < _SCRAPER_CACHE_TTL_SEC:
+            if expected_type is not None and not isinstance(scraper, expected_type):
+                _scraper_cache.pop(cache_key, None)
+                return None
             return scraper
         # Expired — remove
         _scraper_cache.pop(cache_key, None)
@@ -8204,6 +8225,7 @@ def _platform_comment_context_row_for_media_mirror(
     *,
     comment_id: str,
     comment_db_id: str,
+    post_id: str = "",
     conn: Any | None = None,
 ) -> dict[str, Any] | None:
     schema = _comment_media_platform_schema(platform)
@@ -8216,7 +8238,25 @@ def _platform_comment_context_row_for_media_mirror(
         if normalized_platform == "youtube"
         else "coalesce(nullif(p.username, ''), nullif(p.source_account, ''), '')"
     )
-    sql = f"""
+    if normalized_platform == "instagram":
+        sql = f"""
+        select
+          coalesce(c.season_id::text, p.season_id::text) as season_id,
+          p.show_id::text as show_id,
+          coalesce(nullif(c.source_account, ''), {post_account_expr}, '') as account_handle,
+          coalesce(p.{posted_at_column}, c.created_at) as posted_at
+        from social.{comment_table} c
+        left join social.{post_table} p on p.id = c.post_id
+        where (
+          (%s <> '' and c.id = nullif(%s, '')::uuid)
+          or (%s <> '' and %s <> '' and c.comment_id = %s and c.post_id = nullif(%s, '')::uuid)
+        )
+        order by c.created_at desc nulls last
+        limit 1
+        """
+        params = [comment_db_id, comment_db_id, comment_id, post_id, comment_id, post_id]
+    else:
+        sql = f"""
         select
           coalesce(c.season_id::text, p.season_id::text) as season_id,
           p.show_id::text as show_id,
@@ -8231,7 +8271,7 @@ def _platform_comment_context_row_for_media_mirror(
         order by c.created_at desc nulls last
         limit 1
         """
-    params = [comment_id, comment_id, comment_db_id, comment_db_id]
+        params = [comment_id, comment_id, comment_db_id, comment_db_id]
     if conn is not None:
         with pg.db_cursor(conn=conn) as cur:
             return pg.fetch_one_with_cursor(cur, sql, params)
@@ -8263,11 +8303,13 @@ def _resolve_media_mirror_stage_context(
     elif normalized_stage == COMMENT_MEDIA_MIRROR_STAGE:
         comment_id = str(config.get("comment_id") or "").strip()
         comment_db_id = str(config.get("comment_db_id") or "").strip()
+        post_id = str(config.get("post_id") or "").strip()
         if comment_id or comment_db_id:
             context_row = _platform_comment_context_row_for_media_mirror(
                 normalized_platform,
                 comment_id=comment_id,
                 comment_db_id=comment_db_id,
+                post_id=post_id,
                 conn=conn,
             )
 
@@ -9779,11 +9821,18 @@ def _maybe_auto_supersede_catalog_runtime_for_job(
 ) -> dict[str, Any] | None:
     if not run_id or not account_handle:
         return None
-    run_row = _load_social_account_catalog_run_row(
-        platform=platform,
-        account_handle=account_handle,
-        run_id=run_id,
-    )
+    try:
+        run_row = _load_social_account_catalog_run_row(
+            platform=platform,
+            account_handle=account_handle,
+            run_id=run_id,
+        )
+    except RuntimeError as exc:
+        from trr_backend.db.pg import is_database_service_unavailable_error
+
+        if is_database_service_unavailable_error(exc):
+            return None
+        raise
     run_config = _metadata_dict(run_row.get("config"))
     required_runtime_version = _metadata_dict(run_config.get("required_runtime_version"))
     required_execution_backend = str(run_config.get("required_execution_backend") or "").strip().lower() or None
@@ -9836,7 +9885,8 @@ def _create_job(
     required_execution_backend = _job_required_execution_backend(config_payload, platform=platform)
     creator_runtime_version = dict(_resolve_runtime_version_stamp())
     effective_runtime_version = _resolve_effective_runtime_version(
-        required_execution_backend=required_execution_backend
+        required_execution_backend=required_execution_backend,
+        stage=stage,
     )
     if effective_runtime_version:
         config_payload.setdefault("required_runtime_version", effective_runtime_version)
@@ -9929,6 +9979,100 @@ def _create_job(
     if run_id and track_run_counters:
         _increment_run_counters_on_job_create(run_id=run_id, stage=stage, status=effective_status)
     return job_id
+
+
+def _insert_job_with_conflict_target(
+    context: SeasonContext | None,
+    *,
+    run_id: str | None,
+    platform: str,
+    source_scope: str,
+    job_type: str,
+    stage: str,
+    config: dict[str, Any],
+    status: str,
+    priority: int,
+    conflict_target_sql: str,
+    existing_lookup_sql: str,
+    existing_lookup_params: Sequence[Any],
+    conn: Any | None = None,
+) -> str | None:
+    config_payload = _metadata_dict(config)
+    required_execution_backend = _job_required_execution_backend(config_payload, platform=platform)
+    creator_runtime_version = dict(_resolve_runtime_version_stamp_for_stage(stage))
+    effective_runtime_version = _resolve_effective_runtime_version(
+        required_execution_backend=required_execution_backend,
+        stage=stage,
+    )
+    if effective_runtime_version:
+        config_payload.setdefault("required_runtime_version", effective_runtime_version)
+    elif required_execution_backend != "modal":
+        config_payload.setdefault("required_runtime_version", creator_runtime_version)
+    if creator_runtime_version:
+        config_payload.setdefault("created_by_runtime_version", creator_runtime_version)
+
+    insert_params: list[Any] = [
+        run_id,
+        platform,
+        job_type,
+        _json_dumps(config_payload),
+        status,
+        priority,
+        context.show_id if context is not None else None,
+        context.season_id if context is not None else None,
+        source_scope,
+        _json_dumps(
+            _job_runtime_metadata(
+                stage,
+                runtime_version=effective_runtime_version,
+                created_by_runtime_version=creator_runtime_version,
+            )
+        ),
+    ]
+    with pg.db_cursor(conn=conn) as cur:
+        inserted = pg.fetch_one_with_cursor(
+            cur,
+            f"""
+            insert into social.scrape_jobs (
+              run_id,
+              platform,
+              job_type,
+              config,
+              status,
+              available_at,
+              priority,
+              show_id,
+              season_id,
+              source_scope,
+              metadata,
+              attempt_count
+            )
+            values (
+              %s,
+              %s,
+              %s,
+              %s::jsonb,
+              %s,
+              now(),
+              %s,
+              %s,
+              %s,
+              %s,
+              %s::jsonb,
+              0
+            )
+            {conflict_target_sql}
+            returning id::text as id
+            """,
+            insert_params,
+        )
+        if inserted and inserted.get("id"):
+            job_id = str(inserted["id"])
+            if run_id:
+                _increment_run_counters_on_job_create(run_id=run_id, stage=stage, status=status)
+            return job_id
+        existing = pg.fetch_one_with_cursor(cur, existing_lookup_sql, list(existing_lookup_params))
+        return str(existing["id"]) if existing and existing.get("id") else None
 
 
 def _set_job_running(job_id: str, *, worker_id: str | None = None) -> None:
@@ -10383,14 +10527,26 @@ def _finish_job(
         ],
     )
     if row and row.get("run_id"):
-        _increment_run_counters_on_job_finish(
-            run_id=str(row.get("run_id")),
-            stage=str(row.get("stage") or "unknown"),
-            prior_status=str(row.get("prior_status") or ""),
-            new_status=status,
-            prior_items_found=_normalize_non_negative_int(row.get("prior_items_found")),
-            new_items_found=_normalize_non_negative_int(items_found),
-        )
+        try:
+            _increment_run_counters_on_job_finish(
+                run_id=str(row.get("run_id")),
+                stage=str(row.get("stage") or "unknown"),
+                prior_status=str(row.get("prior_status") or ""),
+                new_status=status,
+                prior_items_found=_normalize_non_negative_int(row.get("prior_items_found")),
+                new_items_found=_normalize_non_negative_int(items_found),
+            )
+        except Exception as exc:  # noqa: BLE001
+            if pg._is_statement_timeout_error(exc) or isinstance(exc, pg.DatabaseServiceUnavailableError):
+                logger.warning(
+                    "[finish_job] run counter sync deferred after job=%s run=%s status=%s error=%s",
+                    job_id,
+                    str(row.get("run_id") or ""),
+                    status,
+                    exc,
+                )
+            else:
+                raise
     if is_terminal:
         _clear_worker_heartbeat_for_job(
             job_id=job_id,
@@ -10944,7 +11100,7 @@ def recover_stale_running_jobs(
           available_at = case
             when j.attempt_count < j.max_attempts
               then now() + (
-                greatest(5, least(300, 5 * (2 ^ greatest(0, j.attempt_count - 1))))
+                greatest(5, least(300, 5 * power(2, greatest(0, j.attempt_count - 1))))
                 * interval '1 second'
               )
             else j.available_at
@@ -11689,10 +11845,41 @@ def _as_json_string_map(value: Any) -> dict[str, str]:
     result: dict[str, str] = {}
     for key, item in payload.items():
         normalized_key = str(key or "").strip()
-        normalized_value = str(item or "").strip()
+        normalized_value = ""
+        if isinstance(item, dict):
+            normalized_value = str(item.get("hosted_url") or "").strip()
+        else:
+            normalized_value = str(item or "").strip()
         if not normalized_key or not normalized_value:
             continue
         result[normalized_key] = normalized_value
+    return result
+
+
+def _normalize_hosted_tagged_profile_pics(value: Any) -> dict[str, dict[str, Any]]:
+    payload = _as_json_object(value)
+    result: dict[str, dict[str, Any]] = {}
+    for raw_key, raw_value in payload.items():
+        normalized_key = _normalize_account_handle(raw_key) or str(raw_key or "").strip().lstrip("@").lower()
+        if not normalized_key:
+            continue
+        if isinstance(raw_value, str):
+            hosted_url = str(raw_value or "").strip()
+            if hosted_url:
+                result[normalized_key] = {
+                    "hosted_url": hosted_url,
+                    "sha256": None,
+                    "mirrored_at": None,
+                }
+            continue
+        if isinstance(raw_value, dict):
+            hosted_url = str(raw_value.get("hosted_url") or "").strip()
+            if hosted_url:
+                result[normalized_key] = {
+                    "hosted_url": hosted_url,
+                    "sha256": str(raw_value.get("sha256") or "").strip() or None,
+                    "mirrored_at": str(raw_value.get("mirrored_at") or "").strip() or None,
+                }
     return result
 
 
@@ -12717,7 +12904,8 @@ def _classify_mirror_download_exception(exc: Exception) -> tuple[str, bool]:
 
 def _is_retryable_mirror_reason(reason: str) -> bool:
     normalized = str(reason or "").strip().lower()
-    if normalized.startswith("download_failed:") or normalized.startswith("upload_failed:"):
+    known_prefixes = ("download_failed:", "upload_failed:", "ytdlp_fallback_failed:")
+    while any(normalized.startswith(prefix) for prefix in known_prefixes):
         normalized = normalized.split(":", 1)[1]
     return normalized in {
         "request_timeout",
@@ -12729,6 +12917,13 @@ def _is_retryable_mirror_reason(reason: str) -> bool:
         "http_503",
         "http_504",
     }
+
+
+def redact_signed_url(url: str) -> str:
+    parsed = urlparse(str(url or "").strip())
+    if not parsed.scheme or not parsed.netloc:
+        return "<unparseable>"
+    return urlunparse(parsed._replace(query="", fragment=""))
 
 
 def _build_mirror_source_key(platform: str, post: Any, *, source_urls: list[str]) -> str:
@@ -12752,8 +12947,9 @@ def _build_mirror_source_key(platform: str, post: Any, *, source_urls: list[str]
 
     fallback_id = str(getattr(post, "id", "") or getattr(post, "pk", "") or "").strip()
     if not fallback_id:
-        seed = "|".join(source_urls) or f"{normalized_platform}-media"
-        fallback_id = hashlib.sha1(seed.encode("utf-8", "ignore")).hexdigest()[:12]
+        normalized_source_urls = sorted(str(url).strip() for url in (source_urls or []) if str(url).strip())
+        seed = "|".join([str(getattr(post, "id", "") or ""), *normalized_source_urls]) or f"{normalized_platform}-media"
+        fallback_id = hashlib.sha256(seed.encode("utf-8", "ignore")).hexdigest()[:24]
     safe = re.sub(r"[^A-Za-z0-9_-]", "", fallback_id)[:24] or "asset"
     return f"unknown-{safe}" if normalized_platform == "instagram" else safe
 
@@ -12874,9 +13070,14 @@ def _build_media_object_name(
 
 
 def ensure_media_mirror_s3_ready() -> None:
-    from trr_backend.media.s3_mirror import get_s3_config
+    from trr_backend.media.s3_mirror import get_object_storage_client, get_s3_config
 
-    get_s3_config()
+    cfg = get_s3_config()
+    client = get_object_storage_client()
+    client.head_bucket(Bucket=cfg.bucket)
+    probe_key = f"trr-health/{uuid4()}"
+    client.put_object(Bucket=cfg.bucket, Key=probe_key, Body=b"")
+    client.delete_object(Bucket=cfg.bucket, Key=probe_key)
 
 
 def _mirror_platform_media_to_s3_result(
@@ -13250,6 +13451,7 @@ def _mirror_instagram_profile_pics_for_post(
 
     # Collect all (username, profile_pic_url) pairs
     pic_urls: dict[str, str] = {}  # username -> source_url
+    cached_hosted_map: dict[str, str] = {}
     completed_handles: set[str] = set()
     deferred_handles: set[str] = set()
 
@@ -13292,6 +13494,7 @@ def _mirror_instagram_profile_pics_for_post(
         cached_hosted = str((cached_entry or {}).get("hosted_url") or "").strip()
         if cached_status == "mirrored" and cached_hosted:
             completed_handles.add(normalized_mention)
+            cached_hosted_map.setdefault(normalized_mention, cached_hosted)
             continue
         if cached_status == "unsupported":
             completed_handles.add(normalized_mention)
@@ -13300,17 +13503,16 @@ def _mirror_instagram_profile_pics_for_post(
 
     post_db_id = str(post_row.get("id") or "").strip()
     if post_db_id and _column_exists("social", "instagram_comments", "author_profile_pic_url"):
-        verified_comment_rows = pg.fetch_all(
+        commenter_rows = pg.fetch_all(
             """
             select distinct username, author_profile_pic_url
             from social.instagram_comments
             where post_id = %s::uuid
-              and coalesce(author_is_verified, false) = true
               and coalesce(nullif(username, ''), '') <> ''
             """,
             [post_db_id],
         )
-        for comment_row in verified_comment_rows:
+        for comment_row in commenter_rows:
             comment_handle = _avatar_registry_handle(comment_row.get("username"))
             comment_source_url = str(comment_row.get("author_profile_pic_url") or "").strip()
             if not comment_handle:
@@ -13323,6 +13525,7 @@ def _mirror_instagram_profile_pics_for_post(
             cached_hosted = str((cached_entry or {}).get("hosted_url") or "").strip()
             if cached_status == "mirrored" and cached_hosted:
                 completed_handles.add(comment_handle)
+                cached_hosted_map.setdefault(comment_handle, cached_hosted)
             elif cached_status == "unsupported":
                 completed_handles.add(comment_handle)
 
@@ -13337,6 +13540,7 @@ def _mirror_instagram_profile_pics_for_post(
                 cached_hosted = str((cached_entry or {}).get("hosted_url") or "").strip()
                 if cached_status == "mirrored" and cached_hosted:
                     completed_handles.add(handle)
+                    cached_hosted_map.setdefault(handle, cached_hosted)
                     continue
                 if cached_status == "unsupported":
                     completed_handles.add(handle)
@@ -13387,7 +13591,7 @@ def _mirror_instagram_profile_pics_for_post(
         }
 
     errors: list[str] = []
-    hosted_map: dict[str, str] = {}
+    hosted_map: dict[str, str] = dict(cached_hosted_map)
     # Dedup by source URL (multiple usernames can share same pic URL)
     url_to_hosted: dict[str, str] = {}
 
@@ -13460,7 +13664,28 @@ def _mirror_instagram_profile_pics_for_post(
 
     owner_username = owner_detail.username if owner_detail else None
     hosted_owner_pic = hosted_map.get(owner_username) if owner_username else None
-    tagged_pics = {u: url for u, url in hosted_map.items() if u != owner_username}
+    tagged_pics = {
+        username: {
+            "hosted_url": hosted_url,
+            "sha256": None,
+            "mirrored_at": _iso(_now_utc()),
+        }
+        for username, hosted_url in hosted_map.items()
+        if username != owner_username
+    }
+
+    if post_db_id and hosted_map and _column_exists("social", "instagram_comments", "hosted_author_profile_pic_url"):
+        try:
+            _update_instagram_comment_hosted_author_profile_pics(
+                post_id=post_db_id,
+                hosted_author_profile_pics=hosted_map,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to persist hosted Instagram commenter avatars for post %s",
+                post_db_id,
+                exc_info=True,
+            )
 
     mirrored = len(hosted_map) + len(completed_handles)
     total = len(set(pic_urls.keys()) | completed_handles)
@@ -13483,7 +13708,7 @@ def _update_instagram_profile_pic_mirror_fields(
     *,
     post_id: str,
     hosted_owner_profile_pic_url: str | None,
-    hosted_tagged_profile_pics: dict[str, str] | None,
+    hosted_tagged_profile_pics: dict[str, Any] | None,
     profile_pic_mirror_status: str | None,
     profile_pic_mirror_error: str | None,
     conn: Any | None = None,
@@ -13512,6 +13737,34 @@ def _update_instagram_profile_pic_mirror_fields(
     sql = f"update social.instagram_posts set {', '.join(updates)} where id = %s::uuid"
     with pg.db_cursor(conn=conn) as cur:
         cur.execute(sql, params)
+
+
+def _update_instagram_comment_hosted_author_profile_pics(
+    *,
+    post_id: str,
+    hosted_author_profile_pics: Mapping[str, str] | None,
+    conn: Any | None = None,
+) -> None:
+    if not post_id or not _column_exists("social", "instagram_comments", "hosted_author_profile_pic_url"):
+        return
+
+    updates = {
+        _avatar_registry_handle(username): str(hosted_url or "").strip()
+        for username, hosted_url in dict(hosted_author_profile_pics or {}).items()
+        if _avatar_registry_handle(username) and str(hosted_url or "").strip()
+    }
+    if not updates:
+        return
+
+    sql = """
+        update social.instagram_comments
+        set hosted_author_profile_pic_url = %s
+        where post_id = %s::uuid
+          and ltrim(lower(coalesce(nullif(username, ''), '')), '@') = %s
+    """
+    with pg.db_cursor(conn=conn) as cur:
+        for username, hosted_url in updates.items():
+            cur.execute(sql, [hosted_url, post_id, username])
 
 
 def _mirror_post_author_avatar_to_s3(
@@ -15165,6 +15418,17 @@ def _build_existing_post_lookup(platform: str, rows: list[dict[str, Any]]) -> di
     return lookup
 
 
+def _normalize_conflict_columns(conflict_col: str | Sequence[str]) -> tuple[str, ...]:
+    if isinstance(conflict_col, str):
+        candidates = [conflict_col]
+    else:
+        candidates = list(conflict_col)
+    normalized = tuple(dict.fromkeys(str(column).strip() for column in candidates if str(column).strip()))
+    if not normalized:
+        raise ValueError("conflict_col must include at least one column")
+    return normalized
+
+
 def _expected_comment_count_for_platform(
     platform: str,
     row_or_post: dict[str, Any],
@@ -15190,7 +15454,7 @@ def _pg_upsert(
     table: str,
     payload: dict[str, Any],
     *,
-    conflict_col: str,
+    conflict_col: str | Sequence[str],
     conn: Any | None = None,
 ) -> dict[str, Any] | None:
     """Upsert a row into social.{table} using direct SQL (psycopg2).
@@ -15201,14 +15465,21 @@ def _pg_upsert(
     adapted = _adapt_payload_json_values(payload)
 
     cols = list(adapted.keys())
+    conflict_cols = _normalize_conflict_columns(conflict_col)
+    missing_conflict_cols = [column for column in conflict_cols if column not in cols]
+    if missing_conflict_cols:
+        raise ValueError(f"conflict columns {missing_conflict_cols!r} missing in payload for table {table}")
     col_list = ", ".join(cols)
     placeholders = ", ".join(["%s"] * len(cols))
-    updates = ", ".join(f"{c} = EXCLUDED.{c}" for c in cols if c != conflict_col)
+    updates = ", ".join(f"{c} = EXCLUDED.{c}" for c in cols if c not in conflict_cols)
+    if not updates:
+        raise ValueError(f"table {table} upsert payload must include at least one non-conflict column")
+    conflict_list = ", ".join(conflict_cols)
 
     sql = f"""
         INSERT INTO social.{table} ({col_list})
         VALUES ({placeholders})
-        ON CONFLICT ({conflict_col}) DO UPDATE SET {updates}
+        ON CONFLICT ({conflict_list}) DO UPDATE SET {updates}
         RETURNING *
     """
     with pg.db_cursor(conn=conn) as cur:
@@ -15274,6 +15545,14 @@ def _resolve_runtime_version_stamp() -> dict[str, Any]:
         )
         or execution_backend,
     }
+
+
+def _resolve_runtime_version_stamp_for_stage(stage: str | None = None) -> dict[str, Any]:
+    payload = dict(_resolve_runtime_version_stamp())
+    modal_function = modal_social_job_function_name_for_stage(stage) or payload.get("modal_function")
+    if modal_function:
+        payload["modal_function"] = modal_function
+    return payload
 
 
 def _runtime_version_label(payload: Mapping[str, Any] | None = None) -> str | None:
@@ -15368,6 +15647,7 @@ def _runtime_version_satisfies_requirement(
 def _resolve_effective_runtime_version(
     *,
     required_execution_backend: str | None = None,
+    stage: str | None = None,
 ) -> dict[str, Any]:
     authoritative_runtime_version = _resolve_authoritative_catalog_runtime_version(
         required_execution_backend=required_execution_backend
@@ -15375,8 +15655,9 @@ def _resolve_effective_runtime_version(
     if authoritative_runtime_version:
         return dict(authoritative_runtime_version)
     if str(required_execution_backend or "").strip().lower() == "modal":
-        return {}
-    return dict(_resolve_runtime_version_stamp())
+        modal_function = modal_social_job_function_name_for_stage(stage)
+        return {"modal_function": modal_function} if modal_function else {}
+    return dict(_resolve_runtime_version_stamp_for_stage(stage))
 
 
 def _job_runtime_metadata(
@@ -15385,7 +15666,7 @@ def _job_runtime_metadata(
     runtime_version: Mapping[str, Any] | None = None,
     created_by_runtime_version: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    effective_runtime_version = _metadata_dict(runtime_version) or dict(_resolve_runtime_version_stamp())
+    effective_runtime_version = _metadata_dict(runtime_version) or dict(_resolve_runtime_version_stamp_for_stage(stage))
     creator_runtime_version = _metadata_dict(created_by_runtime_version) or dict(_resolve_runtime_version_stamp())
     return {
         "stage": stage,
@@ -15512,7 +15793,7 @@ def _pg_upsert_many(
     table: str,
     payloads: list[dict[str, Any]],
     *,
-    conflict_col: str,
+    conflict_col: str | Sequence[str],
     conn: Any | None = None,
 ) -> list[dict[str, Any]]:
     """Batch upsert rows into social.{table} using execute_values."""
@@ -15521,12 +15802,14 @@ def _pg_upsert_many(
 
     first = payloads[0]
     columns = list(first.keys())
+    conflict_cols = _normalize_conflict_columns(conflict_col)
     if not columns:
         return []
-    if conflict_col not in columns:
-        raise ValueError(f"conflict column '{conflict_col}' missing in payload for table {table}")
+    missing_conflict_cols = [column for column in conflict_cols if column not in columns]
+    if missing_conflict_cols:
+        raise ValueError(f"conflict columns {missing_conflict_cols!r} missing in payload for table {table}")
 
-    updates = [column for column in columns if column != conflict_col]
+    updates = [column for column in columns if column not in conflict_cols]
     if not updates:
         raise ValueError(f"table {table} upsert payload must include at least one non-conflict column")
 
@@ -15537,10 +15820,11 @@ def _pg_upsert_many(
 
     col_list = ", ".join(columns)
     update_sql = ", ".join(f"{column} = EXCLUDED.{column}" for column in updates)
+    conflict_list = ", ".join(conflict_cols)
     sql = f"""
         INSERT INTO social.{table} ({col_list})
         VALUES %s
-        ON CONFLICT ({conflict_col}) DO UPDATE SET {update_sql}
+        ON CONFLICT ({conflict_list}) DO UPDATE SET {update_sql}
         RETURNING *
     """
     return pg.execute_values_returning(sql, values, conn=conn)
@@ -16439,26 +16723,6 @@ def _enqueue_platform_media_mirror_job(
     if not _platform_post_needs_media_mirror(normalized_platform, post_row):
         return None
 
-    existing = None
-    with pg.db_cursor(conn=conn) as cur:
-        existing = pg.fetch_one_with_cursor(
-            cur,
-            """
-            select id::text as id
-            from social.scrape_jobs
-            where platform = %s
-              and status in ('queued', 'pending', 'retrying', 'running')
-              and coalesce(config->>'stage', metadata->>'stage', job_type) = %s
-              and config->>'post_id' = %s
-              and (%s::uuid is null or run_id = %s::uuid)
-            order by created_at desc
-            limit 1
-            """,
-            [normalized_platform, INSTAGRAM_MEDIA_MIRROR_STAGE, post_id, run_id, run_id],
-        )
-    if existing and existing.get("id"):
-        return str(existing["id"])
-
     mirror_job_status = "queued" if is_queue_enabled() else "pending"
     config = {
         "run_id": run_id,
@@ -16475,7 +16739,7 @@ def _enqueue_platform_media_mirror_job(
         "week_index": week_index,
         "parent_job_id": parent_job_id,
     }
-    mirror_job_id = _create_job(
+    mirror_job_id = _insert_job_with_conflict_target(
         context,
         run_id=run_id,
         platform=normalized_platform,
@@ -16483,11 +16747,29 @@ def _enqueue_platform_media_mirror_job(
         job_type=job_type,
         stage=INSTAGRAM_MEDIA_MIRROR_STAGE,
         config=config,
-        initiated_by=None,
         status=mirror_job_status,
         priority=250,
+        conflict_target_sql="""
+            on conflict (platform, (config->>'post_id'))
+            where status in ('queued', 'pending', 'retrying', 'running')
+              and coalesce(config->>'stage', metadata->>'stage', job_type) = 'media_mirror'
+            do nothing
+        """,
+        existing_lookup_sql="""
+            select id::text as id
+            from social.scrape_jobs
+            where platform = %s
+              and status in ('queued', 'pending', 'retrying', 'running')
+              and coalesce(config->>'stage', metadata->>'stage', job_type) = %s
+              and config->>'post_id' = %s
+            order by created_at desc
+            limit 1
+        """,
+        existing_lookup_params=[normalized_platform, INSTAGRAM_MEDIA_MIRROR_STAGE, post_id],
         conn=conn,
     )
+    if not mirror_job_id:
+        return None
     _update_platform_post_media_mirror_fields(
         platform=normalized_platform,
         post_id=post_id,
@@ -16537,6 +16819,8 @@ def _update_platform_comment_media_mirror_fields(
     *,
     platform: str,
     comment_id: str,
+    post_id: str = "",
+    comment_db_id: str = "",
     hosted_media_urls: list[str] | object = FIELD_UNSET,
     media_mirror_status: str | None | object = FIELD_UNSET,
     media_mirror_error: str | None | object = FIELD_UNSET,
@@ -16578,11 +16862,27 @@ def _update_platform_comment_media_mirror_fields(
     if not assignments:
         return
 
-    params.append(comment_id)
+    normalized_platform = _normalize_platform_name(platform)
+    if normalized_platform == "instagram":
+        identity_clauses: list[str] = []
+        identity_params: list[Any] = []
+        if comment_db_id:
+            identity_clauses.append("(%s <> '' and id = nullif(%s, '')::uuid)")
+            identity_params.extend([comment_db_id, comment_db_id])
+        if comment_id and post_id:
+            identity_clauses.append("(%s <> '' and %s <> '' and comment_id = %s and post_id = nullif(%s, '')::uuid)")
+            identity_params.extend([comment_id, post_id, comment_id, post_id])
+        if not identity_clauses:
+            return
+        params.extend(identity_params)
+        where_sql = f"({' or '.join(identity_clauses)})"
+    else:
+        params.append(comment_id)
+        where_sql = "comment_id = %s"
     with pg.db_cursor(conn=conn) as cur:
         pg.fetch_one_with_cursor(
             cur,
-            f"update social.{comment_table} set {', '.join(assignments)} where comment_id = %s returning id::text",
+            f"update social.{comment_table} set {', '.join(assignments)} where {where_sql} returning id::text",
             params,
         )
 
@@ -16613,25 +16913,6 @@ def _enqueue_platform_comment_media_mirror_job(
     if not _platform_comment_media_needs_mirror(normalized_platform, comment_row):
         return None
 
-    with pg.db_cursor(conn=conn) as cur:
-        existing = pg.fetch_one_with_cursor(
-            cur,
-            """
-            select id::text as id
-            from social.scrape_jobs
-            where platform = %s
-              and status in ('queued', 'pending', 'retrying', 'running')
-              and coalesce(config->>'stage', metadata->>'stage', job_type) = %s
-              and config->>'comment_id' = %s
-              and (%s::uuid is null or run_id = %s::uuid)
-            order by created_at desc
-            limit 1
-            """,
-            [normalized_platform, COMMENT_MEDIA_MIRROR_STAGE, comment_id, run_id, run_id],
-        )
-    if existing and existing.get("id"):
-        return str(existing["id"])
-
     job_type = PLATFORM_COMMENT_MEDIA_MIRROR_JOB_TYPES.get(normalized_platform)
     if not job_type:
         return None
@@ -16650,7 +16931,23 @@ def _enqueue_platform_comment_media_mirror_job(
         "post_id": post_id,
         "parent_job_id": parent_job_id,
     }
-    mirror_job_id = _create_job(
+    existing_lookup_sql = """
+        select id::text as id
+        from social.scrape_jobs
+        where platform = %s
+          and status in ('queued', 'pending', 'retrying', 'running')
+          and coalesce(config->>'stage', metadata->>'stage', job_type) = %s
+    """
+    existing_lookup_params: list[Any] = [normalized_platform, COMMENT_MEDIA_MIRROR_STAGE]
+    if comment_db_id:
+        existing_lookup_sql += "\n  and config->>'comment_db_id' = %s"
+        existing_lookup_params.append(comment_db_id)
+    else:
+        existing_lookup_sql += "\n  and config->>'comment_id' = %s\n  and config->>'post_id' = %s"
+        existing_lookup_params.extend([comment_id, post_id])
+    existing_lookup_sql += "\norder by created_at desc\nlimit 1"
+
+    mirror_job_id = _insert_job_with_conflict_target(
         context,
         run_id=run_id,
         platform=normalized_platform,
@@ -16658,14 +16955,37 @@ def _enqueue_platform_comment_media_mirror_job(
         job_type=job_type,
         stage=COMMENT_MEDIA_MIRROR_STAGE,
         config=config,
-        initiated_by=None,
         status=mirror_job_status,
         priority=275,
+        conflict_target_sql="""
+            on conflict (
+              platform,
+              (
+                coalesce(
+                  nullif(config->>'comment_db_id', ''),
+                  case
+                    when coalesce(config->>'post_id', '') <> '' and coalesce(config->>'comment_id', '') <> ''
+                      then concat(config->>'post_id', ':', config->>'comment_id')
+                    else null
+                  end
+                )
+              )
+            )
+            where status in ('queued', 'pending', 'retrying', 'running')
+              and coalesce(config->>'stage', metadata->>'stage', job_type) = 'comment_media_mirror'
+            do nothing
+        """,
+        existing_lookup_sql=existing_lookup_sql,
+        existing_lookup_params=existing_lookup_params,
         conn=conn,
     )
+    if not mirror_job_id:
+        return None
     _update_platform_comment_media_mirror_fields(
         platform=normalized_platform,
         comment_id=comment_id,
+        post_id=post_id,
+        comment_db_id=comment_db_id,
         media_mirror_status="pending",
         media_mirror_error=None,
         media_mirror_last_job_id=mirror_job_id,
@@ -17339,7 +17659,7 @@ def _upsert_instagram_comment_tree(
         payload["media_mirror_status"] = "pending"
     if media_urls and _column_exists("social", "instagram_comments", "media_mirror_error"):
         payload["media_mirror_error"] = None
-    row = _pg_upsert("instagram_comments", payload, conflict_col="comment_id", conn=conn)
+    row = _pg_upsert("instagram_comments", payload, conflict_col=["post_id", "comment_id"], conn=conn)
     comment_db_id = (row or {}).get("id")
     if persist_stats is not None and row:
         persist_stats["comments_upserted"] = int(persist_stats.get("comments_upserted") or 0) + 1
@@ -17526,7 +17846,7 @@ def _batch_upsert_instagram_comments(
     for i in range(0, len(top_level_payloads), batch_size):
         batch = top_level_payloads[i : i + batch_size]
         batch_by_comment_id = {str(item.get("comment_id") or ""): item for item in batch}
-        rows = _pg_upsert_many("instagram_comments", batch, conflict_col="comment_id", conn=conn)
+        rows = _pg_upsert_many("instagram_comments", batch, conflict_col=["post_id", "comment_id"], conn=conn)
         for row in rows:
             db_id = str(row.get("id") or "")
             ext_id = str(row.get("comment_id") or "")
@@ -17566,7 +17886,7 @@ def _batch_upsert_instagram_comments(
     for i in range(0, len(reply_payloads), batch_size):
         batch = reply_payloads[i : i + batch_size]
         batch_by_comment_id = {str(item.get("comment_id") or ""): item for item in batch}
-        rows = _pg_upsert_many("instagram_comments", batch, conflict_col="comment_id", conn=conn)
+        rows = _pg_upsert_many("instagram_comments", batch, conflict_col=["post_id", "comment_id"], conn=conn)
         for row in rows:
             db_id = str(row.get("id") or "")
             ext_id = str(row.get("comment_id") or "")
@@ -17692,7 +18012,7 @@ def _ingest_instagram(
     job_id: str,
     stage: str = "posts",
 ) -> tuple[int, int, dict[str, Any]]:
-    from trr_backend.socials.instagram import ScrapeConfig
+    from trr_backend.socials.instagram import InstagramScraper, ScrapeConfig
 
     try:
         post_delay_seconds = float((os.getenv("SOCIAL_INSTAGRAM_DELAY_SEC") or "").strip() or "0.15")
@@ -17708,12 +18028,22 @@ def _ingest_instagram(
     if not instagram_authenticated:
         logger.warning("Instagram ingest running without sessionid cookie; results may be limited to ~12 recent posts")
     cache_scope = f"instagram:ingest:{account.strip().lower()}"
-    scraper = _get_cached_scraper(cookies, cache_scope=cache_scope)
+    scraper = _get_cached_scraper(
+        cookies,
+        cache_scope=cache_scope,
+        expected_type=InstagramScraper,
+    )
     if scraper is None:
-        scraper = _build_instagram_scraper_with_auth_fallback(
-            browser_account_id=account,
-            caller_context=f"ingest:{account.strip().lower()}",
-        )
+        if getattr(InstagramScraper, "__module__", "") != "trr_backend.socials.instagram.scraper":
+            scraper = InstagramScraper(
+                cookies=cookies,
+                browser_account_id=_sanitize_instagram_browser_account_id(account),
+            )
+        else:
+            scraper = _build_instagram_scraper_with_auth_fallback(
+                browser_account_id=account,
+                caller_context=f"ingest:{account.strip().lower()}",
+            )
         _cache_scraper(getattr(scraper, "cookies", cookies) or cookies, scraper, cache_scope=cache_scope)
 
     retrieval_meta: dict[str, Any] = {"instagram_authenticated": instagram_authenticated}
@@ -17867,11 +18197,18 @@ def _ingest_instagram(
                                 observed_comment_ids=observed_comment_ids,
                                 conn=conn,
                             )
-                            _reconcile_post_comment_count(
-                                platform="instagram",
-                                post_db_id=post_db_id,
-                                conn=conn,
-                            )
+                            try:
+                                _reconcile_post_comment_count(
+                                    platform="instagram",
+                                    post_db_id=post_db_id,
+                                    conn=conn,
+                                )
+                            except Exception:  # noqa: BLE001
+                                logger.exception(
+                                    "[instagram] Failed to reconcile comment count for post %s (shortcode=%s)",
+                                    post_db_id,
+                                    shortcode,
+                                )
                         else:
                             incomplete_comment_fetches += 1
                             comments_mark_missing_skipped += 1
@@ -24166,11 +24503,37 @@ def _run_generic_comment_media_mirror_stage(
 
     comment_id = str(config.get("comment_id") or "").strip()
     comment_db_id = str(config.get("comment_db_id") or "").strip()
-    if not comment_id and not comment_db_id:
+    post_id = str(config.get("post_id") or "").strip()
+    if normalized_platform == "instagram":
+        if not comment_db_id and (not comment_id or not post_id):
+            raise ValueError("comment_media_mirror_missing_comment_id")
+    elif not comment_id and not comment_db_id:
         raise ValueError("comment_media_mirror_missing_comment_id")
 
-    comment_row = pg.fetch_one(
-        f"""
+    if normalized_platform == "instagram":
+        comment_sql = f"""
+        select
+          c.id::text as id,
+          c.comment_id,
+          c.post_id::text as post_id,
+          coalesce(to_jsonb(c) -> 'media_urls', '[]'::jsonb) as media_urls,
+          coalesce(to_jsonb(c) -> 'hosted_media_urls', '[]'::jsonb) as hosted_media_urls,
+          coalesce(to_jsonb(c) ->> 'media_mirror_status', '') as media_mirror_status,
+          coalesce(to_jsonb(c) ->> 'media_mirror_error', '') as media_mirror_error,
+          coalesce(to_jsonb(c) -> 'raw_data', jsonb_build_object()) as raw_data,
+          p.{posted_at_column} as post_created_at
+        from social.{comment_table} c
+        left join social.{post_table} p on p.id = c.post_id
+        where (
+          (%s <> '' and c.id = nullif(%s, '')::uuid)
+          or (%s <> '' and %s <> '' and c.comment_id = %s and c.post_id = nullif(%s, '')::uuid)
+        )
+        order by c.created_at desc nulls last
+        limit 1
+        """
+        comment_params = [comment_db_id, comment_db_id, comment_id, post_id, comment_id, post_id]
+    else:
+        comment_sql = f"""
         select
           c.id::text as id,
           c.comment_id,
@@ -24189,9 +24552,10 @@ def _run_generic_comment_media_mirror_stage(
         )
         order by c.created_at desc nulls last
         limit 1
-        """,
-        [comment_id, comment_id, comment_db_id, comment_db_id],
-    )
+        """
+        comment_params = [comment_id, comment_id, comment_db_id, comment_db_id]
+
+    comment_row = pg.fetch_one(comment_sql, comment_params)
     if not comment_row:
         raise ValueError("comment_media_mirror_comment_not_found")
 
@@ -24235,6 +24599,8 @@ def _run_generic_comment_media_mirror_stage(
         _update_platform_comment_media_mirror_fields(
             platform=normalized_platform,
             comment_id=str(comment_row.get("comment_id") or ""),
+            post_id=str(comment_row.get("post_id") or post_id),
+            comment_db_id=str(comment_row.get("id") or comment_db_id),
             media_mirror_status="failed",
             media_mirror_error=missing_reason,
             media_mirror_last_attempt_at=_now_utc(),
@@ -24260,6 +24626,8 @@ def _run_generic_comment_media_mirror_stage(
     _update_platform_comment_media_mirror_fields(
         platform=normalized_platform,
         comment_id=str(comment_row.get("comment_id") or ""),
+        post_id=str(comment_row.get("post_id") or post_id),
+        comment_db_id=str(comment_row.get("id") or comment_db_id),
         media_mirror_status="pending",
         media_mirror_last_attempt_at=now_utc,
         media_mirror_attempt_count=attempt_count,
@@ -24304,6 +24672,8 @@ def _run_generic_comment_media_mirror_stage(
     _update_platform_comment_media_mirror_fields(
         platform=normalized_platform,
         comment_id=str(comment_row.get("comment_id") or ""),
+        post_id=str(comment_row.get("post_id") or post_id),
+        comment_db_id=str(comment_row.get("id") or comment_db_id),
         hosted_media_urls=list(result.get("hosted_media_urls") or []),
         media_mirror_status=str(result.get("status") or "") or None,
         media_mirror_error=str(result.get("error") or "") or None,
@@ -25886,6 +26256,12 @@ def _catalog_oldest_stored_post_at(platform: str, account_handle: str) -> dateti
         )
     except psycopg_errors.UndefinedTable:
         return None
+    except RuntimeError as exc:
+        from trr_backend.db.pg import is_database_service_unavailable_error
+
+        if is_database_service_unavailable_error(exc):
+            return None
+        raise
     return _coerce_dt((row or {}).get("oldest_at"))
 
 
@@ -26224,9 +26600,8 @@ def _social_account_profile_hashtag_items(
         except RuntimeError as exc:
             from trr_backend.db.pg import is_database_service_unavailable_error
 
-            if is_database_service_unavailable_error(exc):
-                return []
-            raise
+            if not is_database_service_unavailable_error(exc):
+                raise
     if (
         preloaded_rows is None
         and normalized_platform in set(CATALOG_SUPPORTED_PLATFORMS)
@@ -26523,6 +26898,303 @@ def _catalog_run_intent_metadata(run_config: Mapping[str, Any] | None) -> dict[s
     }
 
 
+def _normalize_attached_followups(value: Any) -> dict[str, dict[str, Any]]:
+    payload = dict(value) if isinstance(value, Mapping) else {}
+    normalized: dict[str, dict[str, Any]] = {}
+    comments_raw = dict(payload.get("comments")) if isinstance(payload.get("comments"), Mapping) else {}
+    media_raw = dict(payload.get("media")) if isinstance(payload.get("media"), Mapping) else {}
+
+    comments_entry = {
+        "run_id": str(comments_raw.get("run_id") or "").strip() or None,
+        "state": str(comments_raw.get("state") or "").strip().lower() or None,
+        "status": str(comments_raw.get("status") or "").strip().lower() or None,
+        "source": str(comments_raw.get("source") or "").strip().lower() or None,
+    }
+    if any(comments_entry.values()):
+        normalized["comments"] = comments_entry
+
+    media_entry = {
+        "attachment_id": str(media_raw.get("attachment_id") or "").strip() or None,
+        "state": str(media_raw.get("state") or "").strip().lower() or None,
+        "status": str(media_raw.get("status") or "").strip().lower() or None,
+        "source": str(media_raw.get("source") or "").strip().lower() or None,
+        "enqueued_job_ids": [
+            str(item).strip() for item in list(media_raw.get("enqueued_job_ids") or []) if str(item).strip()
+        ],
+        "enqueued_job_count": _normalize_non_negative_int(media_raw.get("enqueued_job_count")),
+    }
+    if (
+        media_entry["attachment_id"]
+        or media_entry["state"]
+        or media_entry["status"]
+        or media_entry["source"]
+        or media_entry["enqueued_job_ids"]
+        or media_entry["enqueued_job_count"] > 0
+    ):
+        normalized["media"] = media_entry
+    return normalized
+
+
+def _attached_followup_state_for_status(status: str | None, *, default: str = "pending") -> str:
+    normalized = str(status or "").strip().lower()
+    if normalized in {"queued", "pending", "retrying", "attached"}:
+        return "pending"
+    if normalized in {"running", "cancelling"}:
+        return "running"
+    if normalized in {"completed", "failed", "cancelled"}:
+        return normalized
+    return default
+
+
+def _build_attached_comments_followup(
+    *,
+    run_id: str | None,
+    status: str | None,
+    source: str,
+    state: str | None = None,
+) -> dict[str, Any]:
+    normalized_status = str(status or "").strip().lower() or None
+    return {
+        "run_id": str(run_id or "").strip() or None,
+        "state": str(state or "").strip().lower() or _attached_followup_state_for_status(normalized_status),
+        "status": normalized_status or "pending",
+        "source": str(source or "").strip().lower() or None,
+    }
+
+
+def _build_attached_media_followup(
+    *,
+    attachment_id: str,
+    source: str,
+    state: str | None = None,
+    status: str | None = None,
+    enqueued_job_ids: Sequence[Any] | None = None,
+    enqueued_job_count: int | None = None,
+) -> dict[str, Any]:
+    normalized_job_ids = [str(item).strip() for item in list(enqueued_job_ids or []) if str(item).strip()]
+    normalized_status = str(status or "").strip().lower() or None
+    resolved_count = (
+        _normalize_non_negative_int(enqueued_job_count) if enqueued_job_count is not None else len(normalized_job_ids)
+    )
+    return {
+        "attachment_id": str(attachment_id or "").strip() or None,
+        "state": str(state or "").strip().lower()
+        or _attached_followup_state_for_status(normalized_status, default="pending"),
+        "status": normalized_status or ("completed" if resolved_count <= 0 else "queued"),
+        "source": str(source or "").strip().lower() or None,
+        "enqueued_job_ids": normalized_job_ids,
+        "enqueued_job_count": resolved_count,
+    }
+
+
+def _catalog_media_attachment_id(launch_group_id: str | None) -> str:
+    normalized_launch_group_id = str(launch_group_id or "").strip()
+    if normalized_launch_group_id:
+        return f"media-{normalized_launch_group_id}"
+    return f"media-{uuid4()}"
+
+
+def _load_scrape_run_status(run_id: str, *, conn: Any | None = None) -> str | None:
+    normalized_run_id = str(run_id or "").strip()
+    if not normalized_run_id:
+        return None
+    sql = """
+        select status
+        from social.scrape_runs
+        where id = %s::uuid
+        limit 1
+    """
+    if conn is None:
+        row = pg.fetch_one(sql, [normalized_run_id]) or {}
+    else:
+        with pg.db_cursor(conn=conn, label="load_scrape_run_status") as cur:
+            row = pg.fetch_one_with_cursor(cur, sql, [normalized_run_id]) or {}
+    return str(row.get("status") or "").strip().lower() or None
+
+
+def _load_scrape_jobs_for_ids(job_ids: Sequence[Any], *, conn: Any | None = None) -> list[dict[str, Any]]:
+    normalized_job_ids = [str(item).strip() for item in list(job_ids or []) if str(item).strip()]
+    if not normalized_job_ids:
+        return []
+    sql = """
+        select
+          id::text as id,
+          status,
+          coalesce(config->>'stage', metadata->>'stage', job_type) as stage
+        from social.scrape_jobs
+        where id = any(%s::uuid[])
+        """
+    if conn is None:
+        rows = pg.fetch_all(sql, [normalized_job_ids])
+    else:
+        with pg.db_cursor(conn=conn, label="load_scrape_jobs_for_ids") as cur:
+            rows = pg.fetch_all_with_cursor(cur, sql, [normalized_job_ids])
+    return [dict(row) for row in rows]
+
+
+def _load_media_followup_jobs_for_run(
+    run_id: str,
+    *,
+    conn: Any | None = None,
+) -> list[dict[str, Any]]:
+    normalized_run_id = str(run_id or "").strip()
+    if not normalized_run_id:
+        return []
+    sql = """
+        select
+          id::text as id,
+          status,
+          coalesce(config->>'stage', metadata->>'stage', job_type) as stage
+        from social.scrape_jobs
+        where run_id = %s::uuid
+          and lower(coalesce(config->>'stage', metadata->>'stage', job_type, '')) in (
+            'media_mirror',
+            'comment_media_mirror'
+          )
+        order by created_at desc, id desc
+        """
+    if conn is None:
+        rows = pg.fetch_all(sql, [normalized_run_id])
+    else:
+        with pg.db_cursor(conn=conn, label="load_media_followup_jobs_for_run") as cur:
+            rows = pg.fetch_all_with_cursor(cur, sql, [normalized_run_id])
+    return [dict(row) for row in rows]
+
+
+def _aggregate_attached_job_status(job_rows: Sequence[Mapping[str, Any]]) -> str | None:
+    statuses = [
+        str(row.get("status") or "").strip().lower() for row in job_rows if str(row.get("status") or "").strip()
+    ]
+    if not statuses:
+        return None
+    if any(status in {"running", "cancelling"} for status in statuses):
+        return "running"
+    if any(status in {"queued", "pending", "retrying"} for status in statuses):
+        return "queued"
+    if any(status == "failed" for status in statuses):
+        return "failed"
+    if any(status == "cancelled" for status in statuses) and not any(status == "completed" for status in statuses):
+        return "cancelled"
+    if any(status == "completed" for status in statuses):
+        return "completed"
+    return statuses[0]
+
+
+def _resolve_run_attached_followups(
+    *,
+    run_config: Mapping[str, Any] | None,
+    run_id: str | None = None,
+    run_status: str | None = None,
+    comments_run_id: str | None = None,
+    conn: Any | None = None,
+) -> dict[str, dict[str, Any]]:
+    config = _metadata_dict(run_config)
+    attached_followups = _normalize_attached_followups(config.get("attached_followups"))
+    resolved: dict[str, dict[str, Any]] = {}
+
+    comments_entry = dict(attached_followups.get("comments") or {})
+    effective_comments_run_id = (
+        str(comments_entry.get("run_id") or "").strip()
+        or str(comments_run_id or config.get("comments_run_id") or "").strip()
+        or None
+    )
+    if comments_entry or effective_comments_run_id:
+        effective_comments_status = (
+            _load_scrape_run_status(effective_comments_run_id, conn=conn)
+            if effective_comments_run_id
+            else str(comments_entry.get("status") or "").strip().lower() or None
+        )
+        resolved["comments"] = _build_attached_comments_followup(
+            run_id=effective_comments_run_id,
+            status=effective_comments_status or comments_entry.get("status"),
+            source=str(comments_entry.get("source") or "new_run"),
+            state=str(comments_entry.get("state") or "").strip().lower() or None,
+        )
+
+    media_entry = dict(attached_followups.get("media") or {})
+    if media_entry:
+        enqueued_job_ids = [
+            str(item).strip() for item in list(media_entry.get("enqueued_job_ids") or []) if str(item).strip()
+        ]
+        media_source = str(media_entry.get("source") or "").strip().lower() or None
+        media_job_rows = (
+            _load_scrape_jobs_for_ids(enqueued_job_ids, conn=conn)
+            if enqueued_job_ids
+            else _load_media_followup_jobs_for_run(str(run_id or "").strip(), conn=conn)
+            if media_source == "catalog_media_mirror" and str(run_id or "").strip()
+            else _load_media_followup_jobs_for_run(effective_comments_run_id, conn=conn)
+            if media_source == "comments_media_followups" and effective_comments_run_id
+            else []
+        )
+        resolved_media_status = _aggregate_attached_job_status(media_job_rows)
+        if resolved_media_status is None and media_source == "comments_media_followups":
+            resolved_media_status = str((resolved.get("comments") or {}).get("status") or "").strip().lower() or None
+        if resolved_media_status is None:
+            fallback_status = str(media_entry.get("status") or "").strip().lower() or None
+            if media_source == "catalog_media_mirror":
+                run_fallback_status = str(run_status or "").strip().lower() or None
+                if run_fallback_status in {
+                    "queued",
+                    "pending",
+                    "retrying",
+                    "running",
+                    "cancelling",
+                    "completed",
+                    "failed",
+                    "cancelled",
+                }:
+                    fallback_status = run_fallback_status
+            if fallback_status:
+                resolved_media_status = fallback_status
+            elif _normalize_non_negative_int(media_entry.get("enqueued_job_count")) <= 0:
+                resolved_media_status = "completed"
+        resolved["media"] = _build_attached_media_followup(
+            attachment_id=str(media_entry.get("attachment_id") or "").strip(),
+            source=media_source or "catalog_media_mirror",
+            state=str(media_entry.get("state") or "").strip().lower() or None,
+            status=resolved_media_status,
+            enqueued_job_ids=enqueued_job_ids,
+            enqueued_job_count=max(
+                _normalize_non_negative_int(media_entry.get("enqueued_job_count")),
+                len(enqueued_job_ids),
+                len(media_job_rows),
+            ),
+        )
+    return resolved
+
+
+def _enqueue_instagram_account_media_repair_jobs(
+    *,
+    run_id: str,
+    source_scope: str,
+    account_handle: str,
+    conn: Any | None = None,
+) -> dict[str, Any]:
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    normalized_run_id = str(run_id or "").strip()
+    rows = _load_existing_social_account_posts("instagram", normalized_account, None, None)
+    enqueued_job_ids: list[str] = []
+    for row in rows:
+        if not _platform_post_needs_media_mirror("instagram", row):
+            continue
+        mirror_job_id = _enqueue_instagram_media_mirror_job(
+            None,
+            run_id=normalized_run_id,
+            source_scope=source_scope,
+            account=normalized_account,
+            post_row=dict(row),
+            week_index=None,
+            parent_job_id=None,
+            conn=conn,
+        )
+        if mirror_job_id:
+            enqueued_job_ids.append(str(mirror_job_id))
+    return {
+        "enqueued_job_ids": enqueued_job_ids,
+        "enqueued_job_count": len(enqueued_job_ids),
+    }
+
+
 def _catalog_recent_runs(
     platform: str,
     account_handle: str,
@@ -26536,80 +27208,60 @@ def _catalog_recent_runs(
     run_failure_not_dismissed_sql = _run_failure_not_dismissed_sql("r")
     try:
         sql = f"""
-            with scoped_jobs as (
+            with scoped_runs as (
               select
-                j.id::text as job_id,
-                j.run_id::text as run_id,
-                j.status as job_status,
-                j.created_at,
-                j.started_at,
-                j.completed_at,
-                j.error_message,
-                coalesce(j.metadata, '{{}}'::jsonb) as metadata,
+                r.id::text as run_id,
                 coalesce(r.config, '{{}}'::jsonb) as run_config,
                 coalesce(r.summary, '{{}}'::jsonb) as run_summary,
                 r.status as run_status,
                 r.created_at as run_created_at,
                 r.started_at as run_started_at,
-                r.completed_at as run_completed_at,
-                lower(
-                  coalesce(
-                    nullif(j.config->>'stage', ''),
-                    nullif(j.metadata->>'stage', ''),
-                    nullif(j.job_type, ''),
-                    'unknown'
-                  )
-                ) as stage,
-                case
-                  when j.status in ('queued', 'pending', 'retrying', 'running', 'cancelling') then 0
-                  else 1
-                end as activity_rank,
-                case
-                  when lower(
-                    coalesce(
-                      nullif(j.config->>'stage', ''),
-                      nullif(j.metadata->>'stage', ''),
-                      nullif(j.job_type, ''),
-                      'unknown'
-                    )
-                  ) = 'shared_account_discovery' then 0
-                  when lower(
-                    coalesce(
-                      nullif(j.config->>'stage', ''),
-                      nullif(j.metadata->>'stage', ''),
-                      nullif(j.job_type, ''),
-                      'unknown'
-                    )
-                  ) = 'shared_account_posts' then 1
-                  when lower(
-                    coalesce(
-                      nullif(j.config->>'stage', ''),
-                      nullif(j.metadata->>'stage', ''),
-                      nullif(j.job_type, ''),
-                      'unknown'
-                    )
-                  ) = 'post_classify' then 2
-                  when lower(
-                    coalesce(
-                      nullif(j.config->>'stage', ''),
-                      nullif(j.metadata->>'stage', ''),
-                      nullif(j.job_type, ''),
-                      'unknown'
-                    )
-                  ) = 'season_materialize' then 3
-                  when lower(
-                    coalesce(
-                      nullif(j.config->>'stage', ''),
-                      nullif(j.metadata->>'stage', ''),
-                      nullif(j.job_type, ''),
-                      'unknown'
-                    )
-                  ) = 'analytics_refresh' then 4
-                  else 99
-                end as stage_rank
+                r.completed_at as run_completed_at
+              from social.scrape_runs r
+              where coalesce(r.config->>'pipeline_ingest_mode', '') = %s
+                and {run_failure_not_dismissed_sql}
+                and exists (
+                  select 1
+                  from social.scrape_jobs j
+                  where j.run_id = r.id
+                    and j.platform = %s
+                    and lower(
+                      coalesce(
+                        nullif(j.config->>'account', ''),
+                        nullif(j.metadata->>'account', ''),
+                        ''
+                      )
+                    ) = %s
+                    and lower(
+                      coalesce(
+                        nullif(j.config->>'stage', ''),
+                        nullif(j.metadata->>'stage', ''),
+                        nullif(j.job_type, ''),
+                        'unknown'
+                      )
+                    ) = any(%s::text[])
+                )
+            )
+            select
+              latest_job.job_id,
+              run_id,
+              coalesce(nullif(lower(coalesce(run_status, '')), ''), latest_job.job_status) as status,
+              run_created_at as created_at,
+              run_started_at as started_at,
+              run_completed_at as completed_at,
+              latest_error.error_message as error_message,
+              coalesce(latest_job.metadata, '{{}}'::jsonb) as metadata,
+              run_config,
+              run_summary
+            from scoped_runs
+            left join lateral (
+              select
+                j.id::text as job_id,
+                lower(coalesce(nullif(j.status, ''), '')) as job_status,
+                coalesce(j.metadata, '{{}}'::jsonb) as metadata
               from social.scrape_jobs j
-              join social.scrape_runs r on r.id = j.run_id
-              where j.platform = %s
+              where j.run_id::text = scoped_runs.run_id
+                and j.platform = %s
                 and lower(
                   coalesce(
                     nullif(j.config->>'account', ''),
@@ -26625,54 +27277,47 @@ def _catalog_recent_runs(
                     'unknown'
                   )
                 ) = any(%s::text[])
-                and coalesce(r.config->>'pipeline_ingest_mode', '') = %s
-                and {run_failure_not_dismissed_sql}
-            ),
-            representative_runs as (
-              select distinct on (run_id)
-                job_id,
-                run_id,
-                job_status,
-                run_status,
-                created_at,
-                started_at,
-                completed_at,
-                error_message,
-                metadata,
-                run_config,
-                run_summary,
-                run_created_at,
-                run_started_at,
-                run_completed_at
-              from scoped_jobs
-              order by run_id, activity_rank asc, created_at desc, stage_rank asc
-            )
-            select
-              job_id,
-              run_id,
-              case
-                when lower(coalesce(run_status, '')) = 'cancelled' then 'cancelled'
-                when lower(coalesce(job_status, '')) = 'running' then 'running'
-                when lower(coalesce(job_status, '')) = 'cancelling' then 'cancelling'
-                when lower(coalesce(job_status, '')) in ('queued', 'pending', 'retrying') then 'queued'
-                else coalesce(nullif(run_status, ''), job_status)
-              end as status,
-              coalesce(run_created_at, created_at) as created_at,
-              coalesce(run_started_at, started_at) as started_at,
-              coalesce(run_completed_at, completed_at) as completed_at,
-              error_message,
-              metadata,
-              run_config,
-              run_summary
-            from representative_runs
-            order by coalesce(run_created_at, created_at) desc, created_at desc
+              order by coalesce(j.completed_at, j.started_at, j.created_at) desc, j.id desc
+              limit 1
+            ) latest_job on true
+            left join lateral (
+              select j.error_message
+              from social.scrape_jobs j
+              where j.run_id::text = scoped_runs.run_id
+                and j.platform = %s
+                and lower(
+                  coalesce(
+                    nullif(j.config->>'account', ''),
+                    nullif(j.metadata->>'account', ''),
+                    ''
+                  )
+                ) = %s
+                and lower(
+                  coalesce(
+                    nullif(j.config->>'stage', ''),
+                    nullif(j.metadata->>'stage', ''),
+                    nullif(j.job_type, ''),
+                    'unknown'
+                  )
+                ) = any(%s::text[])
+                and nullif(j.error_message, '') is not null
+              order by coalesce(j.completed_at, j.started_at, j.created_at) desc, j.id desc
+              limit 1
+            ) latest_error on true
+            order by run_created_at desc, run_id desc
             limit %s
             """
         params = [
+            SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
             normalized_platform,
             normalized_account,
             list(ACCOUNT_PROFILE_CATALOG_RECENT_RUN_STAGES),
-            SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            normalized_platform,
+            normalized_account,
+            list(ACCOUNT_PROFILE_CATALOG_RECENT_RUN_STAGES),
+            normalized_platform,
+            normalized_account,
+            list(ACCOUNT_PROFILE_CATALOG_RECENT_RUN_STAGES),
             safe_limit,
         ]
         if conn is None:
@@ -26682,6 +27327,26 @@ def _catalog_recent_runs(
                 rows = pg.fetch_all_with_cursor(cur, sql, params)
         for row in rows:
             row.update(_catalog_run_intent_metadata(row.get("run_config")))
+            run_config = _metadata_dict(row.get("run_config"))
+            row["launch_group_id"] = str(run_config.get("launch_group_id") or "").strip() or None
+            row["launch_state"] = str(run_config.get("launch_state") or "").strip().lower() or None
+            row["selected_tasks"] = _normalize_optional_social_account_catalog_backfill_selected_tasks(
+                run_config.get("selected_tasks")
+            )
+            row["effective_selected_tasks"] = (
+                _normalize_optional_social_account_catalog_backfill_selected_tasks(
+                    run_config.get("effective_selected_tasks")
+                )
+                or row["selected_tasks"]
+            )
+            row["comments_run_id"] = str(run_config.get("comments_run_id") or "").strip() or None
+            row["attached_followups"] = _resolve_run_attached_followups(
+                run_config=run_config,
+                run_id=str(row.get("run_id") or "").strip() or None,
+                run_status=str(row.get("status") or "").strip().lower() or None,
+                comments_run_id=row["comments_run_id"],
+                conn=conn,
+            )
         return rows
     except psycopg_errors.UndefinedTable:
         return []
@@ -28310,6 +28975,27 @@ def _shared_instagram_account_lock_key(account_handle: str) -> int:
     return int(hashlib.md5(f"instagram-account:{normalized_account}".encode()).hexdigest()[:15], 16) % (2**31)
 
 
+def _shared_instagram_account_lock_max_attempts() -> int:
+    raw_value = str(os.getenv("SOCIAL_INSTAGRAM_ACCOUNT_LOCK_MAX_ATTEMPTS") or "").strip()
+    if raw_value:
+        return max(1, _normalize_non_negative_int(raw_value) or 1)
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return 2
+    return 40
+
+
+def _shared_instagram_account_lock_wait_seconds() -> float:
+    raw_value = str(os.getenv("SOCIAL_INSTAGRAM_ACCOUNT_LOCK_WAIT_SECONDS") or "").strip()
+    if raw_value:
+        try:
+            return max(0.0, float(raw_value))
+        except ValueError:
+            logger.warning("Invalid SOCIAL_INSTAGRAM_ACCOUNT_LOCK_WAIT_SECONDS=%r; using default", raw_value)
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        return 0.0
+    return 15.0
+
+
 @contextmanager
 def _shared_instagram_account_execution(account_handle: str):
     from trr_backend.socials.account_browser_sessions import AccountBrowserSessionManager
@@ -28326,7 +29012,8 @@ def _shared_instagram_account_execution(account_handle: str):
         # Retry with backoff instead of failing immediately, so concurrent jobs
         # for the same account wait for the lock rather than all failing.
         with pg.db_read_connection(label=lock_label) as conn:
-            max_lock_attempts = 40  # ~10 minutes total backoff (handles long scrapes)
+            max_lock_attempts = _shared_instagram_account_lock_max_attempts()
+            wait_seconds = _shared_instagram_account_lock_wait_seconds()
             lock_acquired = False
             for attempt in range(max_lock_attempts):
                 with pg.db_cursor(conn=conn, label=lock_label) as cur:
@@ -28342,7 +29029,6 @@ def _shared_instagram_account_execution(account_handle: str):
                     lock_acquired = True
                     break
                 if attempt < max_lock_attempts - 1:
-                    wait_seconds = 15.0
                     logger.info(
                         "[instagram-account-lock] lock busy, retrying in %.0fs (attempt %d/%d) account=%s",
                         wait_seconds,
@@ -28440,40 +29126,68 @@ def _persist_shared_catalog_posts_batch(
             account_handle=account_handle,
             posts=list(posts),
         )
+        if job_id is None and not enable_media_followups:
+            source_ids = [sid for row in catalog_rows if (sid := str(_platform_source_id(platform, row)).strip())]
+            deduped_source_ids = sorted(set(source_ids))
+            return (
+                catalog_rows,
+                deduped_source_ids,
+                {
+                    "catalog_posts_upserted": len(catalog_rows),
+                    "materialized_posts_upserted": 0,
+                    "media_mirror_jobs_enqueued": 0,
+                },
+            )
         materialized_rows: list[dict[str, Any]] = []
         media_mirror_jobs_enqueued = 0
-        with pg.db_connection(label="instagram-shared-catalog-materialize") as conn:
-            for post in posts:
-                row = _upsert_instagram_post(
-                    None,
-                    job_id=job_id,
-                    account=account_handle,
-                    post=post,
-                    conn=conn,
-                )
-                if not row:
-                    continue
-                materialized_rows.append(row)
-                if enable_media_followups and _platform_post_needs_media_mirror("instagram", row):
-                    mirror_job_id = _enqueue_instagram_media_mirror_job(
+        try:
+            with pg.db_connection(label="instagram-shared-catalog-materialize") as conn:
+                for post in posts:
+                    row = _upsert_instagram_post(
                         None,
-                        run_id=run_id,
-                        source_scope=source_scope,
+                        job_id=job_id,
                         account=account_handle,
-                        post_row=dict(row),
-                        week_index=None,
-                        parent_job_id=job_id,
+                        post=post,
+                        conn=conn,
                     )
-                    if mirror_job_id:
-                        media_mirror_jobs_enqueued += 1
+                    if not row:
+                        continue
+                    materialized_rows.append(row)
+                    if enable_media_followups and _platform_post_needs_media_mirror("instagram", row):
+                        mirror_job_id = _enqueue_instagram_media_mirror_job(
+                            None,
+                            run_id=run_id,
+                            source_scope=source_scope,
+                            account=account_handle,
+                            post_row=dict(row),
+                            week_index=None,
+                            parent_job_id=job_id,
+                        )
+                        if mirror_job_id:
+                            media_mirror_jobs_enqueued += 1
+        except pg.DatabaseServiceUnavailableError:
+            if job_id is not None:
+                raise
+            logger.warning(
+                (
+                    "[shared-account] instagram catalog materialization deferred "
+                    "for account=%s run_id=%s because the database is unavailable"
+                ),
+                account_handle,
+                run_id,
+            )
         rows = materialized_rows or catalog_rows
         source_ids = [sid for row in rows if (sid := str(_platform_source_id(platform, row)).strip())]
         deduped_source_ids = sorted(set(source_ids))
-        return rows, deduped_source_ids, {
-            "catalog_posts_upserted": len(catalog_rows),
-            "materialized_posts_upserted": len(materialized_rows),
-            "media_mirror_jobs_enqueued": media_mirror_jobs_enqueued,
-        }
+        return (
+            rows,
+            deduped_source_ids,
+            {
+                "catalog_posts_upserted": len(catalog_rows),
+                "materialized_posts_upserted": len(materialized_rows),
+                "media_mirror_jobs_enqueued": media_mirror_jobs_enqueued,
+            },
+        )
 
     rows: list[dict[str, Any]] = []
     source_ids_list: list[str] = []
@@ -28490,11 +29204,31 @@ def _persist_shared_catalog_posts_batch(
             if source_id:
                 source_ids_list.append(source_id)
     deduped_source_ids = sorted({str(source_id).strip() for source_id in source_ids_list if str(source_id).strip()})
-    return rows, deduped_source_ids, {
-        "catalog_posts_upserted": len(rows),
-        "materialized_posts_upserted": 0,
-        "media_mirror_jobs_enqueued": 0,
-    }
+    return (
+        rows,
+        deduped_source_ids,
+        {
+            "catalog_posts_upserted": len(rows),
+            "materialized_posts_upserted": 0,
+            "media_mirror_jobs_enqueued": 0,
+        },
+    )
+
+
+def _normalize_shared_catalog_posts_batch_result(
+    value: Any,
+) -> tuple[list[dict[str, Any]], list[str], dict[str, int]]:
+    if isinstance(value, tuple):
+        if len(value) == 3:
+            rows, source_ids, persist_meta = value
+        elif len(value) == 2:
+            rows, source_ids = value
+            persist_meta = {}
+        else:
+            raise ValueError("shared catalog post batch result must contain 2 or 3 items")
+    else:
+        raise ValueError("shared catalog post batch result must be a tuple")
+    return list(rows or []), list(source_ids or []), dict(persist_meta or {})
 
 
 def _run_shared_account_discovery_frontier_stage(
@@ -28677,14 +29411,16 @@ def _run_shared_account_discovery_frontier_stage(
     activity["phase"] = "history_bootstrap_saving_first_page"
     activity["posts_checked"] = len(page_posts)
     _flush_progress(force=True)
-    rows, _source_ids, persist_meta = _persist_shared_catalog_posts_batch(
-        platform=platform,
-        run_id=run_id,
-        account_handle=account_handle,
-        posts=page_posts,
-        job_id=job_id,
-        source_scope=source_scope,
-        enable_media_followups=not bool(config.get("details_refresh_skip_media_followups")),
+    rows, _source_ids, persist_meta = _normalize_shared_catalog_posts_batch_result(
+        _persist_shared_catalog_posts_batch(
+            platform=platform,
+            run_id=run_id,
+            account_handle=account_handle,
+            posts=page_posts,
+            job_id=job_id,
+            source_scope=source_scope,
+            enable_media_followups=not bool(config.get("details_refresh_skip_media_followups")),
+        )
     )
     pages_scanned = 1
     posts_checked = len(page_posts)
@@ -28843,9 +29579,7 @@ def _discover_instagram_cursor_partitions(
     progress_cb: Callable[[dict[str, Any]], None] | None = None,
     partition_callback: Callable[[SharedAccountCursorPartition, int | None], None] | None = None,
 ) -> tuple[list[SharedAccountCursorPartition], dict[str, Any]]:
-    # Discovery is read-only (scanning cursors, not writing posts), so skip the
-    # account-level advisory lock.  This prevents stale locks from blocking new runs.
-    with nullcontext(account_handle):
+    with _shared_instagram_account_execution(account_handle):
         public_scraper = _build_shared_instagram_scraper(browser_account_id=account_handle)
         auth_scraper = (
             _build_shared_instagram_scraper(authenticated=True, browser_account_id=account_handle)
@@ -28877,7 +29611,7 @@ def _discover_instagram_cursor_partitions(
         max_rate_limit_retries = 3
 
         # Brief pause after auth validation probe before page 1.
-        time_module.sleep(1.0)
+        time_module.sleep(5.0)
         while True:
             pages_scanned += 1
             adaptive_delay = _shared_instagram_catalog_delay_seconds(
@@ -28904,7 +29638,7 @@ def _discover_instagram_cursor_partitions(
                 if is_rate_limit and consecutive_rate_limit_failures < max_rate_limit_retries:
                     consecutive_rate_limit_failures += 1
                     pages_scanned -= 1  # don't count failed page
-                    backoff = min(60.0, 20.0 * consecutive_rate_limit_failures)
+                    backoff = float(60 * consecutive_rate_limit_failures)
                     logger.info(
                         "Discovery rate-limited (attempt %d/%d), backing off %.0fs before retry",
                         consecutive_rate_limit_failures,
@@ -29270,10 +30004,7 @@ def _scrape_shared_instagram_posts_partitioned(
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     from trr_backend.socials.instagram import ScrapeConfig
 
-    # Partitioned scraping operates on non-overlapping cursor ranges, so
-    # we skip the account-level advisory lock.  This allows multiple partition
-    # workers to scrape the same account concurrently.
-    with nullcontext(account_handle):
+    with _shared_instagram_account_execution(account_handle):
         public_scraper = _build_shared_instagram_scraper(browser_account_id=account_handle)
         auth_allowed, _auth_reason = _shared_instagram_frontier_auth_validation(config)
         auth_scraper = (
@@ -29306,7 +30037,7 @@ def _scrape_shared_instagram_posts_partitioned(
         media_mirror_jobs_enqueued = 0
 
         # Brief pause after auth validation probe before page 1.
-        time_module.sleep(1.0)
+        time_module.sleep(5.0)
         while True:
             pages_scanned += 1
             adaptive_delay = _shared_instagram_catalog_delay_seconds(
@@ -29332,7 +30063,7 @@ def _scrape_shared_instagram_posts_partitioned(
                 if is_rate_limit and consecutive_rate_limit_failures < max_rate_limit_retries:
                     consecutive_rate_limit_failures += 1
                     pages_scanned -= 1
-                    backoff = min(60.0, 20.0 * consecutive_rate_limit_failures)
+                    backoff = float(60 * consecutive_rate_limit_failures)
                     logger.info(
                         "Partition fetch rate-limited (attempt %d/%d), backing off %.0fs",
                         consecutive_rate_limit_failures,
@@ -29351,14 +30082,16 @@ def _scrape_shared_instagram_posts_partitioned(
             if not page_posts:
                 break
             posts_checked += len(page_posts)
-            batch_rows, _source_ids, persist_meta = _persist_shared_catalog_posts_batch(
-                platform="instagram",
-                run_id=run_id,
-                account_handle=account_handle,
-                posts=page_posts,
-                job_id=job_id,
-                source_scope=str(config.get("source_scope") or "bravo"),
-                enable_media_followups=not bool(config.get("details_refresh_skip_media_followups")),
+            batch_rows, _source_ids, persist_meta = _normalize_shared_catalog_posts_batch_result(
+                _persist_shared_catalog_posts_batch(
+                    platform="instagram",
+                    run_id=run_id,
+                    account_handle=account_handle,
+                    posts=page_posts,
+                    job_id=job_id,
+                    source_scope=str(config.get("source_scope") or "bravo"),
+                    enable_media_followups=not bool(config.get("details_refresh_skip_media_followups")),
+                )
             )
             rows.extend(batch_rows)
             media_mirror_jobs_enqueued += _normalize_non_negative_int(persist_meta.get("media_mirror_jobs_enqueued"))
@@ -29653,7 +30386,9 @@ def _scrape_shared_instagram_post_details_refresh(
                 )
                 parsed_post = None
                 detail_fetch_skipped = False
-                if not skip_detail_fetch and (gallery_likes is None or gallery_comments is None or gallery_views is None):
+                if not skip_detail_fetch and (
+                    gallery_likes is None or gallery_comments is None or gallery_views is None
+                ):
                     if detail_fetch_cap == 0 or details_refresh_detail_fetch_attempts >= detail_fetch_cap:
                         details_refresh_detail_fetch_skipped_limit += 1
                         detail_fetch_skipped = True
@@ -29904,9 +30639,8 @@ def _scrape_shared_instagram_posts(
             row = _upsert_instagram_post(None, job_id=job_id, account=account_handle, post=post)
             if row:
                 rows.append(row)
-                if (
-                    not bool(config.get("details_refresh_skip_media_followups"))
-                    and _platform_post_needs_media_mirror("instagram", row)
+                if not bool(config.get("details_refresh_skip_media_followups")) and _platform_post_needs_media_mirror(
+                    "instagram", row
                 ):
                     mirror_job_id = _enqueue_instagram_media_mirror_job(
                         None,
@@ -31611,23 +32345,24 @@ def _run_shared_account_frontier_posts_stage(
                     runtime_metadata={"retrieval_meta": retrieval_meta, "frontier": claimed_frontier},
                 )
 
-            page_rows, _source_ids, persist_meta = _persist_shared_catalog_posts_batch(
-                platform=platform,
-                run_id=run_id,
-                account_handle=account_handle,
-                posts=page_posts,
-                job_id=job_id,
-                source_scope=source_scope,
-                enable_media_followups=not bool(config.get("details_refresh_skip_media_followups")),
+            page_rows, _source_ids, persist_meta = _normalize_shared_catalog_posts_batch_result(
+                _persist_shared_catalog_posts_batch(
+                    platform=platform,
+                    run_id=run_id,
+                    account_handle=account_handle,
+                    posts=page_posts,
+                    job_id=job_id,
+                    source_scope=source_scope,
+                    enable_media_followups=not bool(config.get("details_refresh_skip_media_followups")),
+                )
             )
             total_pages_scanned += 1
             total_posts_checked += len(page_posts)
             total_posts_saved += len(page_rows)
             if persist_meta.get("media_mirror_jobs_enqueued"):
-                last_retrieval_meta["media_mirror_jobs_enqueued"] = (
-                    _normalize_non_negative_int(last_retrieval_meta.get("media_mirror_jobs_enqueued"))
-                    + _normalize_non_negative_int(persist_meta.get("media_mirror_jobs_enqueued"))
-                )
+                last_retrieval_meta["media_mirror_jobs_enqueued"] = _normalize_non_negative_int(
+                    last_retrieval_meta.get("media_mirror_jobs_enqueued")
+                ) + _normalize_non_negative_int(persist_meta.get("media_mirror_jobs_enqueued"))
             page_oldest_posted_at, page_newest_posted_at = _shared_instagram_posted_at_bounds(page_posts)
             if page_oldest_posted_at is not None and (
                 oldest_posted_at_seen is None or page_oldest_posted_at < oldest_posted_at_seen
@@ -32433,13 +33168,23 @@ def _execute_shared_claimed_job(job: Mapping[str, Any], *, worker_id: str | None
             account_handle=account_handle,
             source_scope=source_scope,
         )
-        cancelled_result = _abort_claimed_job_if_cancelled(
-            job_id=job_id,
-            run_id=run_id,
-            stage=stage,
-            platform=platform,
-            account=account_handle,
-        )
+        try:
+            cancelled_result = _abort_claimed_job_if_cancelled(
+                job_id=job_id,
+                run_id=run_id,
+                stage=stage,
+                platform=platform,
+                account=account_handle,
+            )
+        except pg.DatabaseServiceUnavailableError as cancel_exc:
+            logger.warning(
+                "[shared-account] cancel-state check deferred for job=%s stage=%s account=%s error=%s",
+                job_id,
+                stage,
+                account_handle,
+                cancel_exc,
+            )
+            cancelled_result = None
         if cancelled_result is not None:
             return cancelled_result
         if stage == SHARED_ACCOUNT_DISCOVERY_STAGE:
@@ -32490,13 +33235,23 @@ def _execute_shared_claimed_job(job: Mapping[str, Any], *, worker_id: str | None
             account_handle=account_handle,
             source_scope=source_scope,
         )
-        cancelled_result = _abort_claimed_job_if_cancelled(
-            job_id=job_id,
-            run_id=run_id,
-            stage=stage,
-            platform=platform,
-            account=account_handle,
-        )
+        try:
+            cancelled_result = _abort_claimed_job_if_cancelled(
+                job_id=job_id,
+                run_id=run_id,
+                stage=stage,
+                platform=platform,
+                account=account_handle,
+            )
+        except pg.DatabaseServiceUnavailableError as cancel_exc:
+            logger.warning(
+                "[shared-account] post-stage cancel-state check deferred for job=%s stage=%s account=%s error=%s",
+                job_id,
+                stage,
+                account_handle,
+                cancel_exc,
+            )
+            cancelled_result = None
         if cancelled_result is not None:
             return cancelled_result
         _finish_job(
@@ -32605,56 +33360,77 @@ def _execute_shared_claimed_job(job: Mapping[str, Any], *, worker_id: str | None
                 platform=platform,
                 account_handle=account_handle,
             )
-            recovery_job_id = _enqueue_shared_discovery_job(
-                run_id=run_id,
-                platform=platform,
-                source_scope=source_scope,
-                account_handle=account_handle,
-                shared_account_source_id=config.get("shared_account_source_id"),
-                pipeline_ingest_mode=ingest_mode,
-                runner_count=max(
-                    1,
-                    _normalize_non_negative_int(config.get("runner_count"))
-                    or CATALOG_BACKFILL_FULL_HISTORY_RUNNER_COUNT,
-                ),
-                expected_total_posts=expected_total_posts,
-                runner_strategy="full_history_cursor_breakpoints",
-                partition_strategy=CATALOG_FULL_HISTORY_CURSOR_PARTITION_STRATEGY,
-                required_worker_lane=str(config.get("required_worker_lane") or "").strip().lower() or None,
-                required_execution_backend=str(config.get("required_execution_backend") or "").strip().lower() or None,
-                allow_local_dev_inline_bypass=bool(config.get("allow_local_dev_inline_bypass")),
-                frontier_auth_allowed=recovery_frontier_auth_allowed if platform == "instagram" else None,
-                frontier_auth_reason=recovery_frontier_auth_reason if platform == "instagram" else None,
-                transport_preference=recovery_transport_preference if platform == "instagram" else None,
-                allow_public_transport_fallback=(
-                    recovery_allow_public_transport_fallback if platform == "instagram" else None
-                ),
-                catalog_action=str(config.get("catalog_action") or "").strip().lower() or None,
-                catalog_action_scope=str(config.get("catalog_action_scope") or "").strip().lower() or None,
-                initiated_by=None,
-                worker_id=followup_worker_id,
-                priority=100,
-                recovery_depth=_normalize_non_negative_int(config.get("recovery_depth")) + 1,
-            )
-            retry_requeue = {
-                "job_id": recovery_job_id,
-                "stage": SHARED_ACCOUNT_DISCOVERY_STAGE,
-                "runner_strategy": "full_history_cursor_breakpoints",
-                "partition_strategy": CATALOG_FULL_HISTORY_CURSOR_PARTITION_STRATEGY,
-            }
-            retry_config_updates = {}
-            next_available_at = None
+            try:
+                recovery_job_id = _enqueue_shared_discovery_job(
+                    run_id=run_id,
+                    platform=platform,
+                    source_scope=source_scope,
+                    account_handle=account_handle,
+                    shared_account_source_id=config.get("shared_account_source_id"),
+                    pipeline_ingest_mode=ingest_mode,
+                    runner_count=max(
+                        1,
+                        _normalize_non_negative_int(config.get("runner_count"))
+                        or CATALOG_BACKFILL_FULL_HISTORY_RUNNER_COUNT,
+                    ),
+                    expected_total_posts=expected_total_posts,
+                    runner_strategy="full_history_cursor_breakpoints",
+                    partition_strategy=CATALOG_FULL_HISTORY_CURSOR_PARTITION_STRATEGY,
+                    required_worker_lane=str(config.get("required_worker_lane") or "").strip().lower() or None,
+                    required_execution_backend=str(config.get("required_execution_backend") or "").strip().lower()
+                    or None,
+                    allow_local_dev_inline_bypass=bool(config.get("allow_local_dev_inline_bypass")),
+                    frontier_auth_allowed=recovery_frontier_auth_allowed if platform == "instagram" else None,
+                    frontier_auth_reason=recovery_frontier_auth_reason if platform == "instagram" else None,
+                    transport_preference=recovery_transport_preference if platform == "instagram" else None,
+                    allow_public_transport_fallback=(
+                        recovery_allow_public_transport_fallback if platform == "instagram" else None
+                    ),
+                    catalog_action=str(config.get("catalog_action") or "").strip().lower() or None,
+                    catalog_action_scope=str(config.get("catalog_action_scope") or "").strip().lower() or None,
+                    initiated_by=None,
+                    worker_id=followup_worker_id,
+                    priority=100,
+                    recovery_depth=_normalize_non_negative_int(config.get("recovery_depth")) + 1,
+                )
+            except pg.DatabaseServiceUnavailableError as enqueue_exc:
+                logger.warning(
+                    "[shared-account] recovery discovery enqueue deferred for run=%s stage=%s account=%s error=%s",
+                    run_id,
+                    stage,
+                    account_handle,
+                    enqueue_exc,
+                )
+            else:
+                retry_requeue = {
+                    "job_id": recovery_job_id,
+                    "stage": SHARED_ACCOUNT_DISCOVERY_STAGE,
+                    "runner_strategy": "full_history_cursor_breakpoints",
+                    "partition_strategy": CATALOG_FULL_HISTORY_CURSOR_PARTITION_STRATEGY,
+                }
+                retry_config_updates = {}
+                next_available_at = None
         if retry_config_updates:
             updated_config = _update_job_config(job_id, config_updates=retry_config_updates)
             if updated_config:
                 config = updated_config
-        existing_job = (
-            pg.fetch_one(
-                "select items_found, metadata from social.scrape_jobs where id = %s",
-                [job_id],
+        try:
+            existing_job = (
+                pg.fetch_one(
+                    "select items_found, metadata from social.scrape_jobs where id = %s",
+                    [job_id],
+                )
+                or {}
             )
-            or {}
-        )
+        except pg.DatabaseServiceUnavailableError as fetch_exc:
+            logger.warning(
+                "[shared-account] existing job metadata fetch deferred for job=%s stage=%s account=%s error=%s",
+                job_id,
+                stage,
+                account_handle,
+                fetch_exc,
+            )
+            existing_job = {}
         metadata = _metadata_dict(existing_job.get("metadata"))
         metadata.update(
             {
@@ -32949,7 +33725,7 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
             dispatch_blocked_failure_count=0,
             dispatch_blocked_first_seen_at=None,
         )
-        dispatch_result = dispatch_social_job(job_id=job_id)
+        dispatch_result = dispatch_social_job(job_id=job_id, stage=stage)
         if dispatch_result.get("dispatched"):
             _touch_job_dispatch_metadata(
                 job_id,
@@ -33144,10 +33920,13 @@ def _claim_next_jobs(
           from social.scrape_workers
           where worker_id = %s
         ),
+        stale_worker_window as (
+          select make_interval(secs => %s) as max_staleness
+        ),
         healthy_instagram_auth_workers as (
           select count(*)::int as healthy_auth_workers
           from social.scrape_workers
-          where last_seen_at >= now() - make_interval(secs => %s)
+          where last_seen_at >= now() - (select max_staleness from stale_worker_window)
             and status in ('starting', 'idle', 'working')
             and 'instagram' = any(
               coalesce(
@@ -33264,6 +34043,20 @@ def _claim_next_jobs(
               j.worker_id is null
               or j.worker_id = %s::text
               or (j.worker_id is not null and %s::text is not null and %s::text like j.worker_id || '%%')
+              or exists (
+                select 1
+                from social.scrape_workers owning_worker
+                where owning_worker.worker_id = j.worker_id
+                  and (
+                    owning_worker.status = 'stopped'
+                    or owning_worker.last_seen_at < now() - (select max_staleness from stale_worker_window)
+                  )
+              )
+              or not exists (
+                select 1
+                from social.scrape_workers owning_worker
+                where owning_worker.worker_id = j.worker_id
+              )
             )
             and (
               j.platform <> 'youtube'
@@ -33834,8 +34627,7 @@ def _fetch_next_preclaimed_job(
 
 
 def _stage_claim_candidates(stage: str | None) -> tuple[str | None, ...]:
-    normalized_stage = _normalize_social_job_stage_for_stale(stage)
-    if normalized_stage == "comments":
+    if stage == "comments":
         return ("comments", "posts")
     return (stage,)
 
@@ -34716,6 +35508,7 @@ def ingest_shared_accounts(
     details_refresh_skip_detail_fetch: bool | None = None,
     details_refresh_skip_media_followups: bool | None = None,
     launch_group_id: str | None = None,
+    existing_run_id: str | None = None,
 ) -> dict[str, Any]:
     _assert_social_queue_schema_ready()
     if source_scope not in SUPPORTED_SCOPES:
@@ -34782,7 +35575,9 @@ def ingest_shared_accounts(
     bounded_end = _coerce_dt(date_end)
     bounded_window = _catalog_backfill_has_bounded_window(date_start=bounded_start, date_end=bounded_end)
     details_refresh_only = bool(social_account_post_details_only)
-    effective_details_refresh_skip_detail_fetch = bool(details_refresh_skip_detail_fetch) if details_refresh_skip_detail_fetch is not None else False
+    effective_details_refresh_skip_detail_fetch = (
+        bool(details_refresh_skip_detail_fetch) if details_refresh_skip_detail_fetch is not None else False
+    )
     effective_details_refresh_skip_media_followups = (
         bool(details_refresh_skip_media_followups)
         if details_refresh_skip_media_followups is not None
@@ -34986,13 +35781,20 @@ def ingest_shared_accounts(
         run_config["required_runtime_version"] = creator_runtime_version
     if creator_runtime_version:
         run_config["created_by_runtime_version"] = creator_runtime_version
-    run_id = _create_run(
-        None,
-        source_scope=source_scope,
-        initiated_by=initiated_by,
-        config=run_config,
-        status="queued",
-    )
+    run_id = str(existing_run_id or "").strip()
+    if run_id:
+        _merge_catalog_run_config(
+            run_id=run_id,
+            metadata_updates=run_config,
+        )
+    else:
+        run_id = _create_run(
+            None,
+            source_scope=source_scope,
+            initiated_by=initiated_by,
+            config=run_config,
+            status="queued",
+        )
     initial_job_status = "queued" if is_queue_enabled() else "pending"
     job_ids: list[str] = []
     discovery_jobs_created = False
@@ -36255,9 +37057,9 @@ def _run_progress_persist_counters(job_rows: Sequence[Mapping[str, Any]]) -> dic
             normalized_reason = str(reason or "").strip().lower()
             if not normalized_reason:
                 continue
-            posts_skipped_by_reason[normalized_reason] = (
-                posts_skipped_by_reason.get(normalized_reason, 0) + _normalize_non_negative_int(count)
-            )
+            posts_skipped_by_reason[normalized_reason] = posts_skipped_by_reason.get(
+                normalized_reason, 0
+            ) + _normalize_non_negative_int(count)
         silent_drop_detected = silent_drop_detected or bool(truthfulness.get("silent_drop_detected"))
     return {
         "posts_upserted": posts_upserted,
@@ -36503,6 +37305,7 @@ def _build_run_dispatch_health(job_rows: Sequence[Mapping[str, Any]]) -> dict[st
         "latest_remote_blocked_reason": latest_remote_blocked_reason,
         "configured_app_name": modal_app_name() or None,
         "configured_function_name": modal_social_job_function_name() or None,
+        "configured_function_names": modal_social_job_function_names(),
         "modal_environment": modal_environment_name(),
         "max_stale_dispatch_retries": _resolve_stale_modal_dispatch_recovery_limit(),
     }
@@ -37720,6 +38523,22 @@ def get_social_account_catalog_run_progress(
         summary_override=summary_override,
     )
     payload.update(_catalog_run_intent_metadata(run_config))
+    payload["launch_group_id"] = str(run_config.get("launch_group_id") or "").strip() or None
+    payload["launch_state"] = str(run_config.get("launch_state") or "").strip().lower() or None
+    payload["selected_tasks"] = _normalize_optional_social_account_catalog_backfill_selected_tasks(
+        run_config.get("selected_tasks")
+    )
+    payload["effective_selected_tasks"] = (
+        _normalize_optional_social_account_catalog_backfill_selected_tasks(run_config.get("effective_selected_tasks"))
+        or payload["selected_tasks"]
+    )
+    payload["comments_run_id"] = str(run_config.get("comments_run_id") or "").strip() or None
+    payload["attached_followups"] = _resolve_run_attached_followups(
+        run_config=run_config,
+        run_id=run_id,
+        run_status=str(run_row.get("status") or "").strip().lower() or None,
+        comments_run_id=payload["comments_run_id"],
+    )
     resume_state_payload = run_config.get("resume_state") if isinstance(run_config.get("resume_state"), dict) else None
     payload["resume_state"] = resume_state_payload
     partition_progress = _shared_account_partition_progress(
@@ -48454,6 +49273,8 @@ def refresh_post_comments(
     max_comments = 1_000_000 if requested_max_comments == 0 else requested_max_comments
 
     if normalized_platform == "instagram":
+        from trr_backend.socials.instagram import InstagramScraper
+
         row = pg.fetch_one(
             """
             select p.id::text as id,
@@ -48467,10 +49288,16 @@ def refresh_post_comments(
             raise ValueError("Post not found")
 
         account = str(row.get("account") or "")
-        scraper = _build_instagram_scraper_with_auth_fallback(
-            browser_account_id=account or None,
-            caller_context=f"refresh_post_comments:{source_id}",
-        )
+        if getattr(InstagramScraper, "__module__", "") != "trr_backend.socials.instagram.scraper":
+            scraper = InstagramScraper(
+                cookies=_load_instagram_cookies(),
+                browser_account_id=_sanitize_instagram_browser_account_id(account),
+            )
+        else:
+            scraper = _build_instagram_scraper_with_auth_fallback(
+                browser_account_id=account or None,
+                caller_context=f"refresh_post_comments:{source_id}",
+            )
         comments: list[Any] = []
         upserted = 0
         fetch_failed = False
@@ -50243,10 +51070,10 @@ SocialAccountProfileSummaryDetail = Literal["full", "lite"]
 def _normalize_social_account_profile_summary_detail(
     detail: str | None,
 ) -> SocialAccountProfileSummaryDetail:
-    normalized = str(detail or "full").strip().lower()
-    if normalized == "lite":
-        return "lite"
-    return "full"
+    normalized = str(detail or "lite").strip().lower()
+    if normalized == "full":
+        return "full"
+    return "lite"
 
 
 def _social_account_profile_search_sql_parts(
@@ -50614,9 +51441,7 @@ def _instagram_social_account_profile_has_collaborator_catalog_rows(
         row = pg.fetch_one(sql, [normalized_account, normalized_account, normalized_account]) or {}
     else:
         with pg.db_cursor(conn=conn, label="instagram_profile_has_collaborator_catalog_rows") as cur:
-            row = (
-                pg.fetch_one_with_cursor(cur, sql, [normalized_account, normalized_account, normalized_account]) or {}
-            )
+            row = pg.fetch_one_with_cursor(cur, sql, [normalized_account, normalized_account, normalized_account]) or {}
     return bool(row)
 
 
@@ -50757,7 +51582,10 @@ def _timed_social_account_profile_summary_query(
         elapsed_ms = int((time_module.perf_counter() - started_at) * 1000)
         status = "fallback" if fallback is not None else "error"
         logger.info(
-            "Social account profile summary query completed: platform=%s account=%s query=%s status=%s elapsed_ms=%s error=%s",
+            (
+                "Social account profile summary query completed: platform=%s account=%s "
+                "query=%s status=%s elapsed_ms=%s error=%s"
+            ),
             platform,
             account_handle,
             query_name,
@@ -50874,7 +51702,7 @@ def _materialized_social_account_total_posts(
         left join core.shows sh on sh.id = coalesce(p.show_id, s.show_id)
         where {owner_match_clause}
           {search_clause}
-          {' '.join(date_clauses)}
+          {" ".join(date_clauses)}
         """
     params = [normalized_account, *search_params, *date_params]
     if conn is None:
@@ -51795,7 +52623,7 @@ def get_social_account_profile_summary(
                 ),
                 fallback=lambda _exc: [],
             )
-        if normalized_platform == "instagram":
+        if normalized_platform == "instagram" and normalized_detail == "full":
             query_loaders["comments_saved_summary"] = lambda: _timed_social_account_profile_summary_query(
                 platform=normalized_platform,
                 account_handle=normalized_account,
@@ -52163,34 +52991,157 @@ def _instagram_social_account_comments_saved_summary(
 ) -> dict[str, int]:
     normalized_account = _normalize_social_account_profile_handle(account_handle)
     owner_match_clause = _social_account_profile_owner_match_sql("instagram", alias="p")
-    active_comment_filter = "and c.is_missing = false" if _comment_lifecycle_supported("instagram_comments") else ""
+    active_comment_filter = (
+        "and coalesce(c.is_missing, false) = false" if _comment_lifecycle_supported("instagram_comments") else ""
+    )
     sql = f"""
+            with post_totals as (
+              select
+                count(*) filter (
+                  where greatest(0, coalesce(p.comments_count, 0)) > 0
+                )::int as retrieved_comment_posts,
+                coalesce(
+                  sum(
+                    case
+                      when greatest(0, coalesce(p.comments_count, 0)) > 0
+                      then greatest(0, coalesce(p.comments_count, 0))
+                      else 0
+                    end
+                  ),
+                  0
+                )::int as retrieved_comments
+              from social.instagram_posts p
+              where {owner_match_clause}
+                and nullif(p.shortcode, '') is not null
+            ),
+            saved_comment_rows as (
+              select
+                count(c.id)::int as saved_comments,
+                count(distinct c.post_id)::int as saved_comment_posts,
+                coalesce(
+                  sum(
+                    least(
+                      coalesce(jsonb_array_length(coalesce(to_jsonb(c) -> 'hosted_media_urls', '[]'::jsonb)), 0),
+                      coalesce(jsonb_array_length(coalesce(to_jsonb(c) -> 'media_urls', '[]'::jsonb)), 0)
+                    )
+                  ),
+                  0
+                )::int as saved_comment_media_files
+              from social.instagram_comments c
+              join social.instagram_posts p on p.id = c.post_id
+              where {owner_match_clause}
+                and nullif(p.shortcode, '') is not null
+                {active_comment_filter}
+            )
             select
-              count(*) filter (
-                where greatest(0, coalesce(p.comments_count, 0)) > 0
-              )::int as total_posts,
-              count(*) filter (
-                where greatest(0, coalesce(p.comments_count, 0)) > 0
-                  and exists (
-                    select 1
-                    from social.instagram_comments c
-                    where c.post_id = p.id
-                      {active_comment_filter}
-                  )
-              )::int as saved_posts
-            from social.instagram_posts p
-            where {owner_match_clause}
-              and nullif(p.shortcode, '') is not null
+              saved_comment_rows.saved_comments,
+              saved_comment_rows.saved_comment_posts,
+              saved_comment_rows.saved_comment_media_files,
+              post_totals.retrieved_comments,
+              post_totals.retrieved_comment_posts
+            from post_totals
+            cross join saved_comment_rows
             """
     if conn is None:
-        row = pg.fetch_one(sql, [normalized_account]) or {}
+        row = pg.fetch_one(sql, [normalized_account, normalized_account]) or {}
     else:
         with pg.db_cursor(conn=conn, label="instagram_comments_saved_summary") as cur:
-            row = pg.fetch_one_with_cursor(cur, sql, [normalized_account]) or {}
+            row = pg.fetch_one_with_cursor(cur, sql, [normalized_account, normalized_account]) or {}
+    saved_comments = _normalize_non_negative_int(row.get("saved_comments"))
+    saved_comment_posts = _normalize_non_negative_int(row.get("saved_comment_posts"))
+    retrieved_comments = max(saved_comments, _normalize_non_negative_int(row.get("retrieved_comments")))
+    retrieved_comment_posts = max(saved_comment_posts, _normalize_non_negative_int(row.get("retrieved_comment_posts")))
     return {
-        "saved_posts": _normalize_non_negative_int(row.get("saved_posts")),
-        "total_posts": _normalize_non_negative_int(row.get("total_posts")),
+        "saved_comments": saved_comments,
+        "retrieved_comments": retrieved_comments,
+        "saved_comment_posts": saved_comment_posts,
+        "retrieved_comment_posts": retrieved_comment_posts,
+        "saved_comment_media_files": _normalize_non_negative_int(row.get("saved_comment_media_files")),
     }
+
+
+def _instagram_media_urls_with_normalized_keys(value: Any) -> list[tuple[str, str]]:
+    seen: set[str] = set()
+    urls: list[tuple[str, str]] = []
+    for raw_url in _as_text_list(value):
+        normalized = _normalize_media_url_for_compare(raw_url) or raw_url
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        urls.append((raw_url, normalized))
+    return urls
+
+
+def _instagram_post_has_distinct_reel_still(
+    *,
+    post_format: Any,
+    thumbnail_url: Any,
+    media_urls: Any,
+) -> bool:
+    normalized_format = _normalize_instagram_post_format_value(post_format)
+    if normalized_format != "reel":
+        return False
+    normalized_media_urls = {normalized for _, normalized in _instagram_media_urls_with_normalized_keys(media_urls)}
+    if not normalized_media_urls:
+        return False
+    thumbnail = str(thumbnail_url or "").strip()
+    if not thumbnail or _is_video_like_media_url(thumbnail):
+        return False
+    normalized_thumb = _normalize_media_url_for_compare(thumbnail) or thumbnail
+    return bool(normalized_thumb and normalized_thumb not in normalized_media_urls)
+
+
+def _instagram_post_media_file_breakdown(post_row: Mapping[str, Any]) -> dict[str, int]:
+    thumbnail_url = str(post_row.get("thumbnail_url") or "").strip()
+    hosted_thumbnail_url = str(post_row.get("hosted_thumbnail_url") or "").strip()
+    source_media_urls = _instagram_media_urls_with_normalized_keys(post_row.get("media_urls"))
+    hosted_media_urls = _instagram_media_urls_with_normalized_keys(post_row.get("hosted_media_urls"))
+
+    total_post_media_files = len(source_media_urls)
+    saved_post_media_files = min(len(hosted_media_urls), total_post_media_files)
+    if total_post_media_files == 0 and thumbnail_url:
+        total_post_media_files = 1
+        saved_post_media_files = 1 if hosted_thumbnail_url else 0
+
+    total_reel_still_files = int(
+        _instagram_post_has_distinct_reel_still(
+            post_format=post_row.get("post_format"),
+            thumbnail_url=thumbnail_url,
+            media_urls=[url for url, _normalized in source_media_urls],
+        )
+    )
+    saved_reel_still_files = 0
+    if total_reel_still_files and hosted_thumbnail_url:
+        normalized_hosted_thumbnail = _normalize_media_url_for_compare(hosted_thumbnail_url) or hosted_thumbnail_url
+        normalized_hosted_media_urls = {normalized for _, normalized in hosted_media_urls}
+        if normalized_hosted_thumbnail not in normalized_hosted_media_urls:
+            saved_reel_still_files = 1
+
+    return {
+        "total_post_media_files": total_post_media_files,
+        "saved_post_media_files": min(saved_post_media_files, total_post_media_files),
+        "total_reel_still_files": total_reel_still_files,
+        "saved_reel_still_files": min(saved_reel_still_files, total_reel_still_files),
+    }
+
+
+def _instagram_post_avatar_urls(post_row: Mapping[str, Any]) -> set[str]:
+    urls: set[str] = set()
+    hosted_owner = str(post_row.get("hosted_owner_profile_pic_url") or "").strip()
+    if hosted_owner:
+        urls.add(hosted_owner)
+    hosted_tagged = post_row.get("hosted_tagged_profile_pics")
+    if isinstance(hosted_tagged, dict):
+        for value in hosted_tagged.values():
+            hosted_url = str(value or "").strip()
+            if hosted_url:
+                urls.add(hosted_url)
+    elif isinstance(hosted_tagged, list):
+        for value in hosted_tagged:
+            hosted_url = str(value or "").strip()
+            if hosted_url:
+                urls.add(hosted_url)
+    return urls
 
 
 def _instagram_social_account_media_target_counts(
@@ -52200,36 +53151,80 @@ def _instagram_social_account_media_target_counts(
 ) -> dict[str, int]:
     normalized_account = _normalize_social_account_profile_handle(account_handle)
     owner_match_clause = _social_account_profile_owner_match_sql("instagram", alias="p")
-    sql = f"""
-            with posts as (
-              select
-                case
-                  when nullif(p.thumbnail_url, '') is not null then 1
-                  else 0
-                end
-                + coalesce(jsonb_array_length(coalesce(p.media_urls, '[]'::jsonb)), 0) as total_media_files,
-                case
-                  when nullif(p.hosted_thumbnail_url, '') is not null then 1
-                  else 0
-                end
-                + coalesce(jsonb_array_length(coalesce(p.hosted_media_urls, '[]'::jsonb)), 0) as saved_media_files
-              from social.instagram_posts p
-              where {owner_match_clause}
-                and nullif(p.shortcode, '') is not null
-            )
+    thumbnail_expr = _instagram_posts_thumbnail_expr("p")
+    post_format_expr = _instagram_posts_json_text_expr("p", "post_format")
+    active_comment_filter = (
+        "and coalesce(c.is_missing, false) = false" if _comment_lifecycle_supported("instagram_comments") else ""
+    )
+    posts_sql = f"""
             select
-              coalesce(sum(total_media_files), 0)::int as total_files,
-              coalesce(sum(least(saved_media_files, total_media_files)), 0)::int as saved_files
-            from posts
+              {post_format_expr} as post_format,
+              {thumbnail_expr} as thumbnail_url,
+              coalesce(p.media_urls, '[]'::jsonb) as media_urls,
+              coalesce(to_jsonb(p) ->> 'hosted_thumbnail_url', '') as hosted_thumbnail_url,
+              coalesce(to_jsonb(p) -> 'hosted_media_urls', '[]'::jsonb) as hosted_media_urls,
+              coalesce(to_jsonb(p) ->> 'hosted_owner_profile_pic_url', '') as hosted_owner_profile_pic_url,
+              coalesce(to_jsonb(p) -> 'hosted_tagged_profile_pics', '{{}}'::jsonb) as hosted_tagged_profile_pics
+            from social.instagram_posts p
+            where {owner_match_clause}
+              and nullif(p.shortcode, '') is not null
+            """
+    comments_sql = f"""
+            select
+              coalesce(to_jsonb(c) -> 'media_urls', '[]'::jsonb) as media_urls,
+              coalesce(to_jsonb(c) -> 'hosted_media_urls', '[]'::jsonb) as hosted_media_urls,
+              coalesce(to_jsonb(c) ->> 'hosted_author_profile_pic_url', '') as hosted_author_profile_pic_url
+            from social.instagram_comments c
+            join social.instagram_posts p on p.id = c.post_id
+            where {owner_match_clause}
+              and nullif(p.shortcode, '') is not null
+              {active_comment_filter}
             """
     if conn is None:
-        row = pg.fetch_one(sql, [normalized_account]) or {}
+        post_rows = pg.fetch_all(posts_sql, [normalized_account])
+        comment_rows = pg.fetch_all(comments_sql, [normalized_account])
     else:
-        with pg.db_cursor(conn=conn, label="instagram_media_target_counts") as cur:
-            row = pg.fetch_one_with_cursor(cur, sql, [normalized_account]) or {}
+        with pg.db_cursor(conn=conn, label="instagram_media_target_counts_posts") as cur:
+            post_rows = pg.fetch_all_with_cursor(cur, posts_sql, [normalized_account])
+        with pg.db_cursor(conn=conn, label="instagram_media_target_counts_comments") as cur:
+            comment_rows = pg.fetch_all_with_cursor(cur, comments_sql, [normalized_account])
+
+    total_post_media_files = 0
+    saved_post_media_files = 0
+    total_reel_still_files = 0
+    saved_reel_still_files = 0
+    avatar_urls: set[str] = set()
+    for post_row in post_rows:
+        breakdown = _instagram_post_media_file_breakdown(post_row)
+        total_post_media_files += breakdown["total_post_media_files"]
+        saved_post_media_files += breakdown["saved_post_media_files"]
+        total_reel_still_files += breakdown["total_reel_still_files"]
+        saved_reel_still_files += breakdown["saved_reel_still_files"]
+        avatar_urls.update(_instagram_post_avatar_urls(post_row))
+
+    total_comment_media_files = 0
+    saved_comment_media_files = 0
+    for comment_row in comment_rows:
+        source_media_urls = _instagram_media_urls_with_normalized_keys(comment_row.get("media_urls"))
+        hosted_media_urls = _instagram_media_urls_with_normalized_keys(comment_row.get("hosted_media_urls"))
+        total_comment_media_files += len(source_media_urls)
+        saved_comment_media_files += min(len(hosted_media_urls), len(source_media_urls))
+        hosted_author_profile_pic_url = str(comment_row.get("hosted_author_profile_pic_url") or "").strip()
+        if hosted_author_profile_pic_url:
+            avatar_urls.add(hosted_author_profile_pic_url)
+
+    total_files = total_post_media_files + total_comment_media_files + total_reel_still_files
+    saved_files = saved_post_media_files + saved_comment_media_files + saved_reel_still_files
     return {
-        "saved_files": _normalize_non_negative_int(row.get("saved_files")),
-        "total_files": _normalize_non_negative_int(row.get("total_files")),
+        "saved_files": min(saved_files, total_files),
+        "total_files": total_files,
+        "saved_post_media_files": saved_post_media_files,
+        "total_post_media_files": total_post_media_files,
+        "saved_comment_media_files": saved_comment_media_files,
+        "total_comment_media_files": total_comment_media_files,
+        "saved_avatar_files": len(avatar_urls),
+        "saved_reel_still_files": saved_reel_still_files,
+        "total_reel_still_files": total_reel_still_files,
     }
 
 
@@ -52401,6 +53396,15 @@ def _normalize_social_account_catalog_backfill_selected_tasks(selected_tasks: Se
     return [task for task in SOCIAL_ACCOUNT_CATALOG_BACKFILL_SELECTED_TASKS if task in seen]
 
 
+def _normalize_optional_social_account_catalog_backfill_selected_tasks(selected_tasks: Any) -> list[str]:
+    if selected_tasks is None:
+        return []
+    try:
+        return _normalize_social_account_catalog_backfill_selected_tasks(selected_tasks)
+    except SocialIngestValidationError:
+        return []
+
+
 def _social_account_comments_start_lock_key(platform: str, account_handle: str) -> int:
     normalized_platform = _normalize_social_account_profile_platform(platform)
     normalized_account = _normalize_social_account_profile_handle(account_handle)
@@ -52450,6 +53454,10 @@ def start_social_account_comments_scrape(
         if normalized_mode == "profile" and normalized_max_comments_per_post is None
         else normalized_max_comments_per_post
     )
+    queue_enabled = is_queue_enabled()
+    modal_queue_dispatch = queue_enabled and not allow_local_dev_inline_bypass and is_modal_remote_executor_enabled()
+    required_worker_lane = None if modal_queue_dispatch else INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE
+    required_execution_backend = "modal" if modal_queue_dispatch else None
 
     lock_key = _social_account_comments_start_lock_key(normalized_platform, normalized_account)
     lock_label = f"comments-scrape-lock:{normalized_platform}:{normalized_account[:48]}"
@@ -52485,8 +53493,8 @@ def start_social_account_comments_scrape(
                     ),
                     detail=active_run,
                 )
-            if is_queue_enabled() and not allow_local_dev_inline_bypass:
-                if is_modal_remote_executor_enabled():
+            if queue_enabled and not allow_local_dev_inline_bypass:
+                if modal_queue_dispatch:
                     assert_worker_available_when_queue_enabled(
                         required_execution_backend="modal",
                         platform=normalized_platform,
@@ -52522,7 +53530,7 @@ def start_social_account_comments_scrape(
                         message,
                     )
 
-            run_status = "queued" if is_queue_enabled() else "pending"
+            run_status = "queued" if queue_enabled else "pending"
             run_config = {
                 "platform": normalized_platform,
                 "account": normalized_account,
@@ -52538,11 +53546,11 @@ def start_social_account_comments_scrape(
                 ),
                 "comments_enable_media_followups": bool(comments_enable_media_followups),
                 "launch_group_id": str(launch_group_id or "").strip() or None,
-                "required_worker_lane": INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE,
+                "required_worker_lane": required_worker_lane,
+                "required_execution_backend": required_execution_backend,
                 "allow_local_dev_inline_bypass": bool(allow_local_dev_inline_bypass),
                 "ingest_mode": "comments_only",
             }
-            required_execution_backend = _job_required_execution_backend(run_config, platform=normalized_platform)
             creator_runtime_version = dict(_resolve_runtime_version_stamp())
             effective_runtime_version = _resolve_effective_runtime_version(
                 required_execution_backend=required_execution_backend
@@ -52572,7 +53580,8 @@ def start_social_account_comments_scrape(
                     "source_id": source_id if normalized_mode == "single_post" else None,
                     "target_source_ids": target_source_ids,
                     "account": normalized_account,
-                    "required_worker_lane": INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE,
+                    "required_worker_lane": required_worker_lane,
+                    "required_execution_backend": required_execution_backend,
                 },
                 initiated_by=initiated_by,
                 status=run_status,
@@ -52580,7 +53589,7 @@ def start_social_account_comments_scrape(
                 worker_id=inline_worker_id,
                 preclaim=bool(inline_worker_id),
             )
-            if is_queue_enabled():
+            if queue_enabled:
                 dispatch_due_social_jobs(run_id=run_id)
             return {
                 "run_id": run_id,
@@ -52591,7 +53600,8 @@ def start_social_account_comments_scrape(
                 "target_source_ids": target_source_ids,
                 "comments_enable_media_followups": bool(comments_enable_media_followups),
                 "launch_group_id": str(launch_group_id or "").strip() or None,
-                "required_worker_lane": INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE,
+                "required_worker_lane": required_worker_lane,
+                "required_execution_backend": required_execution_backend,
                 "runtime_version": _metadata_dict(run_config.get("required_runtime_version")) or None,
                 "created_by_runtime_version": _metadata_dict(run_config.get("created_by_runtime_version")) or None,
             }
@@ -53219,11 +54229,15 @@ def get_social_account_catalog_post_detail(
     hosted_media_urls = _as_text_list(merged_row.get("hosted_media_urls"))
     if not hosted_media_urls:
         hosted_media_urls = _as_text_list(fallback_row.get("hosted_media_urls"))
-    hosted_thumbnail_url = str(merged_row.get("hosted_thumbnail_url") or "").strip() or str(
-        fallback_row.get("hosted_thumbnail_url") or ""
-    ).strip() or None
-    thumbnail_url = hosted_thumbnail_url or source_thumbnail_url or (
-        hosted_media_urls[0] if hosted_media_urls else (source_media_urls[0] if source_media_urls else None)
+    hosted_thumbnail_url = (
+        str(merged_row.get("hosted_thumbnail_url") or "").strip()
+        or str(fallback_row.get("hosted_thumbnail_url") or "").strip()
+        or None
+    )
+    thumbnail_url = (
+        hosted_thumbnail_url
+        or source_thumbnail_url
+        or (hosted_media_urls[0] if hosted_media_urls else (source_media_urls[0] if source_media_urls else None))
     )
     media_urls = hosted_media_urls or source_media_urls
 
@@ -53297,7 +54311,9 @@ def get_social_account_catalog_post_detail(
         "collaborators_detail": _as_json_object_list(
             merged_row.get("collaborators_detail") or raw_data.get("collaborators_detail")
         ),
-        "child_posts_data": _as_json_object_list(merged_row.get("child_posts_data") or raw_data.get("child_posts_data")),
+        "child_posts_data": _as_json_object_list(
+            merged_row.get("child_posts_data") or raw_data.get("child_posts_data")
+        ),
         "post_format": str(merged_row.get("post_format") or raw_data.get("post_format") or "").strip() or None,
         "permalink": _social_account_profile_post_url("instagram", merged_row, account_handle=normalized_account),
     }
@@ -54055,6 +55071,195 @@ def _social_account_catalog_start_lock_key(platform: str, account_handle: str) -
     ) % (2**31)
 
 
+def _catalog_launch_initial_status(*, allow_local_dev_inline_bypass: bool) -> str:
+    if allow_local_dev_inline_bypass or not is_queue_enabled():
+        return "pending"
+    return "queued"
+
+
+def _build_social_account_catalog_launch_placeholder_config(
+    *,
+    platform: str,
+    account_handle: str,
+    source_scope: str,
+    date_start: datetime | None,
+    date_end: datetime | None,
+    allow_local_dev_inline_bypass: bool,
+    execution_preference: str,
+    launch_group_id: str | None,
+    resume_frontier_cursor: str | None,
+    catalog_action: str | None,
+    catalog_action_scope: str | None,
+    selected_tasks: Sequence[Any] | None = None,
+    task_resolution_pending: bool,
+) -> dict[str, Any]:
+    placeholder_config = {
+        "pipeline_ingest_mode": SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+        "source_scope": source_scope,
+        "platforms": [platform],
+        "accounts_override": [account_handle],
+        "date_start": _iso(date_start),
+        "date_end": _iso(date_end),
+        "allow_local_dev_inline_bypass": bool(allow_local_dev_inline_bypass),
+        "execution_preference": execution_preference,
+        "resume_frontier_cursor": str(resume_frontier_cursor or "").strip() or None,
+        "launch_group_id": str(launch_group_id or "").strip() or None,
+        "catalog_action": str(catalog_action or "").strip().lower() or None,
+        "catalog_action_scope": str(catalog_action_scope or "").strip().lower() or None,
+        "launch_state": "pending",
+        "launch_task_resolution_pending": task_resolution_pending,
+        **_configured_execution_metadata(),
+    }
+    normalized_selected_tasks = _normalize_social_account_catalog_backfill_selected_tasks(selected_tasks)
+    if normalized_selected_tasks:
+        placeholder_config["selected_tasks"] = normalized_selected_tasks
+        placeholder_config["effective_selected_tasks"] = normalized_selected_tasks
+    creator_runtime_version = dict(_resolve_runtime_version_stamp())
+    if creator_runtime_version:
+        placeholder_config["created_by_runtime_version"] = creator_runtime_version
+    return placeholder_config
+
+
+def _record_social_account_catalog_launch_failure(*, run_id: str, error_message: str) -> None:
+    normalized_run_id = str(run_id or "").strip()
+    if not normalized_run_id:
+        return
+    _merge_catalog_run_config(
+        run_id=normalized_run_id,
+        metadata_updates={
+            "launch_state": "failed",
+            "launch_task_resolution_pending": False,
+            "launch_failed_at": _iso(_now_utc()),
+            "launch_error_message": str(error_message or "").strip() or "Catalog launch failed.",
+        },
+    )
+    _set_run_status(normalized_run_id, "failed")
+
+
+def _reserve_social_account_catalog_launch(
+    *,
+    platform: str,
+    account_handle: str,
+    source_scope: str,
+    initiated_by: str | None,
+    placeholder_config: Mapping[str, Any],
+    initial_status: str,
+) -> dict[str, Any]:
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    lock_key = _social_account_catalog_start_lock_key(normalized_platform, normalized_account)
+    lock_label = f"catalog-start-lock:{normalized_platform}:{normalized_account[:48]}"
+    lock_wait_started_at = time_module.perf_counter()
+    with pg.db_connection(label=lock_label) as lock_conn:
+        with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
+            lock_row = pg.fetch_one_with_cursor(cur, "select pg_try_advisory_lock(%s) as locked", [lock_key]) or {}
+        lock_wait_ms = round((time_module.perf_counter() - lock_wait_started_at) * 1000, 1)
+        if not bool(lock_row.get("locked")):
+            active_run = get_active_social_account_catalog_run(
+                normalized_platform,
+                normalized_account,
+                conn=lock_conn,
+            )
+            active_run_id = str((active_run or {}).get("run_id") or "").strip() or None
+            active_status = str((active_run or {}).get("status") or "").strip().lower() or "running"
+            raise SocialIngestConflictError(
+                "SOCIAL_ACCOUNT_CATALOG_RUN_ALREADY_ACTIVE",
+                f"Catalog run {active_run_id or 'unknown'} is already {active_status} for @{normalized_account}.",
+                detail={
+                    "run_id": active_run_id,
+                    "status": active_status,
+                    "platform": normalized_platform,
+                    "account_handle": normalized_account,
+                },
+            )
+        lock_held_started_at = time_module.perf_counter()
+        try:
+            active_run = get_active_social_account_catalog_run(
+                normalized_platform,
+                normalized_account,
+                conn=lock_conn,
+            )
+            if active_run:
+                active_run_id = str(active_run.get("run_id") or "").strip() or None
+                active_status = str(active_run.get("status") or "").strip().lower() or "running"
+                raise SocialIngestConflictError(
+                    "SOCIAL_ACCOUNT_CATALOG_RUN_ALREADY_ACTIVE",
+                    f"Catalog run {active_run_id or 'unknown'} is already {active_status} for @{normalized_account}.",
+                    detail={
+                        "run_id": active_run_id,
+                        "status": active_status,
+                        "platform": normalized_platform,
+                        "account_handle": normalized_account,
+                    },
+                )
+            initial_summary = _build_run_summary_payload(
+                total_jobs=0,
+                completed_jobs=0,
+                failed_jobs=0,
+                active_jobs=0,
+                items_found_total=0,
+                stage_counts={},
+            )
+            run_row = pg.fetch_one_with_cursor(
+                cur,
+                """
+                insert into social.scrape_runs (
+                  season_id,
+                  show_id,
+                  source_scope,
+                  status,
+                  initiated_by,
+                  config,
+                  summary,
+                  started_at
+                )
+                values (
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s,
+                  %s::jsonb,
+                  %s::jsonb,
+                  case when %s = 'running' then now() else null end
+                )
+                returning id::text as id
+                """,
+                [
+                    None,
+                    None,
+                    source_scope,
+                    initial_status,
+                    initiated_by,
+                    json.dumps(dict(_metadata_dict(placeholder_config))),
+                    json.dumps(initial_summary),
+                    initial_status,
+                ],
+            )
+            run_id = str((run_row or {}).get("id") or "").strip()
+            if not run_id and "locked" in (run_row or {}):
+                run_id = ""
+            if not run_id and "locked" not in (run_row or {}):
+                raise RuntimeError("Failed to create social scrape run")
+        finally:
+            try:
+                with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
+                    pg.fetch_one_with_cursor(cur, "select pg_advisory_unlock(%s) as unlocked", [lock_key])
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[catalog-start-lock] advisory unlock failed for %s/%s",
+                    normalized_platform,
+                    normalized_account,
+                    exc_info=True,
+                )
+        lock_held_ms = round((time_module.perf_counter() - lock_held_started_at) * 1000, 1)
+    return {
+        "run_id": run_id,
+        "lock_wait_ms": lock_wait_ms,
+        "lock_held_ms": lock_held_ms,
+    }
+
+
 def resolve_social_account_catalog_action_seed(
     *,
     date_start: datetime | None = None,
@@ -54113,6 +55318,7 @@ def start_social_account_catalog_backfill(
     details_refresh_skip_detail_fetch: bool | None = None,
     details_refresh_skip_media_followups: bool | None = None,
     launch_group_id: str | None = None,
+    existing_run_id: str | None = None,
 ) -> dict[str, Any]:
     normalized_platform = _normalize_social_account_profile_platform(platform)
     normalized_account = _normalize_social_account_profile_handle(account_handle)
@@ -54135,118 +55341,264 @@ def start_social_account_catalog_backfill(
     if normalized_platform not in set(CATALOG_SUPPORTED_PLATFORMS):
         raise ValueError("Catalog backfill is not supported for this platform.")
     _assert_social_account_profile_exists(normalized_platform, normalized_account)
-    lock_key = _social_account_catalog_start_lock_key(normalized_platform, normalized_account)
-    lock_label = f"catalog-start-lock:{normalized_platform}:{normalized_account[:48]}"
-    with pg.db_connection(label=lock_label) as lock_conn:
-        with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
-            lock_row = pg.fetch_one_with_cursor(cur, "select pg_try_advisory_lock(%s) as locked", [lock_key]) or {}
-        if not bool(lock_row.get("locked")):
-            active_run = get_active_social_account_catalog_run(
-                normalized_platform,
-                normalized_account,
-                conn=lock_conn,
-            )
-            active_run_id = str((active_run or {}).get("run_id") or "").strip() or None
-            active_status = str((active_run or {}).get("status") or "").strip().lower() or "running"
-            raise SocialIngestConflictError(
-                "SOCIAL_ACCOUNT_CATALOG_RUN_ALREADY_ACTIVE",
-                f"Catalog run {active_run_id or 'unknown'} is already {active_status} for @{normalized_account}.",
-                detail={
-                    "run_id": active_run_id,
-                    "status": active_status,
-                    "platform": normalized_platform,
-                    "account_handle": normalized_account,
-                },
-            )
-        try:
-            active_run = get_active_social_account_catalog_run(
-                normalized_platform,
-                normalized_account,
-                conn=lock_conn,
-            )
-            if active_run:
-                active_run_id = str(active_run.get("run_id") or "").strip()
-                active_status = str(active_run.get("status") or "").strip().lower() or "running"
-                raise SocialIngestConflictError(
-                    "SOCIAL_ACCOUNT_CATALOG_RUN_ALREADY_ACTIVE",
-                    f"Catalog run {active_run_id or 'unknown'} is already {active_status} for @{normalized_account}.",
-                    detail={
-                        "run_id": active_run_id or None,
-                        "status": active_status,
-                        "platform": normalized_platform,
-                        "account_handle": normalized_account,
-                    },
-                )
-            if (
-                is_queue_enabled()
-                and not allow_local_dev_inline_bypass
-                and _shared_account_catalog_requires_modal_executor(
-                    platform=normalized_platform,
-                    pipeline_ingest_mode=SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
-                )
-            ):
-                assert_worker_available_when_queue_enabled(
-                    required_execution_backend="modal",
-                    platform=normalized_platform,
-                )
-            skip_implicit_frontier_resume = (
-                normalized_platform == "instagram"
-                and normalized_catalog_action == "backfill"
-                and normalized_catalog_action_scope == "full_history"
-            )
-            if (
-                not skip_implicit_frontier_resume
-                and normalized_date_start is None
-                and normalized_date_end is None
-                and normalized_resume_cursor is None
-            ):
-                frontier = _latest_account_frontier(normalized_platform, normalized_account)
-                next_cursor = str(frontier.get("next_cursor") or "").strip() or None
-                if next_cursor and not frontier.get("exhausted"):
-                    normalized_resume_cursor = next_cursor
-                    normalized_resume_snapshot = {
-                        "id": frontier.get("id"),
-                        "run_id": frontier.get("run_id"),
-                        "next_cursor": next_cursor,
-                        "total_posts": frontier.get("total_posts"),
-                        "posts_checked": frontier.get("posts_checked") or 0,
-                        "posts_saved": frontier.get("posts_saved") or 0,
-                        "pages_scanned": frontier.get("pages_scanned") or 0,
-                        "last_transport": frontier.get("last_transport"),
-                    }
-            result = ingest_shared_accounts(
-                platforms=[normalized_platform],
+    run_id = str(existing_run_id or "").strip() or None
+    reserved_here = run_id is None
+    if reserved_here:
+        reservation = _reserve_social_account_catalog_launch(
+            platform=normalized_platform,
+            account_handle=normalized_account,
+            source_scope=source_scope,
+            initiated_by=initiated_by,
+            placeholder_config=_build_social_account_catalog_launch_placeholder_config(
+                platform=normalized_platform,
+                account_handle=normalized_account,
                 source_scope=source_scope,
-                accounts_override=[normalized_account],
                 date_start=normalized_date_start,
                 date_end=normalized_date_end,
-                pipeline_ingest_mode=SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
-                initiated_by=initiated_by,
-                inline_worker_id=inline_worker_id,
                 allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
                 execution_preference=normalized_execution_preference,
-                allow_ephemeral_accounts_override_sources=True,
+                launch_group_id=launch_group_id,
                 resume_frontier_cursor=normalized_resume_cursor,
-                resume_frontier_snapshot=normalized_resume_snapshot,
                 catalog_action=normalized_catalog_action,
                 catalog_action_scope=normalized_catalog_action_scope,
-                social_account_post_details_only=social_account_post_details_only,
-                details_refresh_skip_detail_fetch=details_refresh_skip_detail_fetch,
-                details_refresh_skip_media_followups=details_refresh_skip_media_followups,
-                launch_group_id=launch_group_id,
+                task_resolution_pending=False,
+            ),
+            initial_status=_catalog_launch_initial_status(
+                allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+            ),
+        )
+        run_id = str(reservation.get("run_id") or "").strip() or None
+        logger.info(
+            "[catalog-launch] kickoff_reserved platform=%s account=%s run_id=%s lock_wait_ms=%.1f lock_held_ms=%.1f",
+            normalized_platform,
+            normalized_account,
+            run_id,
+            float(reservation.get("lock_wait_ms") or 0.0),
+            float(reservation.get("lock_held_ms") or 0.0),
+        )
+
+    try:
+        if (
+            is_queue_enabled()
+            and not allow_local_dev_inline_bypass
+            and _shared_account_catalog_requires_modal_executor(
+                platform=normalized_platform,
+                pipeline_ingest_mode=SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
             )
-            return result
-        finally:
-            try:
-                with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
-                    pg.fetch_one_with_cursor(cur, "select pg_advisory_unlock(%s) as unlocked", [lock_key])
-            except Exception:  # noqa: BLE001
-                logger.debug(
-                    "[catalog-start-lock] advisory unlock failed for %s/%s",
-                    normalized_platform,
-                    normalized_account,
-                    exc_info=True,
-                )
+        ):
+            assert_worker_available_when_queue_enabled(
+                required_execution_backend="modal",
+                platform=normalized_platform,
+            )
+        skip_implicit_frontier_resume = (
+            normalized_platform == "instagram"
+            and normalized_catalog_action == "backfill"
+            and normalized_catalog_action_scope == "full_history"
+        )
+        if (
+            not skip_implicit_frontier_resume
+            and normalized_date_start is None
+            and normalized_date_end is None
+            and normalized_resume_cursor is None
+        ):
+            frontier = _latest_account_frontier(normalized_platform, normalized_account)
+            next_cursor = str(frontier.get("next_cursor") or "").strip() or None
+            if next_cursor and not frontier.get("exhausted"):
+                normalized_resume_cursor = next_cursor
+                normalized_resume_snapshot = {
+                    "id": frontier.get("id"),
+                    "run_id": frontier.get("run_id"),
+                    "next_cursor": next_cursor,
+                    "total_posts": frontier.get("total_posts"),
+                    "posts_checked": frontier.get("posts_checked") or 0,
+                    "posts_saved": frontier.get("posts_saved") or 0,
+                    "pages_scanned": frontier.get("pages_scanned") or 0,
+                    "last_transport": frontier.get("last_transport"),
+                }
+        result = ingest_shared_accounts(
+            platforms=[normalized_platform],
+            source_scope=source_scope,
+            accounts_override=[normalized_account],
+            date_start=normalized_date_start,
+            date_end=normalized_date_end,
+            pipeline_ingest_mode=SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            initiated_by=initiated_by,
+            inline_worker_id=inline_worker_id,
+            allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+            execution_preference=normalized_execution_preference,
+            allow_ephemeral_accounts_override_sources=True,
+            resume_frontier_cursor=normalized_resume_cursor,
+            resume_frontier_snapshot=normalized_resume_snapshot,
+            catalog_action=normalized_catalog_action,
+            catalog_action_scope=normalized_catalog_action_scope,
+            social_account_post_details_only=social_account_post_details_only,
+            details_refresh_skip_detail_fetch=details_refresh_skip_detail_fetch,
+            details_refresh_skip_media_followups=details_refresh_skip_media_followups,
+            launch_group_id=launch_group_id,
+            existing_run_id=run_id,
+        )
+        if run_id:
+            _merge_catalog_run_config(
+                run_id=run_id,
+                metadata_updates={
+                    "launch_state": "ready",
+                    "launch_task_resolution_pending": False,
+                    "launch_completed_at": _iso(_now_utc()),
+                },
+            )
+        return result
+    except Exception as exc:  # noqa: BLE001
+        if reserved_here and run_id:
+            _record_social_account_catalog_launch_failure(
+                run_id=run_id,
+                error_message=str(exc),
+            )
+        raise
+
+
+def begin_social_account_catalog_backfill_launch(
+    platform: str,
+    account_handle: str,
+    *,
+    source_scope: str = "bravo",
+    date_start: datetime | None = None,
+    date_end: datetime | None = None,
+    initiated_by: str | None = None,
+    allow_local_dev_inline_bypass: bool = False,
+    execution_preference: Literal["auto", "prefer_local_inline"] = "auto",
+    selected_tasks: Sequence[Any] | None = None,
+) -> dict[str, Any]:
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    if normalized_platform not in set(CATALOG_SUPPORTED_PLATFORMS):
+        raise ValueError("Catalog backfill is not supported for this platform.")
+    _assert_social_account_profile_exists(normalized_platform, normalized_account)
+    normalized_execution_preference = str(execution_preference or "auto").strip().lower() or "auto"
+    if normalized_execution_preference not in {"auto", "prefer_local_inline"}:
+        normalized_execution_preference = "auto"
+    action_seed = resolve_social_account_catalog_action_seed(
+        date_start=date_start,
+        date_end=date_end,
+        catalog_action="backfill",
+    )
+    launch_group_id = str(uuid4())
+    normalized_selected_tasks = _normalize_social_account_catalog_backfill_selected_tasks(selected_tasks)
+    reservation = _reserve_social_account_catalog_launch(
+        platform=normalized_platform,
+        account_handle=normalized_account,
+        source_scope=source_scope,
+        initiated_by=initiated_by,
+        placeholder_config=_build_social_account_catalog_launch_placeholder_config(
+            platform=normalized_platform,
+            account_handle=normalized_account,
+            source_scope=source_scope,
+            date_start=action_seed["date_start"],
+            date_end=action_seed["date_end"],
+            allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+            execution_preference=normalized_execution_preference,
+            launch_group_id=launch_group_id,
+            resume_frontier_cursor=action_seed["resume_frontier_cursor"],
+            catalog_action=action_seed["catalog_action"],
+            catalog_action_scope=action_seed["catalog_action_scope"],
+            selected_tasks=normalized_selected_tasks,
+            task_resolution_pending=True,
+        ),
+        initial_status=_catalog_launch_initial_status(
+            allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+        ),
+    )
+    run_id = str(reservation.get("run_id") or "").strip()
+    initial_status = _catalog_launch_initial_status(
+        allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+    )
+    logger.info(
+        (
+            "[catalog-launch] kickoff_reserved platform=%s account=%s run_id=%s status=%s "
+            "lock_wait_ms=%.1f lock_held_ms=%.1f"
+        ),
+        normalized_platform,
+        normalized_account,
+        run_id,
+        initial_status,
+        float(reservation.get("lock_wait_ms") or 0.0),
+        float(reservation.get("lock_held_ms") or 0.0),
+    )
+    return {
+        "run_id": run_id,
+        "status": initial_status,
+        "platform": normalized_platform,
+        "account_handle": normalized_account,
+        "launch_group_id": launch_group_id,
+        "selected_tasks": normalized_selected_tasks,
+        "effective_selected_tasks": normalized_selected_tasks,
+        "catalog_run_id": run_id,
+        "comments_run_id": None,
+        "catalog_status": initial_status,
+        "comments_status": None,
+        "catalog_bootstrap_required": None,
+        "comments_deferred_until_catalog_complete": False,
+        "post_details_skipped_reason": None,
+        "launch_state": "pending",
+        "launch_task_resolution_pending": True,
+        "attached_followups": {},
+        "catalog_action": action_seed["catalog_action"],
+        "catalog_action_scope": action_seed["catalog_action_scope"],
+        "ingest_mode": SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+    }
+
+
+def finalize_social_account_catalog_backfill_launch(
+    platform: str,
+    account_handle: str,
+    *,
+    run_id: str,
+    source_scope: str = "bravo",
+    date_start: datetime | None = None,
+    date_end: datetime | None = None,
+    initiated_by: str | None = None,
+    allow_local_dev_inline_bypass: bool = False,
+    execution_preference: Literal["auto", "prefer_local_inline"] = "auto",
+    selected_tasks: Sequence[Any] | None = None,
+    launch_group_id: str | None = None,
+) -> dict[str, Any]:
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    started_at = time_module.perf_counter()
+    try:
+        result = launch_social_account_catalog_backfill(
+            normalized_platform,
+            normalized_account,
+            source_scope=source_scope,
+            date_start=date_start,
+            date_end=date_end,
+            initiated_by=initiated_by,
+            allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+            execution_preference=execution_preference,
+            selected_tasks=selected_tasks,
+            existing_catalog_run_id=run_id,
+            launch_group_id_override=launch_group_id,
+        )
+        logger.info(
+            "[catalog-launch] finalize_complete platform=%s account=%s run_id=%s total_ms=%.1f comments_run_id=%s",
+            normalized_platform,
+            normalized_account,
+            run_id,
+            round((time_module.perf_counter() - started_at) * 1000, 1),
+            str(result.get("comments_run_id") or "").strip() or None,
+        )
+        return result
+    except Exception as exc:  # noqa: BLE001
+        _record_social_account_catalog_launch_failure(
+            run_id=run_id,
+            error_message=str(exc),
+        )
+        logger.exception(
+            "[catalog-launch] finalize_failed platform=%s account=%s run_id=%s",
+            normalized_platform,
+            normalized_account,
+            run_id,
+        )
+        raise
 
 
 def launch_social_account_catalog_backfill(
@@ -54261,9 +55613,20 @@ def launch_social_account_catalog_backfill(
     allow_local_dev_inline_bypass: bool = False,
     execution_preference: Literal["auto", "prefer_local_inline"] = "auto",
     selected_tasks: Sequence[Any] | None = None,
+    existing_catalog_run_id: str | None = None,
+    launch_group_id_override: str | None = None,
 ) -> dict[str, Any]:
     normalized_platform = _normalize_social_account_profile_platform(platform)
     normalized_account = _normalize_social_account_profile_handle(account_handle)
+    launch_started_at = time_module.perf_counter()
+    coverage_ms = 0.0
+    catalog_launch_ms = 0.0
+    comments_launch_ms = 0.0
+    bounded_window_scope = (
+        "bounded_window"
+        if _catalog_backfill_has_bounded_window(date_start=date_start, date_end=date_end)
+        else "full_history"
+    )
     if normalized_platform != "instagram":
         return start_social_account_catalog_backfill(
             normalized_platform,
@@ -54276,29 +55639,31 @@ def launch_social_account_catalog_backfill(
             allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
             execution_preference=execution_preference,
             catalog_action="backfill",
-            catalog_action_scope="bounded_window" if _catalog_backfill_has_bounded_window(date_start=date_start, date_end=date_end) else "full_history",
+            catalog_action_scope=bounded_window_scope,
+            existing_run_id=existing_catalog_run_id,
         )
 
     normalized_selected_tasks = _normalize_social_account_catalog_backfill_selected_tasks(selected_tasks)
-    launch_group_id = str(uuid4())
+    launch_group_id = str(launch_group_id_override or uuid4())
     catalog_result: dict[str, Any] | None = None
     comments_result: dict[str, Any] | None = None
     deferred_comments_followup: dict[str, Any] | None = None
+    attached_followups: dict[str, dict[str, Any]] = {}
     post_details_skipped_reason: str | None = None
     if normalized_platform == "instagram":
+        coverage_started_at = time_module.perf_counter()
         coverage = _instagram_materialization_state(
             normalized_account,
             date_start=date_start,
             date_end=date_end,
         )
+        coverage_ms = round((time_module.perf_counter() - coverage_started_at) * 1000, 1)
         details_already_materialized = bool(coverage.get("details_complete"))
         requires_catalog_bootstrap = bool(coverage.get("bootstrap_required"))
         if details_already_materialized and "post_details" in normalized_selected_tasks:
             post_details_skipped_reason = "already_materialized"
         effective_selected_tasks = [
-            task
-            for task in normalized_selected_tasks
-            if not (task == "post_details" and details_already_materialized)
+            task for task in normalized_selected_tasks if not (task == "post_details" and details_already_materialized)
         ]
     else:
         details_already_materialized = False
@@ -54312,8 +55677,10 @@ def launch_social_account_catalog_backfill(
     catalog_selected = bool(catalog_tasks)
     catalog_details_refresh_only = catalog_selected and not requires_catalog_bootstrap
     comments_deferred_until_catalog_complete = False
+    media_attachment_id = _catalog_media_attachment_id(launch_group_id) if "media" in effective_selected_tasks else None
 
     if catalog_selected:
+        catalog_launch_started_at = time_module.perf_counter()
         catalog_result = start_social_account_catalog_backfill(
             normalized_platform,
             normalized_account,
@@ -54325,22 +55692,27 @@ def launch_social_account_catalog_backfill(
             allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
             execution_preference=execution_preference,
             catalog_action="backfill",
-            catalog_action_scope="bounded_window" if _catalog_backfill_has_bounded_window(date_start=date_start, date_end=date_end) else "full_history",
+            catalog_action_scope=bounded_window_scope,
             social_account_post_details_only=catalog_details_refresh_only,
             details_refresh_skip_detail_fetch="post_details" not in catalog_tasks,
             details_refresh_skip_media_followups="media" not in catalog_tasks,
             launch_group_id=launch_group_id,
+            existing_run_id=existing_catalog_run_id,
         )
+        catalog_launch_ms = round((time_module.perf_counter() - catalog_launch_started_at) * 1000, 1)
+        if media_attachment_id:
+            attached_followups["media"] = _build_attached_media_followup(
+                attachment_id=media_attachment_id,
+                source="catalog_media_mirror",
+                status=str((catalog_result or {}).get("status") or "queued").strip().lower() or "queued",
+            )
 
     if "comments" in effective_selected_tasks:
+        comments_launch_started_at = time_module.perf_counter()
         if requires_catalog_bootstrap and catalog_result is not None:
             comments_deferred_until_catalog_complete = True
             catalog_run_id = str((catalog_result or {}).get("run_id") or "").strip()
-            catalog_run_row = (
-                _load_catalog_run_row_by_id(catalog_run_id)
-                if catalog_run_id
-                else {}
-            )
+            catalog_run_row = _load_catalog_run_row_by_id(catalog_run_id) if catalog_run_id else {}
             catalog_run_config = _metadata_dict(catalog_run_row.get("config"))
             deferred_comments_followup = {
                 "state": "pending",
@@ -54356,6 +55728,12 @@ def launch_social_account_catalog_backfill(
                 "created_by_runtime_version": _metadata_dict(catalog_run_config.get("created_by_runtime_version"))
                 or dict(_resolve_runtime_version_stamp()),
             }
+            attached_followups["comments"] = _build_attached_comments_followup(
+                run_id=None,
+                status="pending",
+                source="deferred_after_catalog",
+                state="pending",
+            )
             if catalog_run_id and deferred_comments_followup:
                 with pg.db_connection(label="catalog-followup-merge") as conn:
                     _merge_catalog_run_config_with_conn(
@@ -54365,23 +55743,74 @@ def launch_social_account_catalog_backfill(
                             "selected_tasks": normalized_selected_tasks,
                             "effective_selected_tasks": effective_selected_tasks,
                             "deferred_comments_followup": deferred_comments_followup,
+                            "attached_followups": attached_followups,
                         },
                     )
         else:
-            comments_result = start_social_account_comments_scrape(
-                normalized_platform,
-                normalized_account,
-                mode="profile",
-                source_scope=source_scope,
-                max_posts=None,
-                max_comments_per_post=None,
-                refresh_policy="all_saved_posts",
-                initiated_by=initiated_by,
-                inline_worker_id=None if catalog_result else inline_worker_id,
-                allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
-                comments_enable_media_followups="media" in effective_selected_tasks,
-                launch_group_id=launch_group_id,
+            comments_source = "new_run"
+            try:
+                comments_result = start_social_account_comments_scrape(
+                    normalized_platform,
+                    normalized_account,
+                    mode="profile",
+                    source_scope=source_scope,
+                    max_posts=None,
+                    max_comments_per_post=None,
+                    refresh_policy="all_saved_posts",
+                    initiated_by=initiated_by,
+                    inline_worker_id=None if catalog_result else inline_worker_id,
+                    allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
+                    comments_enable_media_followups="media" in effective_selected_tasks,
+                    launch_group_id=launch_group_id,
+                )
+            except SocialIngestConflictError as exc:
+                if exc.code != "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE":
+                    raise
+                active_comments_run_id = str(exc.detail.get("run_id") or "").strip()
+                if not active_comments_run_id:
+                    raise
+                comments_result = {
+                    "run_id": active_comments_run_id,
+                    "status": str(exc.detail.get("status") or "running").strip().lower() or "running",
+                    "reused_active_run": True,
+                }
+                comments_source = "reused_run"
+                logger.info(
+                    (
+                        "[catalog-launch] reusing active comments run platform=%s account=%s "
+                        "catalog_run_id=%s comments_run_id=%s"
+                    ),
+                    normalized_platform,
+                    normalized_account,
+                    str((catalog_result or {}).get("run_id") or "").strip() or None,
+                    active_comments_run_id,
+                )
+                catalog_run_id_for_media = str((catalog_result or {}).get("run_id") or "").strip() or None
+                if media_attachment_id and catalog_run_id_for_media:
+                    media_followup = _enqueue_instagram_account_media_repair_jobs(
+                        run_id=catalog_run_id_for_media,
+                        source_scope=source_scope,
+                        account_handle=normalized_account,
+                    )
+                    attached_followups["media"] = _build_attached_media_followup(
+                        attachment_id=media_attachment_id,
+                        source="catalog_media_mirror",
+                        status="queued" if media_followup["enqueued_job_count"] > 0 else "completed",
+                        enqueued_job_ids=media_followup["enqueued_job_ids"],
+                        enqueued_job_count=media_followup["enqueued_job_count"],
+                    )
+            attached_followups["comments"] = _build_attached_comments_followup(
+                run_id=str((comments_result or {}).get("run_id") or "").strip() or None,
+                status=str((comments_result or {}).get("status") or "").strip().lower() or "pending",
+                source=comments_source,
             )
+            if media_attachment_id and comments_source != "reused_run":
+                attached_followups["media"] = _build_attached_media_followup(
+                    attachment_id=media_attachment_id,
+                    source="comments_media_followups",
+                    status=str((comments_result or {}).get("status") or "").strip().lower() or "pending",
+                )
+        comments_launch_ms = round((time_module.perf_counter() - comments_launch_started_at) * 1000, 1)
 
     catalog_run_id = str((catalog_result or {}).get("run_id") or "").strip() or None
     comments_run_id = str((comments_result or {}).get("run_id") or "").strip() or None
@@ -54392,17 +55821,37 @@ def launch_social_account_catalog_backfill(
         }
         if comments_run_id:
             catalog_metadata_updates["comments_run_id"] = comments_run_id
+        if attached_followups:
+            catalog_metadata_updates["attached_followups"] = attached_followups
         _merge_catalog_run_config(
             run_id=catalog_run_id,
             metadata_updates=catalog_metadata_updates,
         )
 
-    primary_run_id = str(
-        (catalog_result or {}).get("run_id") or (comments_result or {}).get("run_id") or ""
-    ).strip() or None
-    primary_status = str(
-        (catalog_result or {}).get("status") or (comments_result or {}).get("status") or ""
-    ).strip() or None
+    primary_run_id = (
+        str((catalog_result or {}).get("run_id") or (comments_result or {}).get("run_id") or "").strip() or None
+    )
+    primary_status = (
+        str((catalog_result or {}).get("status") or (comments_result or {}).get("status") or "").strip() or None
+    )
+    logger.info(
+        (
+            "[catalog-launch] launch_complete platform=%s account=%s run_id=%s "
+            "existing_run_id=%s coverage_ms=%.1f catalog_launch_ms=%.1f "
+            "comments_launch_ms=%.1f total_ms=%.1f selected_tasks=%s "
+            "effective_selected_tasks=%s"
+        ),
+        normalized_platform,
+        normalized_account,
+        primary_run_id,
+        str(existing_catalog_run_id or "").strip() or None,
+        coverage_ms,
+        catalog_launch_ms,
+        comments_launch_ms,
+        round((time_module.perf_counter() - launch_started_at) * 1000, 1),
+        normalized_selected_tasks,
+        effective_selected_tasks,
+    )
     return {
         "run_id": primary_run_id,
         "status": primary_status,
@@ -54418,6 +55867,7 @@ def launch_social_account_catalog_backfill(
         "comments_status": str((comments_result or {}).get("status") or "").strip() or None,
         "catalog_bootstrap_required": requires_catalog_bootstrap if catalog_selected else False,
         "comments_deferred_until_catalog_complete": comments_deferred_until_catalog_complete,
+        "attached_followups": attached_followups,
     }
 
 
@@ -54435,7 +55885,67 @@ def cancel_social_account_catalog_run(
         run_id=run_id,
     )
     run_id = str(run_row.get("id") or "").strip()
-    return cancel_shared_run(run_id, cancelled_by=cancelled_by, reconcile_summary=reconcile_summary)
+    if reconcile_summary:
+        return cancel_shared_run(run_id, cancelled_by=cancelled_by)
+    return cancel_shared_run(run_id, cancelled_by=cancelled_by, reconcile_summary=False)
+
+
+def request_cancel_social_account_catalog_run(
+    *,
+    platform: str,
+    account_handle: str,
+    run_id: str,
+    cancelled_by: str | None = None,
+) -> dict[str, Any]:
+    run_row = _load_social_account_catalog_run_row(
+        platform=platform,
+        account_handle=account_handle,
+        run_id=run_id,
+    )
+    normalized_run_id = str(run_row.get("id") or "").strip()
+    if not normalized_run_id:
+        raise ValueError("Shared run not found")
+
+    cancel_requested_at = _now_utc()
+    cancellation_metadata = {
+        "cancel_requested_at": _iso(cancel_requested_at),
+        "cancel_requested_by": cancelled_by,
+    }
+    pg.fetch_one(
+        """
+        update social.scrape_runs
+        set
+          status = case
+            when status in ('queued', 'pending', 'retrying', 'running', 'cancelling') then 'cancelling'
+            else status
+          end,
+          summary = coalesce(summary, '{}'::jsonb) || %s::jsonb
+        where id = %s::uuid
+        returning id::text as id, status
+        """,
+        [_json_dumps(cancellation_metadata), normalized_run_id],
+    )
+    pg.execute(
+        """
+        update social.scrape_jobs
+        set
+          status = case
+            when status in ('queued', 'pending', 'retrying', 'running') then 'cancelling'
+            else status
+          end,
+          metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
+        where run_id = %s::uuid
+          and status in ('queued', 'pending', 'retrying', 'running')
+        """,
+        [_json_dumps(cancellation_metadata), normalized_run_id],
+    )
+    _invalidate_queue_status_cache()
+    return {
+        "run_id": normalized_run_id,
+        "status": "cancelling",
+        "accepted": True,
+        "cancel_requested_at": _iso(cancel_requested_at),
+    }
 
 
 def _catalog_runtime_supersession_lock_key(run_id: str) -> int:
@@ -55213,7 +56723,7 @@ def sync_newer_social_account_catalog(
             "ALREADY_CURRENT",
             "Newest stored post is already at or beyond the current time.",
         )
-    return start_social_account_catalog_backfill(
+    return launch_social_account_catalog_backfill(
         platform,
         account_handle,
         source_scope=source_scope,

--- a/trr_backend/repositories/social_season_analytics.py
+++ b/trr_backend/repositories/social_season_analytics.py
@@ -15809,6 +15809,14 @@ def _pg_upsert_many(
     if missing_conflict_cols:
         raise ValueError(f"conflict columns {missing_conflict_cols!r} missing in payload for table {table}")
 
+    deduped_payloads: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for payload in payloads:
+        key = tuple(payload.get(column) for column in conflict_cols)
+        if key in deduped_payloads:
+            deduped_payloads.pop(key)
+        deduped_payloads[key] = payload
+    payloads = list(deduped_payloads.values())
+
     updates = [column for column in columns if column not in conflict_cols]
     if not updates:
         raise ValueError(f"table {table} upsert payload must include at least one non-conflict column")

--- a/trr_backend/repositories/social_sync_orchestrator.py
+++ b/trr_backend/repositories/social_sync_orchestrator.py
@@ -97,6 +97,29 @@ def _normalize_platforms(platforms: list[str] | None) -> list[str]:
     return normalized or list(SOCIAL_SUPPORTED_PLATFORMS)
 
 
+def _as_hosted_tagged_url_map(social_repo: Any, value: Any) -> dict[str, str]:
+    repo_helper = getattr(social_repo, "_as_json_string_map", None)
+    if callable(repo_helper):
+        return dict(repo_helper(value) or {})
+
+    result: dict[str, str] = {}
+    if not isinstance(value, dict):
+        return result
+    for raw_key, raw_value in value.items():
+        key = str(raw_key or "").strip().lstrip("@").lower()
+        if not key:
+            continue
+        if isinstance(raw_value, str):
+            hosted_url = raw_value.strip()
+        elif isinstance(raw_value, dict):
+            hosted_url = str(raw_value.get("hosted_url") or "").strip()
+        else:
+            hosted_url = ""
+        if hosted_url:
+            result[key] = hosted_url
+    return result
+
+
 def _window_span_days(*, date_start: datetime | None, date_end: datetime | None) -> float:
     if date_start is None or date_end is None:
         return 0.0
@@ -490,11 +513,7 @@ def _build_avatar_coverage_snapshot(
                 if owner_source and not owner_hosted:
                     if (platform, owner_handle.lstrip("@").lower(), owner_source) not in completed_avatar_keys:
                         missing_avatar_count += 1
-                hosted_tagged = (
-                    post_json.get("hosted_tagged_profile_pics")
-                    if isinstance(post_json.get("hosted_tagged_profile_pics"), dict)
-                    else {}
-                )
+                hosted_tagged = _as_hosted_tagged_url_map(social_repo, post_json.get("hosted_tagged_profile_pics"))
                 for detail_key in ("tagged_users_detail", "collaborators_detail"):
                     for detail in post_json.get(detail_key) or []:
                         if not isinstance(detail, dict):
@@ -1068,11 +1087,7 @@ def _build_missing_detail_target_groups(
             if bool(avatar_state.get("needs_repair")):
                 _add_group_target("avatars", platform, source_id)
             if platform == "instagram":
-                hosted_tagged = (
-                    post_json.get("hosted_tagged_profile_pics")
-                    if isinstance(post_json.get("hosted_tagged_profile_pics"), dict)
-                    else {}
-                )
+                hosted_tagged = _as_hosted_tagged_url_map(social_repo, post_json.get("hosted_tagged_profile_pics"))
                 mention_gap = False
                 for mention in social_repo._as_text_list(  # noqa: SLF001
                     post_json.get("mentions"),

--- a/trr_backend/socials/control_plane/dispatch_runtime.py
+++ b/trr_backend/socials/control_plane/dispatch_runtime.py
@@ -402,7 +402,7 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
             dispatch_blocked_failure_count=0,
             dispatch_blocked_first_seen_at=None,
         )
-        dispatch_result = legacy.dispatch_social_job(job_id=job_id)
+        dispatch_result = legacy.dispatch_social_job(job_id=job_id, stage=stage)
         if dispatch_result.get("dispatched"):
             legacy._touch_job_dispatch_metadata(
                 job_id,

--- a/trr_backend/socials/control_plane/run_lifecycle.py
+++ b/trr_backend/socials/control_plane/run_lifecycle.py
@@ -145,6 +145,7 @@ def _maybe_start_deferred_comments_followup(
     if str(followup.get("platform") or "").strip().lower() != "instagram":
         return
 
+    attached_followups = legacy._normalize_attached_followups(run_config.get("attached_followups"))
     now_iso = legacy._iso(legacy._now_utc())
     try:
         comments_result = legacy.start_social_account_comments_scrape(
@@ -163,6 +164,14 @@ def _maybe_start_deferred_comments_followup(
         _merge_run_config(
             run_id,
             config_updates={
+                "attached_followups": {
+                    **attached_followups,
+                    "comments": legacy._build_attached_comments_followup(
+                        run_id=str((comments_result or {}).get("run_id") or "").strip() or None,
+                        status=str((comments_result or {}).get("status") or "").strip().lower() or "pending",
+                        source="deferred_after_catalog",
+                    ),
+                },
                 "deferred_comments_followup": {
                     **followup,
                     "state": "started",
@@ -176,19 +185,28 @@ def _maybe_start_deferred_comments_followup(
                     )
                     or legacy._metadata_dict(followup.get("created_by_runtime_version"))
                     or dict(legacy._resolve_runtime_version_stamp()),
-                }
+                },
             },
         )
     except Exception as exc:  # noqa: BLE001
         _merge_run_config(
             run_id,
             config_updates={
+                "attached_followups": {
+                    **attached_followups,
+                    "comments": legacy._build_attached_comments_followup(
+                        run_id=str(followup.get("comments_run_id") or "").strip() or None,
+                        status="failed",
+                        source="deferred_after_catalog",
+                        state="failed",
+                    ),
+                },
                 "deferred_comments_followup": {
                     **followup,
                     "state": "failed",
                     "failed_at": now_iso,
                     "error_message": str(exc),
-                }
+                },
             },
         )
         legacy.logger.exception(

--- a/trr_backend/socials/crawlee_runtime/runtime.py
+++ b/trr_backend/socials/crawlee_runtime/runtime.py
@@ -12,12 +12,12 @@ from threading import Thread
 from typing import Any
 from uuid import uuid4
 
-logger = logging.getLogger(__name__)
-
 from .auth_preflight import AuthPreflightResult, build_auth_context
 from .config import CrawleeRuntimeConfig
 from .error_taxonomy import classify_exception
 from .request_keys import build_request_key
+
+logger = logging.getLogger(__name__)
 
 StageRunner = Callable[[], tuple[int, int, dict[str, Any]]]
 
@@ -122,7 +122,24 @@ def _build_runtime_meta(
     }
 
 
-def _run_coroutine(coro: Any) -> Any:
+def _resolve_join_timeout_seconds(*, platform: str, runtime_config: CrawleeRuntimeConfig) -> float:
+    platform_suffix = (platform or "").strip().upper()
+    default_timeout_seconds = max(30.0, min(900.0, float(max(1, int(runtime_config.max_retries))) * 120.0))
+    raw = (
+        os.getenv(f"SOCIAL_CRAWLEE_JOIN_TIMEOUT_SECONDS_{platform_suffix}")
+        or os.getenv("SOCIAL_CRAWLEE_JOIN_TIMEOUT_SECONDS")
+        or ""
+    ).strip()
+    if not raw:
+        return default_timeout_seconds
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return default_timeout_seconds
+    return max(1.0, min(3600.0, parsed))
+
+
+def _run_coroutine(coro: Any, *, join_timeout_seconds: float | None = None) -> Any:
     try:
         asyncio.get_running_loop()
     except RuntimeError:
@@ -131,16 +148,40 @@ def _run_coroutine(coro: Any) -> Any:
     payload: dict[str, Any] = {}
 
     def _thread_main() -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        task = loop.create_task(coro)
+        payload["loop"] = loop
+        payload["task"] = task
         try:
-            payload["result"] = asyncio.run(coro)
+            payload["result"] = loop.run_until_complete(task)
+        except asyncio.CancelledError:
+            payload["cancelled"] = True
         except Exception as exc:  # noqa: BLE001
             payload["error"] = exc
+        finally:
+            try:
+                loop.close()
+            except Exception:  # noqa: BLE001
+                pass
 
     thread = Thread(target=_thread_main, daemon=True)
     thread.start()
-    thread.join()
+    thread.join(timeout=join_timeout_seconds)
+    if thread.is_alive():
+        loop = payload.get("loop")
+        task = payload.get("task")
+        if loop is not None and task is not None and hasattr(loop, "call_soon_threadsafe"):
+            try:
+                loop.call_soon_threadsafe(task.cancel)
+            except Exception:  # noqa: BLE001
+                pass
+        thread.join(timeout=1.0)
+        raise TimeoutError(f"Crawlee runtime coroutine exceeded join timeout ({join_timeout_seconds}s)")
     if "error" in payload:
         raise payload["error"]
+    if payload.get("cancelled"):
+        raise TimeoutError(f"Crawlee runtime coroutine exceeded join timeout ({join_timeout_seconds}s)")
     return payload.get("result")
 
 
@@ -184,10 +225,15 @@ def _execute_with_internal_retry(
             if error_code in {"blocked", "rate_limited"}:
                 counters.blocked_events += 1
             if retryable and attempt < attempts:
-                backoff = min(60, 2 ** attempt)  # 1s, 2s, 4s, 8s … capped at 60s
+                backoff = min(60, 2 ** (attempt - 1))  # 1s, 2s, 4s, 8s … capped at 60s
                 logger.warning(
                     "crawlee retry %d/%d for %s:%s (%s) — backing off %.1fs",
-                    attempt, attempts, platform, stage, error_code, backoff,
+                    attempt,
+                    attempts,
+                    platform,
+                    stage,
+                    error_code,
+                    backoff,
                 )
                 time.sleep(backoff)
                 counters.retries_total += 1
@@ -356,10 +402,15 @@ def execute_platform_stage_with_crawlee(
                         if can_retry:
                             queued_request.retry_count += 1
                             queued_request.session_rotation_count = (queued_request.session_rotation_count or 0) + 1
-                            backoff = min(60, 2 ** queued_request.retry_count)
+                            backoff = min(60, 2 ** max(0, queued_request.retry_count - 1))
                             logger.warning(
                                 "crawlee queue retry %d/%d for %s:%s (%s) — backing off %.1fs",
-                                queued_request.retry_count, max_retries, platform, stage, error_code, backoff,
+                                queued_request.retry_count,
+                                max_retries,
+                                platform,
+                                stage,
+                                error_code,
+                                backoff,
                             )
                             await asyncio.sleep(backoff)
                             counters.retries_total += 1
@@ -408,4 +459,5 @@ def execute_platform_stage_with_crawlee(
             },
         )
 
-    return _run_coroutine(_execute_with_queue())
+    join_timeout_seconds = _resolve_join_timeout_seconds(platform=platform, runtime_config=runtime_config)
+    return _run_coroutine(_execute_with_queue(), join_timeout_seconds=join_timeout_seconds)

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -14,6 +14,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlparse
@@ -26,6 +27,11 @@ from trr_backend.socials.instagram.permalink_metadata import _shortcode_to_media
 from trr_backend.socials.instagram.scraper import InstagramComment, InstagramScraper
 
 logger = logging.getLogger("socials.instagram.comments_scrapling.fetcher")
+
+_COMMENT_PAGINATION_MAX_PAGES_DEFAULT = 25
+_REPLY_PAGINATION_MAX_PAGES_DEFAULT = 10
+_COMMENT_PAGINATION_MAX_SECONDS_DEFAULT = 30.0
+_REPLY_PAGINATION_MAX_SECONDS_DEFAULT = 20.0
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -47,6 +53,28 @@ def _env_truthy(name: str, default: bool) -> bool:
     if not raw:
         return default
     return raw in {"1", "true", "yes", "on"}
+
+
+def _resolve_positive_int_env(name: str, default: int, *, minimum: int, maximum: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def _resolve_positive_float_env(name: str, default: float, *, minimum: float, maximum: float) -> float:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return max(minimum, min(maximum, value))
 
 
 def _auth_failure_text(text: str) -> bool:
@@ -198,7 +226,7 @@ class InstagramCommentsScraplingFetcher:
         if _status_code(response) in {401, 403} or _auth_failure_text(text):
             raise RuntimeError("Instagram auth warm-up failed; session appears logged out or challenged.")
         self._merge_warmup_cookies(response)
-        self._rebuild_http_client()
+        await self._rebuild_http_client()
 
     async def fetch_comments_for_shortcode(
         self,
@@ -226,8 +254,28 @@ class InstagramCommentsScraplingFetcher:
         auth_failed = False
         fetch_reason: str | None = None
         retryable = False
+        pages_seen = 0
+        seen_cursors: set[str] = set()
+        deadline = time.monotonic() + _resolve_positive_float_env(
+            "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_SECONDS",
+            _COMMENT_PAGINATION_MAX_SECONDS_DEFAULT,
+            minimum=1.0,
+            maximum=300.0,
+        )
+        page_cap = _resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_PAGES",
+            _COMMENT_PAGINATION_MAX_PAGES_DEFAULT,
+            minimum=1,
+            maximum=250,
+        )
 
         while True:
+            if time.monotonic() >= deadline:
+                fetch_failed = True
+                fetch_reason = "pagination_deadline_exceeded"
+                retryable = True
+                logger.warning("Instagram comments pagination deadline exceeded for shortcode=%s", shortcode)
+                break
             response = await self._fetch_json_response(
                 COMMENTS_URL.format(media_id=media_id),
                 referer=post_url,
@@ -238,12 +286,18 @@ class InstagramCommentsScraplingFetcher:
                 },
             )
             payload = response.get("payload")
-            fetch_reason = response.get("reason")
-            fetch_failed = bool(response.get("failed"))
-            auth_failed = bool(response.get("auth_failed"))
-            retryable = bool(response.get("retryable"))
-            if fetch_failed or not isinstance(payload, (dict, list)):
+            page_fetch_reason = response.get("reason")
+            page_fetch_failed = bool(response.get("failed"))
+            page_auth_failed = bool(response.get("auth_failed"))
+            page_retryable = bool(response.get("retryable"))
+            fetch_failed = fetch_failed or page_fetch_failed
+            auth_failed = auth_failed or page_auth_failed
+            retryable = retryable or page_retryable
+            if page_fetch_reason and not fetch_reason:
+                fetch_reason = page_fetch_reason
+            if page_fetch_failed or not isinstance(payload, (dict, list)):
                 break
+            pages_seen += 1
 
             comment_rows = payload if isinstance(payload, list) else list(payload.get("comments") or [])
             for comment_data in comment_rows:
@@ -274,9 +328,29 @@ class InstagramCommentsScraplingFetcher:
                 break
             has_more = bool(payload.get("has_more_comments", False)) or bool(payload.get("has_more_headload_comments"))
             next_cursor = payload.get("next_min_id") or payload.get("next_max_id")
-            if not has_more or not next_cursor or next_cursor == cursor:
+            if not has_more or not next_cursor:
                 break
-            cursor = str(next_cursor)
+            next_cursor = str(next_cursor)
+            if next_cursor == cursor or next_cursor in seen_cursors:
+                fetch_failed = True
+                fetch_reason = "pagination_repeated_cursor"
+                logger.warning(
+                    "Instagram comments pagination repeated cursor for shortcode=%s cursor=%s",
+                    shortcode,
+                    next_cursor,
+                )
+                break
+            if pages_seen >= page_cap:
+                fetch_failed = True
+                fetch_reason = "pagination_page_cap_reached"
+                logger.warning(
+                    "Instagram comments pagination page cap reached for shortcode=%s page_cap=%d",
+                    shortcode,
+                    page_cap,
+                )
+                break
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
 
         return InstagramCommentsFetchResult(
             comments=comments,
@@ -314,8 +388,28 @@ class InstagramCommentsScraplingFetcher:
         auth_failed = False
         fetch_reason: str | None = None
         retryable = False
+        pages_seen = 0
+        seen_cursors: set[str] = set()
+        deadline = time.monotonic() + _resolve_positive_float_env(
+            "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_SECONDS",
+            _REPLY_PAGINATION_MAX_SECONDS_DEFAULT,
+            minimum=1.0,
+            maximum=300.0,
+        )
+        page_cap = _resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES",
+            _REPLY_PAGINATION_MAX_PAGES_DEFAULT,
+            minimum=1,
+            maximum=250,
+        )
 
         while True:
+            if time.monotonic() >= deadline:
+                fetch_failed = True
+                fetch_reason = "pagination_deadline_exceeded"
+                retryable = True
+                logger.warning("Instagram reply pagination deadline exceeded for comment_id=%s", comment_id)
+                break
             response = await self._fetch_json_response(
                 COMMENT_REPLIES_URL.format(media_id=media_id, comment_id=comment_id),
                 referer=post_url,
@@ -328,6 +422,7 @@ class InstagramCommentsScraplingFetcher:
             retryable = retryable or bool(response.get("retryable"))
             if fetch_failed or not isinstance(payload, (dict, list)):
                 break
+            pages_seen += 1
 
             if isinstance(payload, dict):
                 reply_rows = payload.get("child_comments") or payload.get("replies") or []
@@ -351,9 +446,29 @@ class InstagramCommentsScraplingFetcher:
             if not bool(payload.get("has_more_tail_child_comments", False)):
                 break
             next_cursor = payload.get("next_min_child_cursor")
-            if not next_cursor or next_cursor == cursor:
+            if not next_cursor:
                 break
-            cursor = str(next_cursor)
+            next_cursor = str(next_cursor)
+            if next_cursor == cursor or next_cursor in seen_cursors:
+                fetch_failed = True
+                fetch_reason = "pagination_repeated_cursor"
+                logger.warning(
+                    "Instagram reply pagination repeated cursor for comment_id=%s cursor=%s",
+                    comment_id,
+                    next_cursor,
+                )
+                break
+            if pages_seen >= page_cap:
+                fetch_failed = True
+                fetch_reason = "pagination_page_cap_reached"
+                logger.warning(
+                    "Instagram reply pagination page cap reached for comment_id=%s page_cap=%d",
+                    comment_id,
+                    page_cap,
+                )
+                break
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
 
         return InstagramCommentsFetchResult(
             comments=replies,
@@ -387,11 +502,15 @@ class InstagramCommentsScraplingFetcher:
                 except Exception:  # noqa: BLE001
                     pass
 
-    def _rebuild_http_client(self) -> None:
+    async def _rebuild_http_client(self) -> None:
         """Create or recreate the httpx client with current cookies and proxy."""
-        if self._http_client is not None:
-            # Can't await aclose in a sync context; let GC handle it.
-            self._http_client = None
+        existing_client = self._http_client
+        self._http_client = None
+        if existing_client is not None:
+            try:
+                await existing_client.aclose()
+            except Exception:  # noqa: BLE001
+                pass
         self._http_client = httpx.AsyncClient(
             cookies=dict(self._raw_cookies),
             timeout=httpx.Timeout(self._timeout_ms / 1000),
@@ -443,7 +562,7 @@ class InstagramCommentsScraplingFetcher:
     ) -> httpx.Response:
         """Plain HTTP GET via httpx. Used for comments/replies JSON API calls."""
         if self._http_client is None:
-            self._rebuild_http_client()
+            await self._rebuild_http_client()
         self._request_count += 1
         headers = self._parser._get_headers(referer)
         clean_params = {k: v for k, v in (params or {}).items() if v is not None} or None

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
@@ -13,6 +14,8 @@ from trr_backend.socials.instagram.comments_scrapling.fetcher import (
 from trr_backend.socials.instagram.comments_scrapling.persistence import persist_instagram_comments_for_post
 from trr_backend.socials.instagram.comments_scrapling.proxy import select_comments_proxy
 from trr_backend.socials.instagram.comments_scrapling.session import resolve_comments_scrapling_session
+
+logger = logging.getLogger("socials.instagram.comments_scrapling.job_runner")
 
 
 @dataclass(slots=True)
@@ -83,6 +86,8 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         "total_posts": len(target_source_ids),
     }
     fetcher_metadata: dict[str, Any] = {}
+    terminal_status = str(job.get("status") or "").strip().lower() or None
+    terminal_error_message: str | None = None
 
     # Single event loop: fetcher is created, warmed up, used for all
     # shortcodes, and closed within one asyncio.run(). The httpx client
@@ -107,81 +112,82 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         try:
             await fetcher.warmup()
             auth_metadata = dict(session.auth_session.metadata or {})
-
-            repo._touch_job_heartbeat(job_id, worker_id=worker_id)
-            repo._emit_job_progress(
-                job_id=job_id,
-                stage=stage,
-                platform="instagram",
-                account=account_handle,
-                scraped_posts=0,
-                scraped_comments=0,
-                posts_upserted=0,
-                comments_upserted=0,
-                activity=activity,
-                progress_state=progress_state,
-                force=True,
-            )
-
-            for index, shortcode in enumerate(target_source_ids, start=1):
+            with pg.db_connection(label="instagram-comments-scrapling-persist") as persist_conn:
                 repo._touch_job_heartbeat(job_id, worker_id=worker_id)
-                result = await fetcher.fetch_comments_for_shortcode(
-                    shortcode,
-                    max_comments=max_comments_per_post,
-                    fetch_replies=fetch_replies,
-                )
-                if result.auth_failed:
-                    raise CommentsScraplingRuntimeError(
-                        f"Instagram auth failed while fetching comments for {shortcode}.",
-                        error_code="instagram_comments_auth_failed",
-                        retryable=False,
-                        runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
-                    )
-                if result.fetch_failed and not result.comments:
-                    raise CommentsScraplingRuntimeError(
-                        f"Instagram comments fetch failed for {shortcode}.",
-                        error_code=str(result.fetch_reason or "instagram_comments_fetch_failed"),
-                        retryable=bool(result.retryable),
-                        runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
-                    )
-                persisted = persist_instagram_comments_for_post(
-                    account_handle=account_handle,
-                    shortcode=shortcode,
-                    comments=result.comments,
-                    run_id=run_id or None,
-                    job_id=job_id,
-                    is_complete=_comments_scrape_is_complete(
-                        result=result,
-                        max_comments_per_post=max_comments_per_post,
-                    ),
-                    source_scope=source_scope,
-                )
-                processed_posts += 1
-                comments_fetched += len(result.comments)
-                comments_upserted += persisted.comments_upserted
-                comments_marked_missing += persisted.comments_marked_missing
-                mirror_jobs_enqueued += persisted.comment_media_mirror_jobs_enqueued
-                mirror_job_enqueue_errors += persisted.comment_media_mirror_job_enqueue_errors
-                activity = {
-                    "phase": "comments_scrapling_running",
-                    "posts_checked": len(target_source_ids),
-                    "matched_posts": index,
-                    "saved_posts": processed_posts,
-                    "total_posts": len(target_source_ids),
-                }
                 repo._emit_job_progress(
                     job_id=job_id,
                     stage=stage,
                     platform="instagram",
                     account=account_handle,
-                    scraped_posts=processed_posts,
-                    scraped_comments=comments_fetched,
-                    posts_upserted=processed_posts,
-                    comments_upserted=comments_upserted,
+                    scraped_posts=0,
+                    scraped_comments=0,
+                    posts_upserted=0,
+                    comments_upserted=0,
                     activity=activity,
                     progress_state=progress_state,
-                    force=index == len(target_source_ids),
+                    force=True,
                 )
+
+                for index, shortcode in enumerate(target_source_ids, start=1):
+                    repo._touch_job_heartbeat(job_id, worker_id=worker_id)
+                    result = await fetcher.fetch_comments_for_shortcode(
+                        shortcode,
+                        max_comments=max_comments_per_post,
+                        fetch_replies=fetch_replies,
+                    )
+                    if result.auth_failed:
+                        raise CommentsScraplingRuntimeError(
+                            f"Instagram auth failed while fetching comments for {shortcode}.",
+                            error_code="instagram_comments_auth_failed",
+                            retryable=False,
+                            runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
+                        )
+                    if result.fetch_failed and not result.comments:
+                        raise CommentsScraplingRuntimeError(
+                            f"Instagram comments fetch failed for {shortcode}.",
+                            error_code=str(result.fetch_reason or "instagram_comments_fetch_failed"),
+                            retryable=bool(result.retryable),
+                            runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
+                        )
+                    persisted = persist_instagram_comments_for_post(
+                        account_handle=account_handle,
+                        shortcode=shortcode,
+                        comments=result.comments,
+                        run_id=run_id or None,
+                        job_id=job_id,
+                        is_complete=_comments_scrape_is_complete(
+                            result=result,
+                            max_comments_per_post=max_comments_per_post,
+                        ),
+                        source_scope=source_scope,
+                        conn=persist_conn,
+                    )
+                    processed_posts += 1
+                    comments_fetched += len(result.comments)
+                    comments_upserted += persisted.comments_upserted
+                    comments_marked_missing += persisted.comments_marked_missing
+                    mirror_jobs_enqueued += persisted.comment_media_mirror_jobs_enqueued
+                    mirror_job_enqueue_errors += persisted.comment_media_mirror_job_enqueue_errors
+                    activity = {
+                        "phase": "comments_scrapling_running",
+                        "posts_checked": len(target_source_ids),
+                        "matched_posts": index,
+                        "saved_posts": processed_posts,
+                        "total_posts": len(target_source_ids),
+                    }
+                    repo._emit_job_progress(
+                        job_id=job_id,
+                        stage=stage,
+                        platform="instagram",
+                        account=account_handle,
+                        scraped_posts=processed_posts,
+                        scraped_comments=comments_fetched,
+                        posts_upserted=processed_posts,
+                        comments_upserted=comments_upserted,
+                        activity=activity,
+                        progress_state=progress_state,
+                        force=index == len(target_source_ids),
+                    )
 
             return auth_metadata, dict(fetcher.runtime_metadata)
         finally:
@@ -223,6 +229,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             items_found=processed_posts + comments_fetched,
             metadata=metadata,
         )
+        terminal_status = "completed"
     except Exception as exc:  # noqa: BLE001
         runtime_error_code = str(getattr(exc, "error_code", "") or "").strip().lower()
         error_code = runtime_error_code or "instagram_comments_scrapling_failed"
@@ -260,26 +267,55 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             last_error_class=error_class,
             next_available_at=next_available_at,
         )
+        terminal_status = "retrying" if can_retry else "failed"
+        terminal_error_message = str(exc)
     finally:
         if run_id:
-            repo._finalize_run_status(run_id)
+            try:
+                repo._finalize_run_status(run_id)
+            except pg.DatabaseServiceUnavailableError as exc:
+                logger.warning(
+                    "Deferred final comments run-status reconciliation after database saturation: run_id=%s error=%s",
+                    run_id,
+                    exc,
+                )
 
-    return (
-        pg.fetch_one(
-            """
-            select
-              id::text,
-              run_id::text as run_id,
-              platform,
-              job_type,
-              status,
-              items_found,
-              error_message,
-              metadata
-            from social.scrape_jobs
-            where id = %s
-            """,
-            [job_id],
+    try:
+        return (
+            pg.fetch_one(
+                """
+                select
+                  id::text,
+                  run_id::text as run_id,
+                  platform,
+                  job_type,
+                  status,
+                  items_found,
+                  error_message,
+                  metadata
+                from social.scrape_jobs
+                where id = %s
+                """,
+                [job_id],
+            )
+            or {}
         )
-        or {}
-    )
+    except pg.DatabaseServiceUnavailableError as exc:
+        logger.warning(
+            "Returning degraded comments job summary after database saturation: job_id=%s error=%s",
+            job_id,
+            exc,
+        )
+        return {
+            "id": job_id,
+            "run_id": run_id or None,
+            "platform": "instagram",
+            "job_type": str(job.get("job_type") or "comments").strip() or "comments",
+            "status": terminal_status or "unknown",
+            "items_found": processed_posts + comments_fetched,
+            "error_message": terminal_error_message,
+            "metadata": {
+                "degraded_summary": True,
+                "database_service_unavailable": True,
+            },
+        }

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -135,7 +135,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         max_comments=max_comments_per_post,
                         fetch_replies=fetch_replies,
                     )
-                    if result.auth_failed:
+                    if result.auth_failed and not result.comments:
                         raise CommentsScraplingRuntimeError(
                             f"Instagram auth failed while fetching comments for {shortcode}.",
                             error_code="instagram_comments_auth_failed",
@@ -162,6 +162,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         source_scope=source_scope,
                         conn=persist_conn,
                     )
+                    persist_conn.commit()
                     processed_posts += 1
                     comments_fetched += len(result.comments)
                     comments_upserted += persisted.comments_upserted

--- a/trr_backend/socials/instagram/comments_scrapling/persistence.py
+++ b/trr_backend/socials/instagram/comments_scrapling/persistence.py
@@ -162,62 +162,75 @@ def persist_instagram_comments_for_post(
     job_id: str | None,
     is_complete: bool,
     source_scope: str = "bravo",
+    conn: Any | None = None,
 ) -> PersistedInstagramComments:
+    if conn is None:
+        with pg.db_connection() as managed_conn:
+            return persist_instagram_comments_for_post(
+                account_handle=account_handle,
+                shortcode=shortcode,
+                comments=comments,
+                run_id=run_id,
+                job_id=job_id,
+                is_complete=is_complete,
+                source_scope=source_scope,
+                conn=managed_conn,
+            )
+
     repo = _load_repo_helpers()
-    with pg.db_connection() as conn:
-        post_row = _materialize_instagram_post_for_comments(
-            repo=repo,
-            account_handle=account_handle,
-            shortcode=shortcode,
+    post_row = _materialize_instagram_post_for_comments(
+        repo=repo,
+        account_handle=account_handle,
+        shortcode=shortcode,
+        conn=conn,
+    )
+    observed_comment_ids: set[str] = set()
+    persist_stats = repo._new_comment_persist_stats()
+    comments_upserted = 0
+    comments_marked_missing = 0
+    post_id = str(post_row.get("id") or "").strip()
+    season_id = str(post_row.get("season_id") or "").strip() or None
+
+    if season_id:
+        context = repo.get_season_context(season_id, conn=conn)
+        comments_upserted = repo._batch_upsert_instagram_comments(
+            context,
+            job_id=job_id,
+            run_id=run_id,
+            account=account_handle,
+            post_id=post_id,
+            comments=comments,
+            observed_comment_ids=observed_comment_ids,
+            persist_stats=persist_stats,
+            source_scope=source_scope,
             conn=conn,
         )
-        observed_comment_ids: set[str] = set()
-        persist_stats = repo._new_comment_persist_stats()
-        comments_upserted = 0
-        comments_marked_missing = 0
-        post_id = str(post_row.get("id") or "").strip()
-        season_id = str(post_row.get("season_id") or "").strip() or None
+    else:
+        comments_upserted = _persist_without_season_context(
+            repo=repo,
+            post_id=post_id,
+            account_handle=account_handle,
+            comments=comments,
+            run_id=run_id,
+            job_id=job_id,
+            observed_comment_ids=observed_comment_ids,
+            persist_stats=persist_stats,
+            conn=conn,
+        )
+    if is_complete:
+        comments_marked_missing = repo._mark_missing_comments_for_anchor(
+            platform="instagram",
+            anchor_id=post_id,
+            observed_comment_ids=observed_comment_ids,
+            conn=conn,
+        )
+        repo._reconcile_post_comment_count(
+            platform="instagram",
+            post_db_id=post_id,
+            conn=conn,
+        )
 
-        if season_id:
-            context = repo.get_season_context(season_id, conn=conn)
-            comments_upserted = repo._batch_upsert_instagram_comments(
-                context,
-                job_id=job_id,
-                run_id=run_id,
-                account=account_handle,
-                post_id=post_id,
-                comments=comments,
-                observed_comment_ids=observed_comment_ids,
-                persist_stats=persist_stats,
-                source_scope=source_scope,
-                conn=conn,
-            )
-        else:
-            comments_upserted = _persist_without_season_context(
-                repo=repo,
-                post_id=post_id,
-                account_handle=account_handle,
-                comments=comments,
-                run_id=run_id,
-                job_id=job_id,
-                observed_comment_ids=observed_comment_ids,
-                persist_stats=persist_stats,
-                conn=conn,
-            )
-        if is_complete:
-            comments_marked_missing = repo._mark_missing_comments_for_anchor(
-                platform="instagram",
-                anchor_id=post_id,
-                observed_comment_ids=observed_comment_ids,
-                conn=conn,
-            )
-            repo._reconcile_post_comment_count(
-                platform="instagram",
-                post_db_id=post_id,
-                conn=conn,
-            )
-
-        stored_total = repo._count_stored_comments([post_id], "instagram", conn=conn).get(post_id, 0)
+    stored_total = repo._count_stored_comments([post_id], "instagram", conn=conn).get(post_id, 0)
     return PersistedInstagramComments(
         post_id=post_id,
         stored_total_comments=int(stored_total or 0),
@@ -308,7 +321,11 @@ def _persist_without_season_context(
             for payload in batch:
                 parent_external_id = str(payload.pop("_parent_external_id", "") or "").strip()
                 payload["parent_comment_id"] = ext_to_db.get(parent_external_id)
-        rows = repo._pg_upsert_many("instagram_comments", batch, conflict_col="comment_id", conn=conn) if batch else []
+        rows = (
+            repo._pg_upsert_many("instagram_comments", batch, conflict_col=["post_id", "comment_id"], conn=conn)
+            if batch
+            else []
+        )
         for row in rows:
             ext_id = str(row.get("comment_id") or "").strip()
             db_id = str(row.get("id") or "").strip()

--- a/trr_backend/socials/instagram/posts_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/posts_scrapling/fetcher.py
@@ -334,7 +334,7 @@ class InstagramPostsScraplingFetcher:
             raise RuntimeError("Instagram auth warm-up failed; session appears logged out or challenged.")
         self._page_tokens = _extract_page_tokens(text)
         self._merge_warmup_cookies(response)
-        self._rebuild_http_client()
+        await self._rebuild_http_client()
         logger.info(
             "instagram_posts_scrapling warmup_success",
             extra={
@@ -472,11 +472,15 @@ class InstagramPostsScraplingFetcher:
         for name, value in new_cookies.items():
             self._raw_cookies[name] = value
 
-    def _rebuild_http_client(self) -> None:
+    async def _rebuild_http_client(self) -> None:
         """Create or recreate the httpx client with current cookies and proxy."""
-        if self._http_client is not None:
-            # Can't await aclose in a sync context; let GC handle it.
-            self._http_client = None
+        existing_client = self._http_client
+        self._http_client = None
+        if existing_client is not None:
+            try:
+                await existing_client.aclose()
+            except Exception:  # noqa: BLE001
+                pass
         self._http_client = httpx.AsyncClient(
             cookies=dict(self._raw_cookies),
             timeout=httpx.Timeout(self._timeout_ms / 1000),
@@ -526,7 +530,7 @@ class InstagramPostsScraplingFetcher:
     ) -> httpx.Response:
         """Plain HTTP POST via httpx. Used for GraphQL posts-page calls."""
         if self._http_client is None:
-            self._rebuild_http_client()
+            await self._rebuild_http_client()
         self._request_count += 1
         return await self._http_client.post(url, data=data, headers=headers)  # type: ignore[union-attr]
 

--- a/trr_backend/socials/instagram/scraper.py
+++ b/trr_backend/socials/instagram/scraper.py
@@ -90,6 +90,10 @@ _INSTAGRAM_BROWSER_SESSIONS = AccountBrowserSessionManager(
     platform="instagram",
     cookie_domains=(".instagram.com",),
 )
+_COMMENT_PAGINATION_MAX_PAGES_DEFAULT = 25
+_REPLY_PAGINATION_MAX_PAGES_DEFAULT = 10
+_COMMENT_PAGINATION_MAX_SECONDS_DEFAULT = 30.0
+_REPLY_PAGINATION_MAX_SECONDS_DEFAULT = 20.0
 
 
 @dataclass
@@ -218,6 +222,36 @@ class InstagramComment:
         # Convert nested replies
         result["replies"] = [r.to_dict() if hasattr(r, "to_dict") else r for r in self.replies]
         return result
+
+
+@dataclass
+class ConcurrentCommentFetchResult:
+    """Structured concurrent comment fetch outcome with explicit per-post errors."""
+
+    comments_by_shortcode: dict[str, list[InstagramComment]] = field(default_factory=dict)
+    errors_by_shortcode: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def total_comments(self) -> int:
+        return sum(len(comments) for comments in self.comments_by_shortcode.values())
+
+    @property
+    def comments(self) -> dict[str, list[InstagramComment]]:
+        return self.comments_by_shortcode
+
+    @property
+    def errors(self) -> dict[str, str]:
+        return self.errors_by_shortcode
+
+    @property
+    def had_failures(self) -> bool:
+        return bool(self.errors_by_shortcode)
+
+    def __getitem__(self, shortcode: str) -> list[InstagramComment]:
+        return self.comments_by_shortcode[shortcode]
+
+    def get(self, shortcode: str, default: list[InstagramComment] | None = None) -> list[InstagramComment] | None:
+        return self.comments_by_shortcode.get(shortcode, default)
 
 
 @dataclass
@@ -352,6 +386,8 @@ class InstagramScraper:
         self._rate_controller = InstagramRateController()
         self._request_client = InstagramRequestClient(session=self.session)
         self._profile_page_context_cache: dict[str, dict[str, str]] = {}
+        self._context_cache_lock = threading.RLock()
+        self._concurrent_rate_limit_lock: threading.Lock | None = None
         self.last_retrieval_meta: dict[str, Any] = {}
         self.comments_auth_failed = False
         self.last_comment_fetch_reason: str | None = None
@@ -395,6 +431,45 @@ class InstagramScraper:
     @staticmethod
     def _env_truthy(name: str) -> bool:
         return str(os.getenv(name) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _resolve_positive_int_env(name: str, default: int, *, minimum: int, maximum: int) -> int:
+        raw = (os.getenv(name) or "").strip()
+        if not raw:
+            return default
+        try:
+            value = int(raw)
+        except ValueError:
+            return default
+        return max(minimum, min(maximum, value))
+
+    @staticmethod
+    def _resolve_positive_float_env(name: str, default: float, *, minimum: float, maximum: float) -> float:
+        raw = (os.getenv(name) or "").strip()
+        if not raw:
+            return default
+        try:
+            value = float(raw)
+        except ValueError:
+            return default
+        return max(minimum, min(maximum, value))
+
+    def _get_profile_page_context_cache_entry(self, username: str) -> dict[str, str]:
+        with self._context_cache_lock:
+            cached = self._profile_page_context_cache.get(username) or {}
+            return dict(cached)
+
+    def _set_profile_page_context_cache_entry(self, username: str, context: dict[str, str]) -> None:
+        with self._context_cache_lock:
+            self._profile_page_context_cache[username] = dict(context)
+
+    def _pop_profile_page_context_cache_entry(self, username: str) -> None:
+        with self._context_cache_lock:
+            self._profile_page_context_cache.pop(username, None)
+
+    def _clear_profile_page_context_cache(self) -> None:
+        with self._context_cache_lock:
+            self._profile_page_context_cache.clear()
 
     def _build_identity_pool(self) -> InstagramIdentityPool:
         proxy_urls = [
@@ -445,7 +520,7 @@ class InstagramScraper:
             self.last_retrieval_meta["identity_pool_exhausted"] = True
             return False
         self.cookies = self._active_identity.cookies
-        self._profile_page_context_cache.pop(username, None)
+        self._pop_profile_page_context_cache_entry(username)
         self._reset_request_session(preserve_session_cookies=False)
         return previous_session_id != self._active_identity.session_id
 
@@ -639,7 +714,7 @@ class InstagramScraper:
                 self.cookies = fresh_cookies
             for k, v in fresh_cookies.items():
                 self.session.cookies.set(k, v, domain=".instagram.com")
-            self._profile_page_context_cache.clear()
+            self._clear_profile_page_context_cache()
             logger.info("[instagram] cookie auto-refresh succeeded — sessionid=%s…", fresh_cookies["sessionid"][:8])
             return {"refreshed": True, "reason": None, "cookie_file": str(cookie_path)}
         except Exception as exc:  # noqa: BLE001
@@ -714,7 +789,7 @@ class InstagramScraper:
                 self.cookies = fresh_cookies
             for k, v in fresh_cookies.items():
                 self.session.cookies.set(k, v, domain=".instagram.com")
-            self._profile_page_context_cache.clear()
+            self._clear_profile_page_context_cache()
             logger.info("[instagram] interactive login succeeded — sessionid=%s…", fresh_cookies["sessionid"][:8])
             return {"refreshed": True, "reason": None, "method": "interactive_chrome"}
         except Exception as exc:  # noqa: BLE001
@@ -972,14 +1047,17 @@ class InstagramScraper:
                     )
                 runtime = dict((result or {}).get("runtime") or {})
                 if runtime:
-                    self._profile_page_context_cache[username] = {
+                    self._set_profile_page_context_cache_entry(
+                        username,
+                        {
                         "lsd": str(runtime.get("lsd") or "").strip(),
                         "spin_r": str(runtime.get("__spin_r") or "").strip(),
                         "spin_b": str(runtime.get("__spin_b") or "").strip(),
                         "spin_t": str(runtime.get("__spin_t") or "").strip(),
                         "hsi": str(runtime.get("__hsi") or "").strip(),
                         "hs": str(runtime.get("__hs") or "").strip(),
-                    }
+                        },
+                    )
                 for cookie in context.cookies():
                     name = str(cookie.get("name") or "").strip()
                     value = str(cookie.get("value") or "")
@@ -1462,7 +1540,7 @@ class InstagramScraper:
         timeout: tuple[int, int] | float | None = None,
         force: bool = False,
     ) -> dict[str, str]:
-        cached = self._profile_page_context_cache.get(username) or {}
+        cached = self._get_profile_page_context_cache_entry(username)
         if cached and not force:
             return dict(cached)
 
@@ -1498,17 +1576,39 @@ class InstagramScraper:
                     domain=".instagram.com",
                 )
         if context:
-            self._profile_page_context_cache[username] = dict(context)
+            self._set_profile_page_context_cache_entry(username, context)
         return dict(context or cached)
 
     def _rate_limit(self, delay: float, *, fast_mode: bool = False):
         self._rate_controller._sleeper = time.sleep
         self._rate_controller._clock = time.monotonic
-        self._rate_controller.before_query(
-            QUERY_TYPE_LEGACY,
-            base_delay=delay,
-            fast_mode=fast_mode,
-        )
+        rate_lock = getattr(self, "_concurrent_rate_limit_lock", None)
+        if rate_lock is None:
+            self._rate_controller.before_query(
+                QUERY_TYPE_LEGACY,
+                base_delay=delay,
+                fast_mode=fast_mode,
+            )
+            return
+        with rate_lock:
+            self._rate_controller.before_query(
+                QUERY_TYPE_LEGACY,
+                base_delay=delay,
+                fast_mode=fast_mode,
+            )
+
+    def _rate_limit_with_lock(
+        self,
+        delay: float,
+        *,
+        fast_mode: bool = False,
+        rate_lock: Any = None,
+    ) -> None:
+        if rate_lock is None:
+            self._rate_limit(delay, fast_mode=fast_mode)
+            return
+        with rate_lock:
+            self._rate_limit(delay, fast_mode=fast_mode)
 
     def _track_response_status(self, status_code: int) -> None:
         self._rate_controller.record_response(QUERY_TYPE_LEGACY, status_code)
@@ -2462,7 +2562,7 @@ class InstagramScraper:
                     force=(bool(cursor) or attempt_index > 0) if should_warm else False,
                 )
                 if should_warm
-                else self._profile_page_context_cache.get(username, {})
+                else self._get_profile_page_context_cache_entry(username)
             )
             request_cookies = self._request_cookies()
             viewer_id = str(request_cookies.get("ds_user_id") or self.cookies.get("ds_user_id") or "0")
@@ -2612,7 +2712,7 @@ class InstagramScraper:
                 "instagram_graphql_cursor_rate_limited",
             }:
                 self._reset_request_session()
-                self._profile_page_context_cache.pop(username, None)
+                self._pop_profile_page_context_cache_entry(username)
             logger.warning("Instagram GraphQL exhausted cursor retries for @%s after cursor=%s", username, cursor)
         elif last_error is not None:
             self.last_retrieval_meta.update(self._graphql_request_error_details(cursor=cursor, error=last_error))
@@ -2639,7 +2739,7 @@ class InstagramScraper:
             refresh_result = self._try_auto_refresh_cookies()
             if refresh_result.get("refreshed"):
                 self._reset_request_session()
-                self._profile_page_context_cache.pop(username, None)
+                self._pop_profile_page_context_cache_entry(username)
                 retry_payload = self.fetch_posts_graphql(
                     username,
                     cursor=cursor,
@@ -2671,7 +2771,7 @@ class InstagramScraper:
             if interactive_result.get("refreshed"):
                 # Got fresh cookies — retry the failed request once
                 self._reset_request_session()
-                self._profile_page_context_cache.pop(username, None)
+                self._pop_profile_page_context_cache_entry(username)
                 retry_payload = self.fetch_posts_graphql(
                     username,
                     cursor=cursor,
@@ -2833,6 +2933,7 @@ class InstagramScraper:
         delay: float = 2.0,
         *,
         fast_mode: bool = False,
+        rate_lock: Any = None,
     ) -> list[InstagramComment]:
         """
         Fetch comments for a post including replies.
@@ -2861,10 +2962,28 @@ class InstagramScraper:
         comments = []
         cursor = None
         comments_fetched = 0
+        pages_seen = 0
+        seen_cursors: set[str] = set()
+        deadline = time.monotonic() + self._resolve_positive_float_env(
+            "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_SECONDS",
+            _COMMENT_PAGINATION_MAX_SECONDS_DEFAULT,
+            minimum=1.0,
+            maximum=300.0,
+        )
+        page_cap = self._resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_PAGES",
+            _COMMENT_PAGINATION_MAX_PAGES_DEFAULT,
+            minimum=1,
+            maximum=250,
+        )
 
         while True:
             response: requests.Response | None = None
-            self._rate_limit(delay, fast_mode=fast_mode)
+            if time.monotonic() >= deadline:
+                self.last_comment_fetch_reason = "pagination_deadline_exceeded"
+                logger.warning("Instagram comments pagination deadline exceeded for shortcode=%s", shortcode)
+                break
+            self._rate_limit_with_lock(delay, fast_mode=fast_mode, rate_lock=rate_lock)
             url = self.COMMENTS_URL.format(media_id=media_id)
             params = {"can_support_threading": "true", "permalink_enabled": "false"}
             if cursor:
@@ -2929,6 +3048,7 @@ class InstagramScraper:
                 comment_rows = data.get("comments", [])
             else:
                 comment_rows = []
+            pages_seen += 1
             for comment_data in comment_rows:
                 comment = self._parse_comment(comment_data, shortcode, post_url)
                 comments.append(comment)
@@ -2943,6 +3063,7 @@ class InstagramScraper:
                         post_url,
                         delay,
                         fast_mode=fast_mode,
+                        rate_lock=rate_lock,
                     )
                     comment.replies = replies
                     logger.info(f"  Comment {comment.comment_id}: {comment.reply_count} replies fetched")
@@ -2963,8 +3084,26 @@ class InstagramScraper:
             if not has_more:
                 break
             next_cursor = (data.get("next_min_id") or data.get("next_max_id")) if isinstance(data, dict) else None
-            if not next_cursor or next_cursor == cursor:
+            if not next_cursor:
                 break
+            next_cursor = str(next_cursor)
+            if next_cursor == cursor or next_cursor in seen_cursors:
+                self.last_comment_fetch_reason = "pagination_repeated_cursor"
+                logger.warning(
+                    "Instagram comments pagination repeated cursor for shortcode=%s cursor=%s",
+                    shortcode,
+                    next_cursor,
+                )
+                break
+            if pages_seen >= page_cap:
+                self.last_comment_fetch_reason = "pagination_page_cap_reached"
+                logger.warning(
+                    "Instagram comments pagination page cap reached for shortcode=%s page_cap=%d",
+                    shortcode,
+                    page_cap,
+                )
+                break
+            seen_cursors.add(next_cursor)
             cursor = next_cursor
 
         logger.info(f"Total: {len(comments)} comments fetched for {shortcode}")
@@ -2979,14 +3118,33 @@ class InstagramScraper:
         delay: float = 2.0,
         *,
         fast_mode: bool = False,
+        rate_lock: Any = None,
     ) -> list[InstagramComment]:
         """Fetch replies to a specific comment."""
         replies = []
         cursor = None
+        pages_seen = 0
+        seen_cursors: set[str] = set()
+        deadline = time.monotonic() + self._resolve_positive_float_env(
+            "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_SECONDS",
+            _REPLY_PAGINATION_MAX_SECONDS_DEFAULT,
+            minimum=1.0,
+            maximum=300.0,
+        )
+        page_cap = self._resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES",
+            _REPLY_PAGINATION_MAX_PAGES_DEFAULT,
+            minimum=1,
+            maximum=250,
+        )
 
         while True:
             response: requests.Response | None = None
-            self._rate_limit(delay, fast_mode=fast_mode)
+            if time.monotonic() >= deadline:
+                self.last_comment_fetch_reason = "pagination_deadline_exceeded"
+                logger.warning("Instagram reply pagination deadline exceeded for comment_id=%s", comment_id)
+                break
+            self._rate_limit_with_lock(delay, fast_mode=fast_mode, rate_lock=rate_lock)
             url = self.COMMENT_REPLIES_URL.format(media_id=media_id, comment_id=comment_id)
             params = {}
             if cursor:
@@ -3047,6 +3205,7 @@ class InstagramScraper:
                 reply_rows = data
             else:
                 reply_rows = []
+            pages_seen += 1
             for reply_data in reply_rows:
                 reply = self._parse_comment(reply_data, shortcode, post_url, is_reply=True, parent_id=comment_id)
                 replies.append(reply)
@@ -3058,6 +3217,24 @@ class InstagramScraper:
             cursor = data.get("next_min_child_cursor") if isinstance(data, dict) else None
             if not cursor:
                 break
+            cursor = str(cursor)
+            if cursor in seen_cursors:
+                self.last_comment_fetch_reason = "pagination_repeated_cursor"
+                logger.warning(
+                    "Instagram reply pagination repeated cursor for comment_id=%s cursor=%s",
+                    comment_id,
+                    cursor,
+                )
+                break
+            if pages_seen >= page_cap:
+                self.last_comment_fetch_reason = "pagination_page_cap_reached"
+                logger.warning(
+                    "Instagram reply pagination page cap reached for comment_id=%s page_cap=%d",
+                    comment_id,
+                    page_cap,
+                )
+                break
+            seen_cursors.add(cursor)
 
         return replies
 
@@ -3070,10 +3247,10 @@ class InstagramScraper:
         *,
         fast_mode: bool = False,
         max_workers: int | None = None,
-    ) -> dict[str, list["InstagramComment"]]:
+    ) -> ConcurrentCommentFetchResult:
         """Fetch comments for multiple posts concurrently.
 
-        Returns a dict mapping shortcode -> list of comments.
+        Returns structured per-shortcode comments and explicit per-shortcode errors.
         Uses a ThreadPoolExecutor for parallel fetching while coordinating
         rate limiting across threads via a shared lock.
 
@@ -3088,34 +3265,29 @@ class InstagramScraper:
         if max_workers is None:
             max_workers = int(os.getenv("SOCIAL_INSTAGRAM_COMMENT_CONCURRENCY", "3"))
         max_workers = max(1, min(max_workers, 8))  # Clamp to 1-8
+        rate_lock = threading.Lock()
 
         if len(shortcodes) <= 1 or max_workers <= 1:
-            # Sequential fallback for single items or concurrency=1
-            result: dict[str, list[InstagramComment]] = {}
+            sequential_result = ConcurrentCommentFetchResult()
             for sc in shortcodes:
-                result[sc] = self.fetch_comments(
-                    sc,
-                    max_comments=max_comments,
-                    fetch_replies=fetch_replies,
-                    delay=delay,
-                    fast_mode=fast_mode,
-                )
-            return result
+                try:
+                    sequential_result.comments_by_shortcode[sc] = self.fetch_comments(
+                        sc,
+                        max_comments=max_comments,
+                        fetch_replies=fetch_replies,
+                        delay=delay,
+                        fast_mode=fast_mode,
+                        rate_lock=rate_lock,
+                    )
+                except Exception as exc:
+                    sequential_result.comments_by_shortcode.setdefault(sc, [])
+                    sequential_result.errors_by_shortcode[sc] = f"{exc.__class__.__name__}: {exc}"
+                    logger.exception("Sequential comment fetch failed for %s", sc)
+            return sequential_result
 
-        # Use a lock to serialize _rate_limit sleep calls so threads don't
-        # all sleep independently (which would be slower than sequential).
-        rate_lock = threading.Lock()
-        original_rate_limit = self._rate_limit
+        result = ConcurrentCommentFetchResult()
 
-        def _synchronized_rate_limit(d: float, *, fast_mode: bool = False):
-            with rate_lock:
-                original_rate_limit(d, fast_mode=fast_mode)
-
-        results: dict[str, list[InstagramComment]] = {}
-
-        def _fetch_one(shortcode: str) -> tuple[str, list[InstagramComment]]:
-            # Temporarily patch _rate_limit with the synchronized version
-            self._rate_limit = _synchronized_rate_limit  # type: ignore[assignment]
+        def _fetch_one(shortcode: str) -> tuple[str, list[InstagramComment], str | None]:
             try:
                 comments = self.fetch_comments(
                     shortcode,
@@ -3123,11 +3295,12 @@ class InstagramScraper:
                     fetch_replies=fetch_replies,
                     delay=delay,
                     fast_mode=fast_mode,
+                    rate_lock=rate_lock,
                 )
-                return shortcode, comments
+                return shortcode, comments, None
             except Exception as exc:
-                logger.error("Concurrent comment fetch failed for %s: %s", shortcode, exc)
-                return shortcode, []
+                logger.exception("Concurrent comment fetch failed for %s", shortcode)
+                return shortcode, [], f"{exc.__class__.__name__}: {exc}"
 
         logger.info(
             "Fetching comments for %d posts concurrently (workers=%d, fast=%s)",
@@ -3139,8 +3312,17 @@ class InstagramScraper:
             futures = {executor.submit(_fetch_one, sc): sc for sc in shortcodes}
             completed = 0
             for future in as_completed(futures):
-                shortcode, comments = future.result()
-                results[shortcode] = comments
+                shortcode = futures[future]
+                try:
+                    shortcode, comments, error = future.result()
+                except Exception as exc:  # noqa: BLE001
+                    result.comments_by_shortcode.setdefault(shortcode, [])
+                    result.errors_by_shortcode[shortcode] = f"{exc.__class__.__name__}: {exc}"
+                    logger.exception("Concurrent comment future crashed for %s", shortcode)
+                    continue
+                result.comments_by_shortcode[shortcode] = comments
+                if error:
+                    result.errors_by_shortcode[shortcode] = error
                 completed += 1
                 if completed % 10 == 0:
                     logger.info(
@@ -3149,14 +3331,13 @@ class InstagramScraper:
                         len(shortcodes),
                     )
 
-        # Restore original _rate_limit
-        self._rate_limit = original_rate_limit  # type: ignore[assignment]
         logger.info(
-            "Concurrent comment fetch complete: %d posts, %d total comments",
-            len(results),
-            sum(len(v) for v in results.values()),
+            "Concurrent comment fetch complete: %d posts, %d total comments, %d errors",
+            len(result.comments_by_shortcode),
+            result.total_comments,
+            len(result.errors_by_shortcode),
         )
-        return results
+        return result
 
     def _parse_comment(
         self,
@@ -3887,7 +4068,7 @@ class InstagramScraper:
                     if refresh.get("refreshed"):
                         rotation_successes += 1
                         self._reset_request_session()
-                        self._profile_page_context_cache.pop(config.username, None)
+                        self._pop_profile_page_context_cache_entry(config.username)
                         page_num -= 1  # retry same page with fresh cookies
                         continue
                 if page_num == 1:
@@ -4001,7 +4182,7 @@ class InstagramScraper:
                     if refresh.get("refreshed"):
                         rotation_successes += 1
                         self._reset_request_session()
-                        self._profile_page_context_cache.pop(config.username, None)
+                        self._pop_profile_page_context_cache_entry(config.username)
 
         logger.info("Scrape complete: checked %d posts, found %d matches", posts_checked, len(posts))
         profile_avatar_backfilled_posts = 0


### PR DESCRIPTION
## Summary
- land the full instagram remediation hardening branch, including comment/media mirror dedupe, dispatch/runtime fixes, and analytics hardening
- add the follow-up hosted author profile pic migration plus remote diagnosis tooling and additional dispatch/tests
- update schema and observability docs alongside the control-plane changes

## Validation
- backend CI-equivalent checks are being reviewed against current repo workflow gates while PR CI runs
