### PR TITLE
chore: rename brain/ to trr-backend-brain for Obsidian clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ scripts/socials/**/*.csv
 # Git worktrees
 /.worktrees/
 .loom-backup/
-brain/sessions/
+trr-backend-brain/sessions/
 
 # Sensitive session data
 data/instagram_cookies.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-brain/BRAIN.md
+trr-backend-brain/BRAIN.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-brain/BRAIN.md
+trr-backend-brain/BRAIN.md

--- a/trr-backend-brain/AGENTS.md
+++ b/trr-backend-brain/AGENTS.md
@@ -1,0 +1,1 @@
+BRAIN.md

--- a/trr-backend-brain/BRAIN.md
+++ b/trr-backend-brain/BRAIN.md
@@ -1,0 +1,24 @@
+# TRR-BACKEND REPO VAULT
+
+Inherits: /Users/thomashulihan/brain/BRAIN.md
+
+## On boot read ONLY
+- this file
+- /Users/thomashulihan/Projects/TRR/TRR-Backend/trr-backend-brain/README.md
+
+## On demand
+- /Users/thomashulihan/Projects/TRR/TRR-Backend/trr-backend-brain/architecture.md
+- /Users/thomashulihan/Projects/TRR/trr-workspace-brain/api-contract.md
+- /Users/thomashulihan/Projects/TRR/TRR-Backend/trr-backend-brain/handoffs/
+- /Users/thomashulihan/Projects/TRR/TRR-Backend/trr-backend-brain/sessions/ (most recent only)
+
+## Boundary rule
+Would this still be true if `/Users/thomashulihan/Projects/TRR/TRR-APP` disappeared?
+- Yes: keep it in this repo's own `trr-backend-brain/`
+- No: move it to `/Users/thomashulihan/Projects/TRR/trr-workspace-brain/`
+
+## Cross-repo handoff rule
+- `AGENTS.md` is the primary project-facing entrypoint for Codex and Claude session work.
+- Check `trr-backend-brain/handoffs/` before editing.
+- If a change crosses the app boundary, update `/Users/thomashulihan/Projects/TRR/trr-workspace-brain/api-contract.md`.
+- Drop a letter in `/Users/thomashulihan/Projects/TRR/trr-workspace-brain/handoffs/TRR-Backend-to-TRR-APP.md`.

--- a/trr-backend-brain/CLAUDE.md
+++ b/trr-backend-brain/CLAUDE.md
@@ -1,0 +1,1 @@
+BRAIN.md

--- a/trr-backend-brain/README.md
+++ b/trr-backend-brain/README.md
@@ -1,0 +1,13 @@
+# TRR-Backend Brain
+
+Scope:
+- FastAPI routes
+- backend domain logic
+- schema and migration ownership
+- operational backend tooling
+
+Carry forward from the previous repo `AGENTS.md`:
+- backend changes land before downstream app follow-through
+- API prefix remains `/api/v1`
+- migrations are additive and never rewritten
+- validate with `ruff check .`, `ruff format --check .`, `pytest -q`, and `make schema-docs-check` when schema changes

--- a/trr-backend-brain/architecture.md
+++ b/trr-backend-brain/architecture.md
@@ -1,0 +1,7 @@
+# TRR-Backend Architecture Notes
+
+- API entrypoints live under `api/`
+- shared backend logic lives under `trr_backend/`
+- schema and database contracts live under `supabase/`
+- scripts and operational helpers live under `scripts/`
+- when PostgREST or exposed SQL contracts change, run `./scripts/reload_postgrest_schema.sh`


### PR DESCRIPTION
## Summary
Follow-up to PR #121 that was already merged. Adds \`trr-backend-brain/\` (replaces generic \`brain/\`) so the directory shows up distinctly across all three TRR vaults in Obsidian.

Cherry-picked from the local rename commit that missed PR #121's merge window. Old \`brain/*\` files are left in-tree here — deletion is intentionally deferred so downstream tools that still reference the old path can migrate incrementally.

## Test plan
- [ ] CI green (\`test\`, \`gitleaks\` — both required on main).
- [ ] No production/runtime code touched.