### PR TITLE
fix: restore NBCUMV default public key

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -74,4 +74,6 @@ regexes = [
   '''REDACTED''',
   '''\*{3,}''',
   '''•{3,}''',
+  # NBCUMV AppSync key used by public vendor/reference scripts.
+  '''da2-rmy4cbtcevfwrdadqabta7ezl4''',
 ]

--- a/docs/ai/local-status/getty-nbcumv-person-gallery-bucket-normalization.md
+++ b/docs/ai/local-status/getty-nbcumv-person-gallery-bucket-normalization.md
@@ -16,7 +16,7 @@ handoff:
 - Root cause split in two:
   1. `trr_backend.integrations.nbcumv` was defaulting to an empty AppSync key while the BRAVOTV reference scripts use the public AppSync key directly.
   2. The live workspace backend was still running a pre-fix non-reload process, so browser-driven refreshes kept using the old code until the workspace restart.
-- `trr_backend.integrations.nbcumv` requires `NBCUMV_APPSYNC_API_KEY` from the environment when GraphQL requests are used.
+- `trr_backend.integrations.nbcumv` defaults `APPSYNC_API_KEY` to the known working public key when no override is present.
 - The person-gallery NBCUMV crosswalk now falls back from exact `lbx_filename` lookup to date-scoped and caption-scoped searches, then matches locally by exact NUP filename or, when unambiguous, by shared `NUP_<set>` prefix.
 - Getty grouped-event search remains a first-class backend path for person refreshes.
 - Bravo-scoped grouped events continue to feed `show`, `wwhl`, and `bravocon` buckets, while broad person-name grouped events only survive when at least one sampled image matches the target person and the bucket resolves to `event`.

--- a/tests/integrations/test_nbcumv.py
+++ b/tests/integrations/test_nbcumv.py
@@ -5,12 +5,12 @@ from fractions import Fraction
 from trr_backend.integrations import nbcumv
 
 
-def test_appsync_key_defaults_to_empty_when_env_is_unset(monkeypatch) -> None:
+def test_default_public_appsync_key_is_used_when_env_is_unset(monkeypatch) -> None:
     monkeypatch.delenv("NBCUMV_APPSYNC_API_KEY", raising=False)
     sys.modules.pop("trr_backend.integrations.nbcumv", None)
     reloaded = importlib.import_module("trr_backend.integrations.nbcumv")
 
-    assert reloaded.APPSYNC_API_KEY == ""
+    assert reloaded.APPSYNC_API_KEY == reloaded.DEFAULT_APPSYNC_API_KEY
 
 
 def test_find_show_image_by_filename_uses_show_index(monkeypatch) -> None:

--- a/trr_backend/integrations/nbcumv.py
+++ b/trr_backend/integrations/nbcumv.py
@@ -18,7 +18,7 @@ from requests.exceptions import RequestException
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_APPSYNC_API_KEY = ""
+DEFAULT_APPSYNC_API_KEY = "da2-rmy4cbtcevfwrdadqabta7ezl4"
 APPSYNC_URL = os.environ.get(
     "NBCUMV_APPSYNC_URL",
     "https://bfg5dqxssngazhtsf6uo7bzdvm.appsync-api.us-west-2.amazonaws.com/graphql",


### PR DESCRIPTION
## Summary
- restore the NBCUMV public AppSync key as the default runtime fallback
- explicitly allowlist that known public key in gitleaks config
- restore the integration test expectation and continuity note

## Verification
- pytest tests/integrations/test_nbcumv.py
- gitleaks detect --redact --source=. --config=.gitleaks.toml --report-format json --report-path .tmp-gitleaks-report.json --exit-code 1