### PR TITLE
Harden Instagram comments workflows

### DIFF
--- a/api/routers/admin_cast.py
+++ b/api/routers/admin_cast.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.auth import AdminUser
+from api.auth import AdminUser, InternalAdminUser
 from api.deps import SupabaseAdminClient, get_list_result
 from trr_backend.db import pg
 
@@ -88,7 +88,7 @@ def _group_cast_summary_rows(
 @router.post("/shows/cast-summary", response_model=CastSummaryBatchResponse)
 def get_admin_cast_summary(
     payload: CastSummaryBatchRequest,
-    _: AdminUser,
+    _: InternalAdminUser,
 ) -> CastSummaryBatchResponse:
     show_ids = [show_id.strip() for show_id in payload.show_ids if show_id.strip()]
     if not show_ids:

--- a/api/routers/socials.py
+++ b/api/routers/socials.py
@@ -567,7 +567,13 @@ def _finalize_catalog_backfill_launch_task(
     selected_tasks: list[str] | None,
     launch_group_id: str | None,
 ) -> None:
-    from trr_backend.repositories.social_season_analytics import finalize_social_account_catalog_backfill_launch
+    from trr_backend.repositories.social_season_analytics import (
+        INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+        INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE,
+        execute_run_with_inline_worker_registration,
+        finalize_social_account_catalog_backfill_launch,
+        is_queue_enabled,
+    )
 
     normalized_platform = str(platform or "").strip().lower()
     normalized_account = str(account_handle or "").strip().lower()
@@ -585,7 +591,7 @@ def _finalize_catalog_backfill_launch_task(
             normalized_run_id,
             normalized_launch_group_id,
         )
-        finalize_social_account_catalog_backfill_launch(
+        result = finalize_social_account_catalog_backfill_launch(
             platform=normalized_platform,
             account_handle=normalized_account,
             run_id=normalized_run_id,
@@ -598,6 +604,23 @@ def _finalize_catalog_backfill_launch_task(
             selected_tasks=selected_tasks,
             launch_group_id=normalized_launch_group_id,
         )
+        if allow_local_dev_inline_bypass or not is_queue_enabled():
+            catalog_run_id = str((result or {}).get("catalog_run_id") or (result or {}).get("run_id") or "").strip()
+            comments_run_id = str((result or {}).get("comments_run_id") or "").strip()
+            if catalog_run_id:
+                execute_run_with_inline_worker_registration(
+                    catalog_run_id,
+                    worker_id=f"api-background:catalog:{normalized_platform}",
+                )
+            if comments_run_id:
+                execute_run_with_inline_worker_registration(
+                    comments_run_id,
+                    worker_id=f"api-background:comments:{normalized_platform}",
+                    stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                    platform="instagram",
+                    supported_platforms=["instagram"],
+                    metadata_updates={"worker_lane": INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE},
+                )
     except Exception:
         logger.exception(
             "[catalog-launch] finalize_background_task_failed platform=%s account=%s run_id=%s launch_group_id=%s",
@@ -1151,6 +1174,7 @@ def _account_profile_cache_key(
     search: str | None = None,
     window: str | None = None,
     comments_only: bool | None = None,
+    comment_filter: str | None = None,
     post_source_id: str | None = None,
     extra: tuple[Any, ...] | None = None,
 ) -> tuple[Any, ...]:
@@ -1163,6 +1187,7 @@ def _account_profile_cache_key(
         str(search or "").strip().lower() or None,
         str(window or "").strip().lower() or None,
         None if comments_only is None else bool(comments_only),
+        str(comment_filter or "").strip().lower() or None,
         str(post_source_id or "").strip() or None,
         *(extra or ()),
     )
@@ -1463,7 +1488,11 @@ def _finalize_social_account_catalog_route_response(
     run_id = str(result.get("run_id") or "").strip()
     catalog_run_id = str(result.get("catalog_run_id") or run_id or "").strip()
     comments_run_id = str(result.get("comments_run_id") or "").strip()
-    if not queue_enabled and catalog_run_id:
+    launch_resolution_pending = (
+        result.get("launch_task_resolution_pending") is True
+        or str(result.get("launch_state") or "").strip().lower() in {"pending", "finalizing"}
+    )
+    if not queue_enabled and catalog_run_id and not launch_resolution_pending:
         logger.warning(
             "Catalog route using inline fallback: platform=%s queue_enabled=%s requires_modal_executor=%s",
             platform,
@@ -1475,7 +1504,7 @@ def _finalize_social_account_catalog_route_response(
             background_tasks,
             worker_prefix=f"api-background:catalog:{platform}",
         )
-    if not queue_enabled and comments_run_id:
+    if not queue_enabled and comments_run_id and not launch_resolution_pending:
         from trr_backend.repositories.social_season_analytics import (
             INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
             INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE,
@@ -3332,12 +3361,16 @@ class SocialAccountCommentsScrapeRequest(BaseModel):
     max_posts: int | None = Field(default=None, ge=1, le=500)
     max_comments_per_post: int | None = Field(default=None, ge=1, le=1000000)
     refresh_policy: Literal["stale_or_missing", "all_saved_posts"] = Field(default="stale_or_missing")
+    target_filter: Literal["incomplete"] | None = Field(default=None)
     allow_inline_dev_fallback: bool = Field(default=False)
+    dry_run: bool = Field(default=False)
 
     @model_validator(mode="after")
     def validate_shape(self) -> SocialAccountCommentsScrapeRequest:
         if self.mode == "single_post" and not str(self.source_id or "").strip():
             raise ValueError("source_id is required for single_post comment scrapes")
+        if self.mode == "single_post" and self.target_filter is not None:
+            raise ValueError("target_filter is only supported for profile comment scrapes")
         return self
 
 
@@ -4479,6 +4512,9 @@ def get_social_account_profile_dashboard_route(
 
     detail = _normalize_social_account_profile_summary_detail(request.query_params.get("detail"))
     normalized_run_id = str(run_id or "").strip() or None
+    dashboard_cache_ttl_seconds = (
+        _ACCOUNT_PROFILE_PROGRESS_CACHE_TTL_SECONDS if normalized_run_id else _ACCOUNT_PROFILE_CACHE_TTL_SECONDS
+    )
     cache_key = _account_profile_cache_key(
         surface="dashboard",
         platform=platform,
@@ -4497,7 +4533,7 @@ def get_social_account_profile_dashboard_route(
             ),
             cache=_ACCOUNT_PROFILE_DASHBOARD_CACHE,
             cache_lock=_ACCOUNT_PROFILE_DASHBOARD_CACHE_LOCK,
-            ttl_seconds=_ACCOUNT_PROFILE_CACHE_TTL_SECONDS,
+            ttl_seconds=dashboard_cache_ttl_seconds,
             max_entries=_ACCOUNT_PROFILE_CACHE_MAX_ENTRIES,
         )
     except ValueError as exc:
@@ -4644,6 +4680,7 @@ def get_social_account_profile_posts_route(
     page_size: int = Query(default=25, ge=1, le=100),
     search: str | None = Query(default=None),
     comments_only: bool = Query(default=False),
+    comment_filter: str | None = Query(default=None),
     _: InternalAdminUser = None,
 ) -> dict[str, Any]:
     from trr_backend.repositories.social_season_analytics import get_social_account_profile_posts
@@ -4656,6 +4693,7 @@ def get_social_account_profile_posts_route(
         page_size=page_size,
         search=search,
         comments_only=comments_only,
+        comment_filter=comment_filter,
     )
     cached_payload = _get_ttl_cached_payload(_ACCOUNT_PROFILE_POSTS_CACHE, _ACCOUNT_PROFILE_POSTS_CACHE_LOCK, cache_key)
     if cached_payload is not None:
@@ -4668,6 +4706,7 @@ def get_social_account_profile_posts_route(
             page_size=page_size,
             search=search,
             comments_only=comments_only,
+            comment_filter=comment_filter,
         )
         _set_ttl_cached_payload(
             _ACCOUNT_PROFILE_POSTS_CACHE,
@@ -4830,6 +4869,7 @@ async def post_social_account_comments_scrape_route(
     payload: SocialAccountCommentsScrapeRequest,
     background_tasks: BackgroundTasks,
     user: InternalAdminUser,
+    dry_run: bool = Query(default=False),
 ) -> dict[str, Any]:
     from trr_backend.repositories.social_season_analytics import (
         INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
@@ -4838,8 +4878,24 @@ async def post_social_account_comments_scrape_route(
         SocialIngestValidationError,
         SocialWorkerUnavailableError,
         _dispatch_due_social_jobs_in_background,
+        preview_social_account_comments_scrape,
         start_social_account_comments_scrape,
     )
+
+    if dry_run or payload.dry_run:
+        try:
+            return await run_in_threadpool(
+                preview_social_account_comments_scrape,
+                platform=platform,
+                account_handle=account_handle,
+                mode=payload.mode,
+                source_id=payload.source_id,
+                max_posts=payload.max_posts,
+                refresh_policy=payload.refresh_policy,
+                target_filter=payload.target_filter,
+            )
+        except SocialIngestValidationError as exc:
+            raise HTTPException(status_code=400, detail={"code": exc.code, "message": str(exc)}) from exc
 
     execution_state = _resolve_social_account_comments_route_execution(
         allow_inline_dev_fallback=payload.allow_inline_dev_fallback,
@@ -4859,6 +4915,7 @@ async def post_social_account_comments_scrape_route(
             max_posts=payload.max_posts,
             max_comments_per_post=payload.max_comments_per_post,
             refresh_policy=payload.refresh_policy,
+            target_filter=payload.target_filter,
             initiated_by=(user or {}).get("email"),
             inline_worker_id=None if queue_enabled else f"api-background:comments:{platform}",
             allow_local_dev_inline_bypass=used_inline_fallback,
@@ -4928,6 +4985,30 @@ def get_social_account_comments_scrape_progress_route(
                 run_id=str(run_id),
             ),
         )
+    except ValueError as exc:
+        raise _value_error_to_bad_request(exc) from exc
+    except LookupError as exc:
+        raise _lookup_error_to_not_found(exc) from exc
+
+
+@router.post("/profiles/{platform}/{account_handle}/comments/runs/{run_id}/cancel")
+def post_social_account_comments_run_cancel_route(
+    platform: str,
+    account_handle: str,
+    run_id: UUID,
+    user: InternalAdminUser,
+) -> dict[str, Any]:
+    from trr_backend.repositories.social_season_analytics import cancel_social_account_comments_run
+
+    try:
+        result = cancel_social_account_comments_run(
+            platform=platform,
+            account_handle=account_handle,
+            run_id=str(run_id),
+            cancelled_by=(user or {}).get("email"),
+        )
+        _clear_account_profile_caches()
+        return result
     except ValueError as exc:
         raise _value_error_to_bad_request(exc) from exc
     except LookupError as exc:
@@ -5138,6 +5219,7 @@ def get_social_account_catalog_run_progress_route(
     account_handle: str,
     run_id: UUID,
     recent_log_limit: int = Query(default=20, ge=1, le=100),
+    fast: bool = Query(default=False),
     _: InternalAdminUser = None,
 ) -> dict[str, Any]:
     from trr_backend.repositories.social_season_analytics import get_social_account_catalog_run_progress
@@ -5146,7 +5228,7 @@ def get_social_account_catalog_run_progress_route(
         surface="catalog-run-progress",
         platform=platform,
         account_handle=account_handle,
-        extra=(str(run_id), recent_log_limit),
+        extra=(str(run_id), recent_log_limit, "fast" if fast else "full"),
     )
     try:
         return _resolve_account_profile_singleflight(
@@ -5156,6 +5238,7 @@ def get_social_account_catalog_run_progress_route(
                 account_handle=account_handle,
                 run_id=str(run_id),
                 recent_log_limit=recent_log_limit,
+                fast=fast,
             ),
             cache=_ACCOUNT_PROFILE_PROGRESS_CACHE,
             cache_lock=_ACCOUNT_PROFILE_PROGRESS_CACHE_LOCK,
@@ -5508,9 +5591,7 @@ async def post_social_account_catalog_backfill_route(
             date_end=date_end,
         )
         use_async_instagram_kickoff = (
-            platform == "instagram"
-            and queue_enabled
-            and not used_inline_fallback
+            str(platform or "").strip().lower() == "instagram"
             and list(payload.selected_tasks or []) != ["comments"]
         )
         if use_async_instagram_kickoff:

--- a/scripts/db/rls_grants_snapshot.py
+++ b/scripts/db/rls_grants_snapshot.py
@@ -111,11 +111,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def resolve_output_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return (Path.cwd() / path).resolve()
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     load_env()
     rendered = render_snapshot()
-    output = args.output if args.output.is_absolute() else WORKSPACE_ROOT / args.output
+    output = resolve_output_path(args.output)
     if args.check:
         existing = output.read_text(encoding="utf-8") if output.is_file() else ""
         if existing != rendered:
@@ -129,4 +135,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/socials/instagram/comments_scrape_cli.py
+++ b/scripts/socials/instagram/comments_scrape_cli.py
@@ -9,6 +9,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
 
 from trr_backend.utils.env import load_env
 

--- a/scripts/socials/instagram/comments_worker.py
+++ b/scripts/socials/instagram/comments_worker.py
@@ -12,7 +12,7 @@ from scripts.socials.worker import main as worker_main
 def main() -> int:
     os.environ.setdefault("SOCIAL_WORKER_LANE", "instagram_comments_scrapling")
     os.environ.setdefault("SOCIAL_WORKER_SCRIPT", "scripts.socials.instagram.comments_worker")
-    argv = [
+    sys.argv = [
         sys.argv[0],
         "--stage",
         "comments_scrapling",
@@ -20,7 +20,7 @@ def main() -> int:
         "instagram",
         *sys.argv[1:],
     ]
-    return worker_main(argv)
+    return worker_main()
 
 
 if __name__ == "__main__":

--- a/scripts/socials/worker.py
+++ b/scripts/socials/worker.py
@@ -236,7 +236,7 @@ def _resolve_optional_positive_float(
 def _default_claim_batch_size_for_stage(stage: str | None) -> int:
     # Queue claims mark jobs running up front; batching post claims creates false
     # stale-heartbeat jobs for the later entries while one worker processes the first.
-    return 1 if (stage or "").strip().lower() in {"posts", "shared_account_posts"} else 2
+    return 1 if (stage or "").strip().lower() in {"posts", "shared_account_posts", "comments_scrapling"} else 2
 
 
 def _claim_stage_candidates(stage: str | None) -> tuple[str | None, ...]:

--- a/tests/api/routers/test_admin_cast.py
+++ b/tests/api/routers/test_admin_cast.py
@@ -5,7 +5,7 @@ from collections.abc import Iterator
 import pytest
 from fastapi.testclient import TestClient
 
-from api.auth import require_admin
+from api.auth import require_admin, require_internal_admin
 from api.main import app
 from api.routers import admin_cast as router_module
 
@@ -16,13 +16,16 @@ def _compact_sql(sql: str) -> str:
 
 @pytest.fixture(autouse=True)
 def override_admin() -> Iterator[None]:
-    app.dependency_overrides[require_admin] = lambda: {
+    admin_user = {
         "id": "admin:test",
         "role": "admin",
         "email": "admin@example.com",
     }
+    app.dependency_overrides[require_admin] = lambda: admin_user
+    app.dependency_overrides[require_internal_admin] = lambda: admin_user
     yield
     app.dependency_overrides.pop(require_admin, None)
+    app.dependency_overrides.pop(require_internal_admin, None)
 
 
 def test_cast_summary_includes_available_photo_url_with_person_card_photo_ranking(

--- a/tests/api/routers/test_socials_season_analytics.py
+++ b/tests/api/routers/test_socials_season_analytics.py
@@ -425,6 +425,56 @@ def test_get_social_account_profile_dashboard_reuses_cached_payload(
     dashboard_mock.assert_called_once()
 
 
+def test_get_social_account_profile_dashboard_uses_progress_cache_ttl_for_run_id(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.routers import socials as socials_router
+
+    socials_router._clear_account_profile_caches()
+    monkeypatch.setattr(socials_router, "_ACCOUNT_PROFILE_PROGRESS_CACHE_TTL_SECONDS", 0)
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+    call_numbers = iter([1, 2])
+
+    def _dashboard_payload(*_args: object, **_kwargs: object) -> dict[str, object]:
+        call_number = next(call_numbers)
+        return {
+            "data": {
+                "summary": {
+                    "platform": "instagram",
+                    "account_handle": "cacheprobe",
+                    "total_posts": 12,
+                },
+                "catalog_run_progress": {"run_id": "run-active", "completed_posts": call_number},
+            },
+            "freshness": {
+                "status": "fresh",
+                "source": "live",
+                "generated_at": "2026-04-27T12:00:00+00:00",
+                "age_seconds": 0,
+            },
+            "operational_alerts": [],
+        }
+
+    with patch(
+        "trr_backend.socials.profile_dashboard.build_social_account_profile_dashboard",
+        side_effect=_dashboard_payload,
+    ) as dashboard_mock:
+        responses = [
+            client.get(
+                "/api/v1/admin/socials/profiles/instagram/cacheprobe/dashboard?detail=lite&run_id=run-active",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            for _ in range(2)
+        ]
+
+    assert [response.status_code for response in responses] == [200, 200]
+    assert responses[0].json()["data"]["catalog_run_progress"]["completed_posts"] == 1
+    assert responses[1].json()["data"]["catalog_run_progress"]["completed_posts"] == 2
+    assert dashboard_mock.call_count == 2
+
+
 def test_get_social_account_profile_summary_returns_503_on_session_pool_saturation(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -576,6 +626,32 @@ def test_get_social_account_profile_posts_forwards_comments_only(
 
     assert response.status_code == 200
     assert mocked.call_args.kwargs["comments_only"] is True
+
+
+def test_get_social_account_profile_posts_forwards_comment_filter(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+    expected = {
+        "items": [],
+        "pagination": {"page": 1, "page_size": 25, "total": 0, "total_pages": 1},
+    }
+
+    with patch(
+        "trr_backend.repositories.social_season_analytics.get_social_account_profile_posts",
+        return_value=expected,
+    ) as mocked:
+        response = client.get(
+            "/api/v1/admin/socials/profiles/instagram/bravotv/posts"
+            "?page=1&page_size=25&comments_only=true&comment_filter=incomplete",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert mocked.call_args.kwargs["comments_only"] is True
+    assert mocked.call_args.kwargs["comment_filter"] == "incomplete"
 
 
 def test_get_social_account_profile_posts_returns_503_on_statement_timeout(
@@ -946,6 +1022,7 @@ def test_queue_catalog_backfill_finalize_task_runs_finalize_and_clears_caches(
         "trr_backend.repositories.social_season_analytics.finalize_social_account_catalog_backfill_launch",
         lambda **kwargs: finalized.append(kwargs) or {"run_id": kwargs["run_id"], "status": "queued"},
     )
+    monkeypatch.setattr("trr_backend.repositories.social_season_analytics.is_queue_enabled", lambda: True)
     monkeypatch.setattr(socials_router, "_clear_account_profile_caches", lambda: cleared.append("cleared"))
 
     socials_router._queue_catalog_backfill_finalize_task(
@@ -983,6 +1060,54 @@ def test_queue_catalog_backfill_finalize_task_runs_finalize_and_clears_caches(
         }
     ]
     assert cleared == ["cleared"]
+
+
+def test_queue_catalog_backfill_finalize_task_starts_inline_fallback_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from api.routers import socials as socials_router
+
+    executed: list[dict[str, Any]] = []
+    background_tasks = BackgroundTasks()
+
+    monkeypatch.setattr(
+        "trr_backend.repositories.social_season_analytics.finalize_social_account_catalog_backfill_launch",
+        lambda **_kwargs: {
+            "run_id": "catalog-run-1",
+            "catalog_run_id": "catalog-run-1",
+            "comments_run_id": "comments-run-1",
+            "status": "running",
+        },
+    )
+    monkeypatch.setattr("trr_backend.repositories.social_season_analytics.is_queue_enabled", lambda: False)
+    monkeypatch.setattr(
+        "trr_backend.repositories.social_season_analytics.execute_run_with_inline_worker_registration",
+        lambda run_id, **kwargs: executed.append({"run_id": run_id, **kwargs}) or {"run_id": run_id},
+    )
+    monkeypatch.setattr(socials_router, "_clear_account_profile_caches", lambda: None)
+
+    socials_router._queue_catalog_backfill_finalize_task(
+        background_tasks=background_tasks,
+        platform="instagram",
+        account_handle="bravotv",
+        run_id="catalog-run-1",
+        source_scope="bravo",
+        date_start=None,
+        date_end=None,
+        initiated_by="admin@example.com",
+        allow_local_dev_inline_bypass=True,
+        execution_preference="auto",
+        selected_tasks=["post_details", "comments", "media"],
+        launch_group_id="launch-group-1",
+    )
+
+    asyncio.run(background_tasks())
+
+    assert executed[0]["run_id"] == "catalog-run-1"
+    assert executed[0]["worker_id"] == "api-background:catalog:instagram"
+    assert executed[1]["run_id"] == "comments-run-1"
+    assert executed[1]["worker_id"] == "api-background:comments:instagram"
+    assert executed[1]["platform"] == "instagram"
 
 
 def test_post_social_account_catalog_backfill_rejects_empty_selected_tasks(
@@ -1485,13 +1610,20 @@ def test_post_social_account_catalog_backfill_allows_local_inline_fallback_when_
             ),
         ) as worker_guard,
         patch(
-            "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+            "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
             return_value={
                 "run_id": "catalog-run-inline-1",
-                "status": "pending",
+                "catalog_run_id": "catalog-run-inline-1",
+                "status": "running",
+                "launch_state": "pending",
+                "launch_task_resolution_pending": True,
                 "ingest_mode": "shared_account_catalog_backfill",
             },
         ) as mocked_start,
+        patch(
+            "api.routers.socials._queue_catalog_backfill_finalize_task",
+            return_value=None,
+        ) as mocked_finalize,
     ):
         response = client.post(
             "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
@@ -1510,9 +1642,9 @@ def test_post_social_account_catalog_backfill_allows_local_inline_fallback_when_
     assert body["used_inline_fallback"] is True
     assert body["requires_modal_executor"] is True
     worker_guard.assert_called_once()
-    mocked_background.assert_called_once()
-    assert mocked_start.call_args.kwargs["inline_worker_id"] == "api-background:catalog:instagram"
+    mocked_background.assert_not_called()
     assert mocked_start.call_args.kwargs["allow_local_dev_inline_bypass"] is True
+    mocked_finalize.assert_called_once()
 
 
 def test_post_social_account_catalog_backfill_uses_local_admin_override_for_instagram_in_dev(
@@ -1539,13 +1671,20 @@ def test_post_social_account_catalog_backfill_uses_local_admin_override_for_inst
             return_value={"resolved": False, "reason": "not available", "error": None},
         ),
         patch(
-            "trr_backend.repositories.social_season_analytics.launch_social_account_catalog_backfill",
+            "trr_backend.repositories.social_season_analytics.begin_social_account_catalog_backfill_launch",
             return_value={
                 "run_id": "catalog-run-inline-override-1",
-                "status": "pending",
+                "catalog_run_id": "catalog-run-inline-override-1",
+                "status": "running",
+                "launch_state": "pending",
+                "launch_task_resolution_pending": True,
                 "ingest_mode": "shared_account_catalog_backfill",
             },
         ) as mocked_start,
+        patch(
+            "api.routers.socials._queue_catalog_backfill_finalize_task",
+            return_value=None,
+        ) as mocked_finalize,
     ):
         response = client.post(
             "/api/v1/admin/socials/profiles/instagram/bravotv/catalog/backfill",
@@ -1561,9 +1700,9 @@ def test_post_social_account_catalog_backfill_uses_local_admin_override_for_inst
     assert body["execution_mode_canonical"] == "inline_fallback"
     assert body["execution_mode_legacy"] == "inline_fallback"
     worker_guard.assert_called_once()
-    mocked_background.assert_called_once()
-    assert mocked_start.call_args.kwargs["inline_worker_id"] == "api-background:catalog:instagram"
+    mocked_background.assert_not_called()
     assert mocked_start.call_args.kwargs["allow_local_dev_inline_bypass"] is True
+    mocked_finalize.assert_called_once()
 
 
 def test_post_social_account_catalog_backfill_returns_modal_dispatch_unavailable_when_target_unresolvable(
@@ -2250,7 +2389,7 @@ def test_post_social_account_catalog_run_cancel(client: TestClient, monkeypatch:
     run_id = str(uuid4())
     expected = {
         "run_id": run_id,
-        "status": "cancelling",
+        "status": "cancelled",
         "accepted": True,
     }
 
@@ -2264,14 +2403,42 @@ def test_post_social_account_catalog_run_cancel(client: TestClient, monkeypatch:
         response = client.post(
             f"/api/v1/admin/socials/profiles/instagram/bravotv/catalog/runs/{run_id}/cancel",
             headers={"Authorization": f"Bearer {token}"},
-        )
+    )
 
     assert response.status_code == 200
-    assert response.json()["status"] == "cancelling"
+    assert response.json()["status"] == "cancelled"
     assert mocked.call_args.kwargs["platform"] == "instagram"
     assert mocked.call_args.kwargs["account_handle"] == "bravotv"
     assert mocked.call_args.kwargs["run_id"] == run_id
     background_mock.assert_called_once()
+
+
+def test_post_social_account_comments_run_cancel(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+    run_id = str(uuid4())
+    expected = {
+        "run_id": run_id,
+        "status": "cancelled",
+        "accepted": True,
+        "cancelled_jobs": 1,
+    }
+
+    with patch(
+        "trr_backend.repositories.social_season_analytics.cancel_social_account_comments_run",
+        return_value=expected,
+    ) as mocked:
+        response = client.post(
+            f"/api/v1/admin/socials/profiles/instagram/bravotv/comments/runs/{run_id}/cancel",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+    assert mocked.call_args.kwargs["platform"] == "instagram"
+    assert mocked.call_args.kwargs["account_handle"] == "bravotv"
+    assert mocked.call_args.kwargs["run_id"] == run_id
+    assert mocked.call_args.kwargs["cancelled_by"] == "admin@example.com"
 
 
 def test_post_social_account_catalog_run_dismiss(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -4809,6 +4976,192 @@ def test_post_social_account_comments_scrape_accepts_all_saved_posts_profile_syn
     assert scrape_mock.call_args.kwargs["dispatch_immediately"] is True
 
 
+def test_post_social_account_comments_scrape_forwards_incomplete_target_filter(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+
+    with (
+        patch(
+            "api.routers.socials._resolve_social_account_comments_route_execution",
+            return_value={
+                "queue_enabled": False,
+                "used_inline_fallback": False,
+                "requires_modal_executor": False,
+            },
+        ),
+        patch("api.routers.socials._start_runs_in_background", return_value=None),
+        patch(
+            "trr_backend.repositories.social_season_analytics.start_social_account_comments_scrape",
+            return_value={
+                "run_id": "comments-run-1",
+                "status": "pending",
+                "target_filter": "incomplete",
+                "incomplete_fill": True,
+            },
+        ) as scrape_mock,
+    ):
+        response = client.post(
+            "/api/v1/admin/socials/profiles/instagram/bravotv/comments/scrape",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "mode": "profile",
+                "source_scope": "bravo",
+                "refresh_policy": "stale_or_missing",
+                "target_filter": "incomplete",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["run_id"] == "comments-run-1"
+    assert body["target_filter"] == "incomplete"
+    assert body["incomplete_fill"] is True
+    scrape_mock.assert_called_once()
+    assert scrape_mock.call_args.kwargs["target_filter"] == "incomplete"
+
+
+def test_post_social_account_comments_scrape_dry_run_returns_preview_without_launch(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+
+    with (
+        patch(
+            "trr_backend.repositories.social_season_analytics.preview_social_account_comments_scrape",
+            return_value={
+                "dry_run": True,
+                "platform": "instagram",
+                "account_handle": "bravotv",
+                "mode": "profile",
+                "target_source_ids_count": 431,
+                "comments_shard_count": 8,
+                "recommended_comments_shard_count": 8,
+                "sample_target_source_ids": ["C123"],
+                "refresh_policy": "all_saved_posts",
+                "target_priority": "gap_first",
+                "timing": {
+                    "target_preview_ms": 12.5,
+                    "target_count_ms": 12.5,
+                    "sample_target_source_ids_ms": 12.5,
+                    "cache_lookup_ms": 0.1,
+                    "total_ms": 12.6,
+                },
+                "preview_cache": {
+                    "enabled": True,
+                    "hit": False,
+                    "age_seconds": None,
+                    "ttl_seconds": 60,
+                },
+                "cache": {
+                    "enabled": True,
+                    "hit": False,
+                    "age_seconds": None,
+                    "ttl_seconds": 60,
+                },
+                "debug": {
+                    "target_plan_strategy": "bounded_profile_preview",
+                    "full_target_list_built": False,
+                },
+            },
+        ) as preview_mock,
+        patch(
+            "trr_backend.repositories.social_season_analytics.start_social_account_comments_scrape",
+            side_effect=AssertionError("dry run should not launch a scrape"),
+        ),
+        patch(
+            "api.routers.socials._resolve_social_account_comments_route_execution",
+            side_effect=AssertionError("dry run should not resolve queue execution"),
+        ),
+    ):
+        response = client.post(
+            "/api/v1/admin/socials/profiles/instagram/bravotv/comments/scrape?dry_run=true",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"mode": "profile", "source_scope": "bravo", "refresh_policy": "all_saved_posts"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["dry_run"] is True
+    assert body["target_source_ids_count"] == 431
+    assert body["comments_shard_count"] == 8
+    assert body["sample_target_source_ids"] == ["C123"]
+    assert body["timing"]["target_preview_ms"] == 12.5
+    assert body["preview_cache"]["hit"] is False
+    assert body["cache"] == body["preview_cache"]
+    assert body["debug"]["target_plan_strategy"] == "bounded_profile_preview"
+    preview_mock.assert_called_once()
+    assert preview_mock.call_args.kwargs["refresh_policy"] == "all_saved_posts"
+
+
+def test_post_social_account_comments_scrape_dry_run_forwards_incomplete_target_filter(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+
+    with (
+        patch(
+            "trr_backend.repositories.social_season_analytics.preview_social_account_comments_scrape",
+            return_value={
+                "dry_run": True,
+                "platform": "instagram",
+                "account_handle": "bravotv",
+                "mode": "profile",
+                "target_filter": "incomplete",
+                "incomplete_fill": True,
+                "target_source_ids_count": 3,
+                "comments_shard_count": 1,
+                "recommended_comments_shard_count": 1,
+                "sample_target_source_ids": ["GAP1"],
+                "refresh_policy": "stale_or_missing",
+                "target_priority": "missing_first_recent",
+                "timing": {
+                    "target_preview_ms": 2.5,
+                    "target_count_ms": 2.5,
+                    "sample_target_source_ids_ms": 2.5,
+                    "cache_lookup_ms": 0.0,
+                    "total_ms": 2.5,
+                },
+                "preview_cache": {"enabled": False, "hit": False, "age_seconds": None, "ttl_seconds": 0},
+                "cache": {"enabled": False, "hit": False, "age_seconds": None, "ttl_seconds": 0},
+                "debug": {"target_plan_strategy": "bounded_profile_preview"},
+            },
+        ) as preview_mock,
+        patch(
+            "trr_backend.repositories.social_season_analytics.start_social_account_comments_scrape",
+            side_effect=AssertionError("dry run should not launch a scrape"),
+        ),
+        patch(
+            "api.routers.socials._resolve_social_account_comments_route_execution",
+            side_effect=AssertionError("dry run should not resolve queue execution"),
+        ),
+    ):
+        response = client.post(
+            "/api/v1/admin/socials/profiles/instagram/bravotv/comments/scrape?dry_run=true",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "mode": "profile",
+                "source_scope": "bravo",
+                "refresh_policy": "stale_or_missing",
+                "target_filter": "incomplete",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["target_filter"] == "incomplete"
+    assert body["incomplete_fill"] is True
+    assert body["target_source_ids_count"] == 3
+    preview_mock.assert_called_once()
+    assert preview_mock.call_args.kwargs["target_filter"] == "incomplete"
+
+
 def test_post_social_account_comments_scrape_queue_dispatches_in_background(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -5475,6 +5828,36 @@ def test_get_social_account_catalog_run_progress_returns_503_on_session_pool_sat
     assert response.status_code == 503
     assert response.json()["detail"]["code"] == "DATABASE_SERVICE_UNAVAILABLE"
     assert response.json()["detail"]["reason"] == "session_pool_capacity"
+
+
+def test_get_social_account_catalog_run_progress_forwards_fast_flag(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret-32-bytes-minimum-abcdef")
+    token = _make_admin_token("test-secret-32-bytes-minimum-abcdef")
+    run_id = str(uuid4())
+    expected = {"run_id": run_id, "run_status": "running"}
+
+    with patch(
+        "trr_backend.repositories.social_season_analytics.get_social_account_catalog_run_progress",
+        return_value=expected,
+    ) as mocked:
+        response = client.get(
+            f"/api/v1/admin/socials/profiles/instagram/bravotv/catalog/runs/{run_id}/progress"
+            "?recent_log_limit=7&fast=1",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    mocked.assert_called_once_with(
+        platform="instagram",
+        account_handle="bravotv",
+        run_id=run_id,
+        recent_log_limit=7,
+        fast=True,
+    )
 
 
 def test_account_profile_singleflight_collapses_same_key_concurrent_loads() -> None:

--- a/tests/repositories/test_social_mirror_repairs.py
+++ b/tests/repositories/test_social_mirror_repairs.py
@@ -533,7 +533,7 @@ def test_run_platform_media_mirror_stage_instagram_selects_asset_manifest(monkey
     monkeypatch.setattr(
         social_repo,
         "_platform_posts_has_column",
-        lambda _platform, column: column in {"media_urls", "asset_manifest"},
+        lambda _platform, column, **_kwargs: column in {"media_urls", "asset_manifest"},
     )
     monkeypatch.setattr(
         social_repo,

--- a/tests/repositories/test_social_run_lifecycle_repository.py
+++ b/tests/repositories/test_social_run_lifecycle_repository.py
@@ -180,6 +180,24 @@ def test_set_run_status_invalidates_week_detail_cache_on_terminal_states(
         social_repo.register_week_detail_cache_invalidator(None)
 
 
+def test_set_run_status_clears_terminal_timestamps_when_reopened(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_fetch_one(sql: str, params: list[object], **_kwargs):
+        captured["sql"] = " ".join(sql.lower().split())
+        captured["params"] = list(params)
+        return {"id": "run-1"}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+
+    social_repo._set_run_status("run-1", "running")
+
+    assert "when %s in ('queued', 'pending', 'retrying', 'running') then null" in str(captured["sql"])
+    assert captured["params"] == ["running", "running", "running", "running", "running", "running", "run-1"]
+
+
 def test_update_run_summary_prefers_incremental_counter_columns(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 

--- a/tests/repositories/test_social_season_analytics.py
+++ b/tests/repositories/test_social_season_analytics.py
@@ -319,6 +319,7 @@ def test_get_social_account_profile_posts_instagram_comments_only_without_search
         *,
         page: int,
         page_size: int,
+        comment_filter: str | None = None,
         conn: object | None = None,
     ) -> tuple[list[dict[str, object]], int]:
         captured.update(
@@ -326,6 +327,7 @@ def test_get_social_account_profile_posts_instagram_comments_only_without_search
                 "account_handle": account_handle,
                 "page": page,
                 "page_size": page_size,
+                "comment_filter": comment_filter,
                 "conn": conn,
             }
         )
@@ -348,12 +350,14 @@ def test_get_social_account_profile_posts_instagram_comments_only_without_search
         page=2,
         page_size=1,
         comments_only=True,
+        comment_filter="incomplete",
     )
 
     assert captured == {
         "account_handle": "bravotv",
         "page": 2,
         "page_size": 1,
+        "comment_filter": "incomplete",
         "conn": summary_conn,
     }
     assert payload["pagination"] == {
@@ -416,8 +420,10 @@ def test_get_social_account_profile_posts_instagram_comments_only_sql_uses_index
     assert captured["page_params"] == ["thetraitorsus", "thetraitorsus", "thetraitorsus", 3, 3]
     normalized_total_sql = " ".join(captured["total_sql"].split()).lower()
     normalized_page_sql = " ".join(captured["page_sql"].split()).lower()
+    reported_comments = " ".join(social_repo._instagram_reported_comments_sql("p").split()).lower()
     assert "owner_rows as materialized" in normalized_total_sql
     assert "collaborator_rows as materialized" in normalized_page_sql
+    assert f"{reported_comments}::bigint as comments_count" in normalized_page_sql
     assert "from social.instagram_posts p" in normalized_page_sql
     assert "social.instagram_account_catalog_post_collaborators m" in normalized_page_sql
     assert "m.collaborator_handle = %s" in normalized_page_sql
@@ -426,6 +432,98 @@ def test_get_social_account_profile_posts_instagram_comments_only_sql_uses_index
     assert "page_ids as" not in normalized_page_sql
     assert "count(*) over ()::int as profile_total" not in normalized_page_sql
     assert "jsonb_array_elements" not in normalized_page_sql
+
+
+def test_get_social_account_profile_posts_instagram_comments_only_incomplete_filter_compares_saved_to_reported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_catalog_collaborator_membership_available",
+        lambda **_kwargs: True,
+    )
+
+    def _fake_fetch_all(sql: str, params: list[Any]) -> list[dict[str, Any]]:
+        captured["page_sql"] = sql
+        captured["page_params"] = params
+        return []
+
+    def _fake_fetch_one(sql: str, params: list[Any]) -> dict[str, Any]:
+        captured["total_sql"] = sql
+        captured["total_params"] = params
+        return {"total": 4}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+
+    rows, total = social_repo._fetch_instagram_comments_only_profile_rows_page(
+        "TheTraitorsUS",
+        page=1,
+        page_size=25,
+        comment_filter="incomplete",
+    )
+
+    assert rows == []
+    assert total == 4
+    normalized_total_sql = " ".join(captured["total_sql"].split()).lower()
+    normalized_page_sql = " ".join(captured["page_sql"].split()).lower()
+    reported_comments = " ".join(social_repo._instagram_reported_comments_sql("d").split()).lower()
+    expected_filter = (
+        f"{reported_comments} > 0 and "
+        "greatest(coalesce(saved_comment_counts.saved_comments, 0), 0) <> "
+        f"{reported_comments}"
+    )
+    assert expected_filter in normalized_total_sql
+    assert expected_filter in normalized_page_sql
+    assert captured["total_params"] == ["thetraitorsus", "thetraitorsus", "thetraitorsus"]
+    assert captured["page_params"] == ["thetraitorsus", "thetraitorsus", "thetraitorsus", 25, 0]
+
+
+def test_get_social_account_profile_posts_instagram_comments_only_not_commentable_filter_uses_reported_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_catalog_collaborator_membership_available",
+        lambda **_kwargs: True,
+    )
+
+    def _fake_fetch_all(sql: str, params: list[Any]) -> list[dict[str, Any]]:
+        captured["page_sql"] = sql
+        captured["page_params"] = params
+        return []
+
+    def _fake_fetch_one(sql: str, params: list[Any]) -> dict[str, Any]:
+        captured["total_sql"] = sql
+        captured["total_params"] = params
+        return {"total": 2}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+
+    rows, total = social_repo._fetch_instagram_comments_only_profile_rows_page(
+        "TheTraitorsUS",
+        page=1,
+        page_size=25,
+        comment_filter="not_commentable",
+    )
+
+    assert rows == []
+    assert total == 2
+    normalized_total_sql = " ".join(captured["total_sql"].split()).lower()
+    normalized_page_sql = " ".join(captured["page_sql"].split()).lower()
+    reported_comments = " ".join(social_repo._instagram_reported_comments_sql("d").split()).lower()
+    expected_filter = f"{reported_comments} = 0"
+    assert expected_filter in normalized_total_sql
+    assert expected_filter in normalized_page_sql
+    assert captured["total_params"] == ["thetraitorsus", "thetraitorsus", "thetraitorsus"]
+    assert captured["page_params"] == ["thetraitorsus", "thetraitorsus", "thetraitorsus", 25, 0]
 
 
 def test_get_social_account_profile_posts_instagram_comments_only_falls_back_without_membership_table(
@@ -444,6 +542,7 @@ def test_get_social_account_profile_posts_instagram_comments_only_falls_back_wit
         *,
         page: int,
         page_size: int,
+        comment_filter: str | None = None,
         conn: object | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         captured.update(
@@ -451,6 +550,7 @@ def test_get_social_account_profile_posts_instagram_comments_only_falls_back_wit
                 "account_handle": account_handle,
                 "page": page,
                 "page_size": page_size,
+                "comment_filter": comment_filter,
                 "conn": conn,
             }
         )
@@ -475,6 +575,7 @@ def test_get_social_account_profile_posts_instagram_comments_only_falls_back_wit
         "account_handle": "TheTraitorsUS",
         "page": 1,
         "page_size": 25,
+        "comment_filter": None,
         "conn": None,
     }
 
@@ -924,6 +1025,114 @@ def test_get_social_account_catalog_run_progress_keeps_full_path_for_active_runs
     social_repo.get_social_account_catalog_run_progress("instagram", "thetraitorsus", run_id)
 
     assert calls == {"stale": 1, "blocked": 1, "frontier": 1}
+
+
+def test_get_social_account_catalog_run_progress_fast_path_skips_heavy_active_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    load_run_kwargs: list[dict[str, Any]] = []
+    run_row = {
+        "run_id": run_id,
+        "season_id": None,
+        "status": "running",
+        "source_scope": "bravo",
+        "config": {
+            "pipeline_ingest_mode": social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            "platforms": ["instagram"],
+            "accounts_override": ["thetraitorsus"],
+            "expected_total_posts_by_account": {"instagram:thetraitorsus": 436},
+        },
+        "summary": {"total_jobs": 1, "completed_jobs": 0, "failed_jobs": 0, "active_jobs": 1},
+        "created_at": datetime(2026, 4, 30, 11, 14, tzinfo=UTC),
+        "started_at": datetime(2026, 4, 30, 11, 16, tzinfo=UTC),
+        "completed_at": None,
+    }
+    job_rows = [
+        {
+            "id": "job-fetch",
+            "platform": "instagram",
+            "job_type": social_repo.SHARED_ACCOUNT_POSTS_JOB_TYPE,
+            "status": "running",
+            "items_found": 436,
+            "error_message": None,
+            "last_error_code": None,
+            "created_at": datetime(2026, 4, 30, 11, 14, tzinfo=UTC),
+            "started_at": datetime(2026, 4, 30, 11, 16, tzinfo=UTC),
+            "completed_at": None,
+            "config": {"account": "thetraitorsus", "stage": social_repo.SHARED_ACCOUNT_POSTS_STAGE},
+            "metadata": {
+                "activity": {
+                    "last_progress_at": "2026-04-30T12:18:08+00:00",
+                    "phase": "details_refresh_update",
+                    "pages_scanned": 14,
+                    "posts_checked": 300,
+                    "matched_posts": 300,
+                    "total_posts": 431,
+                },
+                "persist_counters": {"posts_upserted": 300},
+            },
+            "worker_id": "modal:fetch",
+        }
+    ]
+
+    monkeypatch.setattr(
+        social_repo,
+        "_relation_exists",
+        lambda *_args, **_kwargs: pytest.fail("fast active progress should not use default-pool schema checks"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_scrape_jobs_features",
+        lambda: pytest.fail("fast active progress should not use default-pool feature checks"),
+    )
+
+    def fake_load_run(**kwargs: Any) -> dict[str, Any]:
+        load_run_kwargs.append(kwargs)
+        return run_row
+
+    monkeypatch.setattr(social_repo, "_load_social_account_catalog_run_row", fake_load_run)
+    monkeypatch.setattr(social_repo, "_load_social_account_catalog_jobs", lambda **_kwargs: job_rows)
+    monkeypatch.setattr(
+        social_repo,
+        "_repair_finalizing_catalog_launch_after_jobs",
+        lambda **_kwargs: pytest.fail("fast active progress should not repair launch metadata"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "recover_stale_unclaimed_dispatched_jobs",
+        lambda **_kwargs: pytest.fail("fast active progress should not run stale-job recovery"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "recover_dispatch_blocked_no_progress_jobs",
+        lambda **_kwargs: pytest.fail("fast active progress should not run blocked-job recovery"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_shared_account_frontier_progress",
+        lambda **_kwargs: pytest.fail("fast active progress should not query frontier progress"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_cached_live_profile_total_posts",
+        lambda *_args, **_kwargs: pytest.fail("fast active progress should not refresh live totals"),
+    )
+
+    payload = social_repo.get_social_account_catalog_run_progress(
+        "instagram",
+        "thetraitorsus",
+        run_id,
+        fast=True,
+    )
+
+    assert load_run_kwargs[0]["verify_account"] is False
+    assert load_run_kwargs[0]["pool_name"] == social_repo.SOCIAL_CATALOG_PROGRESS_POOL_NAME
+    assert payload["run_status"] == "running"
+    assert payload["run_state"] == "fetching"
+    assert payload["post_progress"] == {"completed_posts": 300, "matched_posts": 300, "total_posts": 436}
+    assert payload["recent_log"][0]["timestamp"] == "2026-04-30T12:18:08+00:00"
+    assert "8:18 AM" in payload["recent_log"][0]["line"]
 
 
 def test_instagram_social_account_profile_dataset_rows_applies_limit_to_source_queries(
@@ -3004,7 +3213,7 @@ def test_upsert_instagram_post_persists_metadata_and_hosted_urls(monkeypatch) ->
         return {"id": "db-post-1"}
 
     monkeypatch.setattr(social_repo, "_pg_upsert", _fake_upsert)
-    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda _column: True)
+    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None: nullcontext(SimpleNamespace()))
     monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", lambda *_args, **_kwargs: {"views": 300})
 
@@ -3104,6 +3313,58 @@ def test_upsert_instagram_post_persists_metadata_and_hosted_urls(monkeypatch) ->
     assert (payload.get("raw_data") or {}).get("view_metrics", {}).get("source") is None
 
 
+def test_upsert_instagram_post_uses_raw_reported_comment_count_when_post_count_is_zero(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_upsert(table: str, payload: dict[str, object], *, conflict_col: str, conn=None):
+        captured["table"] = table
+        captured["payload"] = payload
+        captured["conflict_col"] = conflict_col
+        return {"id": "db-post-1"}
+
+    monkeypatch.setattr(social_repo, "_pg_upsert", _fake_upsert)
+    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None: nullcontext(SimpleNamespace()))
+    monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", lambda *_args, **_kwargs: {"views": 0})
+
+    post = SimpleNamespace(
+        shortcode="DVg08tmAIFD",
+        pk="media-1",
+        username="peacock",
+        owner_username="peacock",
+        caption="Collab post",
+        post_type="image",
+        media_urls=[],
+        thumbnail_url=None,
+        likes=0,
+        comments=0,
+        video_views=0,
+        taken_at=datetime(2026, 3, 5, 18, 32, tzinfo=UTC),
+        to_dict=lambda: {
+            "shortcode": "DVg08tmAIFD",
+            "username": "peacock",
+            "owner_username": "peacock",
+            "comments": 51,
+            "collaborators": ["thetraitorsus"],
+        },
+    )
+
+    row = social_repo._upsert_instagram_post(
+        None,
+        job_id=None,
+        account="thetraitorsus",
+        post=post,
+        conn=None,
+    )
+
+    assert row == {"id": "db-post-1"}
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    assert payload["comments_count"] == 51
+    assert payload["source_account"] == "thetraitorsus"
+    assert payload["owner_username"] == "peacock"
+
+
 def test_upsert_instagram_post_skips_missing_optional_columns(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -3114,7 +3375,7 @@ def test_upsert_instagram_post_skips_missing_optional_columns(monkeypatch) -> No
         return {"id": "db-post-1"}
 
     monkeypatch.setattr(social_repo, "_pg_upsert", _fake_upsert)
-    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda _column: False)
+    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None: nullcontext(SimpleNamespace()))
     monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", lambda *_args, **_kwargs: {"views": 500})
 
@@ -3165,7 +3426,7 @@ def test_upsert_instagram_post_uses_monotonic_views_and_preserves_when_observed_
         return {"id": "db-post-1"}
 
     monkeypatch.setattr(social_repo, "_pg_upsert", _fake_upsert)
-    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda _column: True)
+    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None: nullcontext(SimpleNamespace()))
 
     existing_views_values = [{"views": 1200}, {"views": 1200}]
@@ -5045,6 +5306,56 @@ def test_ingest_shared_accounts_full_history_instagram_uses_frontier_strategy(
     assert created_jobs[0]["config"]["partition_strategy"] == social_repo.CATALOG_FULL_HISTORY_FRONTIER_STRATEGY
 
 
+def test_shared_account_prefers_frontier_strategy_for_full_history_catalog_gap() -> None:
+    assert (
+        social_repo._shared_account_prefers_frontier_strategy(
+            platform="instagram",
+            pipeline_ingest_mode=social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            expected_total_posts=436,
+            catalog_total_posts=431,
+        )
+        is True
+    )
+    assert (
+        social_repo._shared_account_prefers_frontier_strategy(
+            platform="instagram",
+            pipeline_ingest_mode=social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            expected_total_posts=431,
+            catalog_total_posts=431,
+        )
+        is False
+    )
+    assert (
+        social_repo._shared_account_prefers_frontier_strategy(
+            platform="instagram",
+            pipeline_ingest_mode=social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            resume_frontier_requested=True,
+            expected_total_posts=431,
+            catalog_total_posts=431,
+        )
+        is True
+    )
+    assert (
+        social_repo._shared_account_prefers_frontier_strategy(
+            platform="tiktok",
+            pipeline_ingest_mode=social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            expected_total_posts=436,
+            catalog_total_posts=431,
+        )
+        is False
+    )
+    assert (
+        social_repo._shared_account_prefers_frontier_strategy(
+            platform="instagram",
+            pipeline_ingest_mode=social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            bounded_window=True,
+            expected_total_posts=436,
+            catalog_total_posts=431,
+        )
+        is False
+    )
+
+
 def test_ingest_shared_accounts_full_history_instagram_allows_local_dev_inline_bypass(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5524,9 +5835,228 @@ def test_instagram_social_account_comment_target_shortcodes_all_saved_posts_igno
     )
 
     assert shortcodes == ["C2", "C1"]
+    assert "comments_count" in captured["sql"]
+    assert "raw_data" in captured["sql"]
     assert "saved_comments = 0" not in captured["sql"]
     assert "coalesce(last_seen_at" not in captured["sql"]
-    assert captured["params"] == ["bravotv"]
+    assert captured["params"] == ["bravotv", "bravotv"]
+
+
+def test_instagram_comment_targets_all_saved_posts_gap_first_joins_comments_by_post_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_fetch_all(sql: str, params: list[Any]) -> list[dict[str, Any]]:
+        captured["sql"] = sql
+        captured["params"] = list(params)
+        return [{"shortcode": "NEEDS_COMMENTS"}, {"shortcode": "COMPLETE"}]
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_TARGET_PRIORITY", "gap_first")
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+
+    result = social_repo._instagram_social_account_comment_target_shortcodes(
+        "thetraitorsus",
+        limit=50,
+        refresh_policy="all_saved_posts",
+    )
+
+    assert result == ["NEEDS_COMMENTS", "COMPLETE"]
+    assert "left join social.instagram_comments c on c.post_id = dp.post_id" in captured["sql"]
+    assert "c.is_missing is not true" in captured["sql"]
+    assert "raw_data" in captured["sql"]
+    assert "missing_comments_gap desc" in captured["sql"].lower()
+    assert "post_shortcode" not in captured["sql"]
+    assert captured["params"][-1] == 50
+
+
+def test_instagram_comments_profile_shard_count_bounds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", raising=False)
+    assert social_repo._instagram_comments_profile_shard_count(207) == 4
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "999")
+    assert social_repo._instagram_comments_profile_shard_count(431) == 24
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "0")
+    assert social_repo._instagram_comments_profile_shard_count(431) == 1
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "not-an-int")
+    assert social_repo._instagram_comments_profile_shard_count(431) == 8
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "8")
+    assert social_repo._instagram_comments_profile_shard_count(3) == 3
+
+
+def test_preview_social_account_comments_scrape_uses_bounded_profile_target_plan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    with social_repo._INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_LOCK:
+        social_repo._INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE.clear()
+
+    def _fail_full_target_list(*_args: Any, **_kwargs: Any) -> list[str]:
+        raise AssertionError("preview should not build the full target list")
+
+    def _fake_fetch_one(sql: str, params: list[Any]) -> dict[str, Any]:
+        captured["sql"] = sql
+        captured["params"] = list(params)
+        return {
+            "raw_target_source_ids_count": 431,
+            "sample_target_source_ids": ["C123", "C456", "C789"],
+        }
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "8")
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(social_repo, "_instagram_social_account_comment_target_shortcodes", _fail_full_target_list)
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+
+    payload = social_repo.preview_social_account_comments_scrape(
+        "instagram",
+        "thetraitorsus",
+        mode="profile",
+        refresh_policy="all_saved_posts",
+    )
+
+    assert payload["dry_run"] is True
+    assert payload["target_source_ids_count"] == 431
+    assert payload["raw_target_source_ids_count"] == 431
+    assert payload["sample_target_source_ids"] == ["C123", "C456", "C789"]
+    assert payload["comments_shard_count"] == 8
+    assert payload["recommended_comments_shard_count"] == 8
+    assert payload["refresh_policy"] == "all_saved_posts"
+    assert payload["target_priority"] == "gap_first"
+    assert payload["timing"]["target_preview_ms"] >= 0
+    assert payload["preview_cache"] == {
+        "enabled": True,
+        "hit": False,
+        "age_seconds": None,
+        "ttl_seconds": 60,
+    }
+    assert payload["cache"] == payload["preview_cache"]
+    assert payload["debug"]["target_plan_strategy"] == "bounded_profile_preview"
+    assert payload["debug"]["full_target_list_built"] is False
+    assert "array(" in captured["sql"].lower()
+    assert captured["params"] == ["thetraitorsus", "thetraitorsus", 12]
+
+
+def test_preview_social_account_comments_scrape_reuses_bounded_profile_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    with social_repo._INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_LOCK:
+        social_repo._INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE.clear()
+
+    def _fake_fetch_one(_sql: str, _params: list[Any]) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        return {
+            "raw_target_source_ids_count": 25,
+            "sample_target_source_ids": ["C001", "C002"],
+        }
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS", "60")
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+
+    first = social_repo.preview_social_account_comments_scrape(
+        "instagram",
+        "bravotv",
+        mode="profile",
+        refresh_policy="stale_or_missing",
+    )
+    second = social_repo.preview_social_account_comments_scrape(
+        "instagram",
+        "bravotv",
+        mode="profile",
+        refresh_policy="stale_or_missing",
+    )
+
+    assert calls == 1
+    assert first["preview_cache"]["hit"] is False
+    assert second["preview_cache"]["hit"] is True
+    assert second["cache"] == second["preview_cache"]
+    assert second["target_source_ids_count"] == 25
+    assert second["debug"]["full_target_list_built"] is False
+
+
+def test_instagram_incomplete_comment_targets_reuse_comments_tab_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def _fake_fetch_page(
+        account_handle: str,
+        *,
+        page: int,
+        page_size: int,
+        comment_filter: str | None = None,
+        conn: Any | None = None,
+    ) -> tuple[list[dict[str, Any]], int]:
+        calls.append(
+            {
+                "account_handle": account_handle,
+                "page": page,
+                "page_size": page_size,
+                "comment_filter": comment_filter,
+                "conn": conn,
+            }
+        )
+        if page == 1:
+            return ([{"shortcode": "C001"}, {"source_id": "C002"}], 3)
+        if page == 2:
+            return ([{"shortcode": "C003"}, {"shortcode": "C001"}], 3)
+        return ([], 3)
+
+    monkeypatch.setattr(social_repo, "_fetch_instagram_comments_only_profile_rows_page", _fake_fetch_page)
+
+    targets = social_repo._instagram_social_account_incomplete_comment_target_shortcodes(
+        "thetraitorsus",
+        limit=None,
+    )
+
+    assert targets == ["C001", "C002", "C003"]
+    assert [call["page"] for call in calls] == [1, 2]
+    assert {call["comment_filter"] for call in calls} == {"incomplete"}
+
+
+def test_preview_social_account_comments_scrape_incomplete_fill_targets_only_incomplete_posts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    with social_repo._INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_LOCK:
+        social_repo._INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE.clear()
+
+    def _fake_incomplete_targets(account_handle: str, *, limit: int | None) -> list[str]:
+        captured.update({"account_handle": account_handle, "limit": limit})
+        return ["GAP1", "GAP2", "GAP3"]
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS", "0")
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_social_account_incomplete_comment_target_shortcodes",
+        _fake_incomplete_targets,
+    )
+
+    payload = social_repo.preview_social_account_comments_scrape(
+        "instagram",
+        "thetraitorsus",
+        mode="profile",
+        target_filter="incomplete",
+    )
+
+    assert captured == {"account_handle": "thetraitorsus", "limit": None}
+    assert payload["dry_run"] is True
+    assert payload["target_filter"] == "incomplete"
+    assert payload["incomplete_fill"] is True
+    assert payload["target_source_ids_count"] == 3
+    assert payload["raw_target_source_ids_count"] == 3
+    assert payload["sample_target_source_ids"] == ["GAP1", "GAP2", "GAP3"]
+    assert payload["debug"]["query_target_filter"] == "incomplete"
 
 
 def test_start_social_account_comments_scrape_all_saved_posts_uses_uncapped_profile_defaults(
@@ -5536,6 +6066,7 @@ def test_start_social_account_comments_scrape_all_saved_posts_uses_uncapped_prof
     created_runs: list[dict[str, Any]] = []
     created_jobs: list[dict[str, Any]] = []
 
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "1")
     monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
     monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None, **_kwargs: nullcontext(object()))
     monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", lambda *_args, **_kwargs: {"locked": True})
@@ -5578,8 +6109,63 @@ def test_start_social_account_comments_scrape_all_saved_posts_uses_uncapped_prof
     assert created_runs[0]["refresh_policy"] == "all_saved_posts"
     assert created_runs[0]["max_posts"] is None
     assert created_runs[0]["max_comments_per_post"] == 0
+    assert created_runs[0]["timing"]["target_source_ids_count"] == 2
+    assert created_runs[0]["timing"]["target_enumeration_ms"] >= 0
+    assert payload["timing"]["target_source_ids_count"] == 2
     assert created_jobs[0]["target_source_ids"] == ["C123", "C456"]
     assert created_jobs[0]["max_comments_per_post"] == 0
+
+
+def test_start_social_account_comments_scrape_incomplete_fill_uses_incomplete_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_helper: dict[str, Any] = {}
+    created_runs: list[dict[str, Any]] = []
+    created_jobs: list[dict[str, Any]] = []
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "1")
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None, **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(social_repo.pg, "fetch_one_with_cursor", lambda *_args, **_kwargs: {"locked": True})
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: [{}])
+    monkeypatch.setattr(social_repo, "get_active_social_account_comments_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: False)
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_social_account_incomplete_comment_target_shortcodes",
+        lambda account_handle, **kwargs: (
+            captured_helper.update({"account_handle": account_handle, **kwargs}) or ["GAP1", "GAP2"]
+        ),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_run",
+        lambda *_args, **kwargs: created_runs.append(dict(kwargs.get("config") or {})) or "comments-run-1",
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs.get("config") or {})) or "comments-job-1",
+    )
+
+    payload = social_repo.start_social_account_comments_scrape(
+        "instagram",
+        "bravotv",
+        mode="profile",
+        refresh_policy="stale_or_missing",
+        target_filter="incomplete",
+        max_posts=25,
+    )
+
+    assert payload["run_id"] == "comments-run-1"
+    assert captured_helper == {"account_handle": "bravotv", "limit": 25}
+    assert payload["target_filter"] == "incomplete"
+    assert payload["incomplete_fill"] is True
+    assert created_runs[0]["target_filter"] == "incomplete"
+    assert created_runs[0]["incomplete_fill"] is True
+    assert created_jobs[0]["target_filter"] == "incomplete"
+    assert created_jobs[0]["incomplete_fill"] is True
+    assert created_jobs[0]["target_source_ids"] == ["GAP1", "GAP2"]
 
 
 def test_start_social_account_comments_scrape_reuses_lock_connection_for_active_run_lookup(
@@ -5631,23 +6217,63 @@ def test_start_social_account_comments_scrape_reuses_lock_connection_for_active_
     assert exc_info.value.detail["run_id"] == "comments-run-active-1"
 
 
-def test_start_social_account_comments_scrape_uses_modal_execution_backend_without_dedicated_lane(
+def test_start_social_account_comments_scrape_lock_contention_without_run_reports_launching(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    created_runs: list[dict[str, Any]] = []
-    created_jobs: list[dict[str, Any]] = []
-    dispatch_calls: list[dict[str, Any]] = []
-
     monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
     monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None, **_kwargs: nullcontext(object()))
     monkeypatch.setattr(
         social_repo.pg,
         "fetch_one_with_cursor",
         lambda *_args, **kwargs: (
-            {"locked": True}
+            {"locked": False}
             if "pg_try_advisory_lock" in (kwargs.get("query") or (_args[1] if len(_args) > 1 else ""))
             else {"unlocked": True}
         ),
+    )
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_all_with_cursor",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: [{}])
+
+    with pytest.raises(social_repo.SocialIngestConflictError) as exc_info:
+        social_repo.start_social_account_comments_scrape(
+            "instagram",
+            "bravotv",
+            mode="profile",
+            refresh_policy="stale_or_missing",
+        )
+
+    assert exc_info.value.code == "SOCIAL_ACCOUNT_COMMENTS_LAUNCH_IN_PROGRESS"
+    assert "unknown" not in str(exc_info.value).lower()
+    assert exc_info.value.detail["status"] == "starting"
+    assert exc_info.value.detail["retryable"] is True
+
+
+def test_start_social_account_comments_scrape_uses_modal_execution_backend_without_dedicated_lane(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_runs: list[dict[str, Any]] = []
+    created_jobs: list[dict[str, Any]] = []
+    dispatch_calls: list[dict[str, Any]] = []
+    ordering_events: list[str] = []
+
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None, **_kwargs: nullcontext(object()))
+
+    def _fetch_one_with_cursor(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+        query = kwargs.get("query") or (_args[1] if len(_args) > 1 else "")
+        if "pg_try_advisory_lock" in query:
+            ordering_events.append("advisory_lock")
+            return {"locked": True}
+        return {"unlocked": True}
+
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one_with_cursor",
+        _fetch_one_with_cursor,
     )
     monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: [{}])
     monkeypatch.setattr(social_repo, "get_active_social_account_comments_run", lambda *_args, **_kwargs: None)
@@ -5676,7 +6302,7 @@ def test_start_social_account_comments_scrape_uses_modal_execution_backend_witho
     monkeypatch.setattr(
         social_repo,
         "assert_worker_available_when_queue_enabled",
-        lambda **_kwargs: None,
+        lambda **_kwargs: ordering_events.append("worker_preflight") or None,
     )
 
     payload = social_repo.start_social_account_comments_scrape(
@@ -5694,6 +6320,128 @@ def test_start_social_account_comments_scrape_uses_modal_execution_backend_witho
     assert created_jobs[0]["required_worker_lane"] is None
     assert created_jobs[0]["required_execution_backend"] == "modal"
     assert dispatch_calls == [{"run_id": "comments-run-1"}]
+    assert ordering_events.index("worker_preflight") < ordering_events.index("advisory_lock")
+
+
+def test_start_social_account_comments_scrape_shards_profile_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_runs: list[dict[str, Any]] = []
+    created_jobs: list[dict[str, Any]] = []
+    dispatch_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "4")
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None, **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one_with_cursor",
+        lambda *_args, **kwargs: (
+            {"locked": True}
+            if "pg_try_advisory_lock" in (kwargs.get("query") or (_args[1] if len(_args) > 1 else ""))
+            else {"unlocked": True}
+        ),
+    )
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: [{}])
+    monkeypatch.setattr(social_repo, "get_active_social_account_comments_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+    monkeypatch.setattr(social_repo, "is_modal_remote_executor_enabled", lambda: True)
+    monkeypatch.setattr(social_repo, "assert_worker_available_when_queue_enabled", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_social_account_comment_target_shortcodes",
+        lambda *_args, **_kwargs: [f"C{i:03d}" for i in range(10)],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_run",
+        lambda *_args, **kwargs: created_runs.append(dict(kwargs.get("config") or {})) or "comments-run-1",
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs)) or f"comments-job-{len(created_jobs) + 1}",
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "dispatch_due_social_jobs",
+        lambda **kwargs: dispatch_calls.append(dict(kwargs)) or {"dispatched_job_ids": []},
+    )
+
+    payload = social_repo.start_social_account_comments_scrape(
+        "instagram",
+        "thetraitorsus",
+        mode="profile",
+        refresh_policy="all_saved_posts",
+    )
+
+    assert payload["run_id"] == "comments-run-1"
+    assert payload["target_source_ids_count"] == 10
+    assert payload["comments_shard_count"] == 4
+    assert payload["recommended_comments_shard_count"] == 2
+    assert [job["config"]["target_source_ids"] for job in created_jobs] == [
+        ["C000", "C001", "C002"],
+        ["C003", "C004", "C005"],
+        ["C006", "C007"],
+        ["C008", "C009"],
+    ]
+    assert [job["config"]["comments_shard_index"] for job in created_jobs] == [1, 2, 3, 4]
+    assert {job["config"]["comments_shard_count"] for job in created_jobs} == {4}
+    assert {job["config"]["target_source_ids_count"] for job in created_jobs} == {10}
+    assert created_runs[0]["comments_shard_count"] == 4
+    assert created_runs[0]["target_source_ids_count"] == 10
+    assert created_runs[0]["comments_proxy_shard_sessions"] is False
+    assert created_runs[0]["timing"]["target_source_ids_count"] == 10
+    assert created_runs[0]["timing"]["target_enumeration_ms"] >= 0
+    assert payload["timing"]["target_source_ids_count"] == 10
+    assert dispatch_calls == [{"run_id": "comments-run-1"}]
+
+
+def test_start_social_account_comments_scrape_does_not_shard_single_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_jobs: list[dict[str, Any]] = []
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT", "8")
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None, **_kwargs: nullcontext(object()))
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one_with_cursor",
+        lambda *_args, **kwargs: (
+            {"locked": True}
+            if "pg_try_advisory_lock" in (kwargs.get("query") or (_args[1] if len(_args) > 1 else ""))
+            else {"unlocked": True}
+        ),
+    )
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: [{}])
+    monkeypatch.setattr(social_repo, "get_active_social_account_comments_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: True)
+    monkeypatch.setattr(social_repo, "is_modal_remote_executor_enabled", lambda: True)
+    monkeypatch.setattr(social_repo, "assert_worker_available_when_queue_enabled", lambda **_kwargs: None)
+    monkeypatch.setattr(social_repo, "_create_run", lambda *_args, **_kwargs: "comments-run-1")
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs)) or "comments-job-1",
+    )
+    monkeypatch.setattr(social_repo, "dispatch_due_social_jobs", lambda **_kwargs: {"dispatched_job_ids": []})
+
+    payload = social_repo.start_social_account_comments_scrape(
+        "instagram",
+        "thetraitorsus",
+        mode="single_post",
+        source_id="ABC123",
+    )
+
+    assert payload["target_source_ids"] == ["ABC123"]
+    assert payload["target_source_ids_count"] == 1
+    assert payload["comments_shard_count"] == 1
+    assert payload["timing"]["target_source_ids_count"] == 1
+    assert len(created_jobs) == 1
+    assert created_jobs[0]["config"]["target_source_ids"] == ["ABC123"]
+    assert created_jobs[0]["config"]["comments_shard_index"] == 1
+    assert created_jobs[0]["config"]["comments_shard_count"] == 1
 
 
 def test_start_social_account_comments_scrape_can_defer_queue_dispatch(
@@ -5947,6 +6695,7 @@ def test_instagram_materialization_state_requires_detail_fields(monkeypatch: pyt
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(
         social_repo,
         "_instagram_materialized_detail_gap_counts",
@@ -5973,6 +6722,7 @@ def test_instagram_materialization_state_is_complete_when_counts_and_detail_fiel
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_instagram_materialized_detail_gap_counts", _complete_instagram_detail_gap_counts)
 
     state = social_repo._instagram_materialization_state("BravoTV")
@@ -5982,12 +6732,33 @@ def test_instagram_materialization_state_is_complete_when_counts_and_detail_fiel
     assert state["detail_gap_counts"]["posts_needing_detail_refresh"] == 0
 
 
+def test_instagram_materialization_state_requires_bootstrap_when_expected_total_exceeds_saved_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 431)
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 431)
+    monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 431)
+    monkeypatch.setattr(social_repo, "_instagram_materialized_detail_gap_counts", _complete_instagram_detail_gap_counts)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 436)
+
+    state = social_repo._instagram_materialization_state("TheTraitorsUS")
+
+    assert state["catalog_posts"] == 431
+    assert state["materialized_posts"] == 431
+    assert state["expected_total_posts"] == 436
+    assert state["completion_target_posts"] == 436
+    assert state["missing_catalog_posts"] == 5
+    assert state["missing_materialized_posts"] == 5
+    assert state["details_complete"] is False
+    assert state["bootstrap_required"] is True
+
+
 def test_instagram_materialized_detail_gap_counts_treats_raw_data_without_metadata_success_as_incomplete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, Any] = {}
 
-    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda _column: True)
+    monkeypatch.setattr(social_repo, "_instagram_posts_has_column", lambda *_args, **_kwargs: True)
 
     def _fake_fetch_one(sql: str, params: list[Any] | None = None) -> dict[str, int]:
         captured["sql"] = sql
@@ -6049,6 +6820,7 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
     monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 5)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 5)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 5)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 5)
     monkeypatch.setattr(social_repo, "_instagram_materialized_detail_gap_counts", _complete_instagram_detail_gap_counts)
     monkeypatch.setattr(
         social_repo,
@@ -6068,12 +6840,31 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
     )
     monkeypatch.setattr(
         social_repo,
+        "_load_catalog_run_row_by_id",
+        lambda _run_id: {
+            "config": {
+                "required_runtime_version": {"execution_backend": "modal", "modal_image": "im-latest"},
+                "created_by_runtime_version": {"execution_backend": "local", "commit_sha": "abc123"},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
         "_merge_catalog_run_config",
         lambda *, run_id, metadata_updates: (
             merged_config_updates.append({"run_id": run_id, **metadata_updates})
             or {"id": run_id, "status": "queued", "config": metadata_updates}
         ),
     )
+    monkeypatch.setattr(
+        social_repo,
+        "_merge_catalog_run_config_with_conn",
+        lambda **kwargs: (
+            merged_config_updates.append({"run_id": kwargs["run_id"], **kwargs["metadata_updates"]})
+            or {"config": kwargs["metadata_updates"]}
+        ),
+    )
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
     payload = social_repo.launch_social_account_catalog_backfill(
         "instagram",
@@ -6081,6 +6872,7 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
         source_scope="bravo",
         selected_tasks=selected_tasks,
     )
+    expect_deferred_comments = expect_catalog and expect_comments
 
     assert payload["launch_group_id"] == "launch-group-1"
     assert payload["selected_tasks"] == social_repo._normalize_social_account_catalog_backfill_selected_tasks(
@@ -6088,7 +6880,7 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
     )
     assert payload["effective_selected_tasks"] == effective_selected_tasks
     assert payload["catalog_bootstrap_required"] is False
-    assert payload["comments_deferred_until_catalog_complete"] is False
+    assert payload["comments_deferred_until_catalog_complete"] is expect_deferred_comments
     if expect_catalog:
         assert payload["catalog_run_id"] == "catalog-run-1"
         assert len(catalog_calls) == 1
@@ -6100,11 +6892,25 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
         assert payload["catalog_run_id"] is None
         assert catalog_calls == []
 
-    if expect_comments:
+    if expect_deferred_comments:
+        assert payload["comments_run_id"] is None
+        assert comments_calls == []
+        assert merged_config_updates[-1]["deferred_comments_followup"]["state"] == "pending"
+        assert merged_config_updates[-1]["deferred_comments_followup"]["comments_enable_media_followups"] is (
+            comments_enable_media_followups
+        )
+        assert payload["attached_followups"]["comments"] == {
+            "run_id": None,
+            "state": "pending",
+            "status": "pending",
+            "source": "deferred_after_catalog",
+        }
+        assert merged_config_updates[-1]["attached_followups"]["comments"] == payload["attached_followups"]["comments"]
+    elif expect_comments:
         assert payload["comments_run_id"] == "comments-run-1"
         assert len(comments_calls) == 1
         assert comments_calls[0]["mode"] == "profile"
-        assert comments_calls[0]["refresh_policy"] == "all_saved_posts"
+        assert comments_calls[0]["refresh_policy"] == "stale_or_missing"
         assert comments_calls[0]["comments_enable_media_followups"] is comments_enable_media_followups
         assert comments_calls[0]["launch_group_id"] == "launch-group-1"
         if expect_catalog:
@@ -6122,7 +6928,11 @@ def test_launch_social_account_catalog_backfill_instagram_coordinates_selected_t
         assert merged_config_updates[-1]["selected_tasks"] == payload["selected_tasks"]
         assert merged_config_updates[-1]["effective_selected_tasks"] == effective_selected_tasks
         if "media" in effective_selected_tasks:
-            expected_media_source = "comments_media_followups" if expect_comments else "catalog_media_mirror"
+            expected_media_source = (
+                "catalog_media_mirror"
+                if expect_deferred_comments
+                else "comments_media_followups" if expect_comments else "catalog_media_mirror"
+            )
             assert payload["attached_followups"]["media"] == {
                 "attachment_id": "media-launch-group-1",
                 "state": "pending",
@@ -6147,6 +6957,7 @@ def test_launch_social_account_catalog_backfill_instagram_defaults_selected_task
     monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 5)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 5)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 5)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 5)
     monkeypatch.setattr(social_repo, "_instagram_materialized_detail_gap_counts", _complete_instagram_detail_gap_counts)
     monkeypatch.setattr(
         social_repo,
@@ -6166,12 +6977,31 @@ def test_launch_social_account_catalog_backfill_instagram_defaults_selected_task
     )
     monkeypatch.setattr(
         social_repo,
+        "_load_catalog_run_row_by_id",
+        lambda _run_id: {
+            "config": {
+                "required_runtime_version": {"execution_backend": "modal", "modal_image": "im-latest"},
+                "created_by_runtime_version": {"execution_backend": "local", "commit_sha": "abc123"},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
         "_merge_catalog_run_config",
         lambda *, run_id, metadata_updates: (
             merged_config_updates.append({"run_id": run_id, **metadata_updates})
             or {"id": run_id, "status": "queued", "config": metadata_updates}
         ),
     )
+    monkeypatch.setattr(
+        social_repo,
+        "_merge_catalog_run_config_with_conn",
+        lambda **kwargs: (
+            merged_config_updates.append({"run_id": kwargs["run_id"], **kwargs["metadata_updates"]})
+            or {"config": kwargs["metadata_updates"]}
+        ),
+    )
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
     payload = social_repo.launch_social_account_catalog_backfill("instagram", "bravotv", source_scope="bravo")
 
@@ -6179,29 +7009,30 @@ def test_launch_social_account_catalog_backfill_instagram_defaults_selected_task
     assert payload["effective_selected_tasks"] == ["comments", "media"]
     assert payload["post_details_skipped_reason"] == "already_materialized"
     assert payload["catalog_run_id"] == "catalog-run-default"
-    assert payload["comments_run_id"] == "comments-run-default"
-    assert payload["comments_deferred_until_catalog_complete"] is False
+    assert payload["comments_run_id"] is None
+    assert payload["comments_deferred_until_catalog_complete"] is True
     assert payload["attached_followups"]["comments"] == {
-        "run_id": "comments-run-default",
+        "run_id": None,
         "state": "pending",
-        "status": "queued",
-        "source": "new_run",
+        "status": "pending",
+        "source": "deferred_after_catalog",
     }
     assert payload["attached_followups"]["media"] == {
         "attachment_id": "media-launch-group-default",
         "state": "pending",
         "status": "queued",
-        "source": "comments_media_followups",
+        "source": "catalog_media_mirror",
         "enqueued_job_ids": [],
         "enqueued_job_count": 0,
     }
     assert len(catalog_calls) == 1
     assert catalog_calls[0]["details_refresh_skip_detail_fetch"] is True
     assert catalog_calls[0]["details_refresh_skip_media_followups"] is False
-    assert len(comments_calls) == 1
+    assert comments_calls == []
     assert merged_config_updates[-1]["selected_tasks"] == ["post_details", "comments", "media"]
     assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
-    assert merged_config_updates[-1]["comments_run_id"] == "comments-run-default"
+    assert merged_config_updates[-1]["deferred_comments_followup"]["state"] == "pending"
+    assert merged_config_updates[-1]["deferred_comments_followup"]["comments_enable_media_followups"] is True
     assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
 
 
@@ -6330,6 +7161,38 @@ def test_begin_social_account_catalog_backfill_launch_returns_pending_payload(
     assert payload["launch_task_resolution_pending"] is True
     assert payload["selected_tasks"] == ["post_details", "comments", "media"]
     assert payload["effective_selected_tasks"] == ["post_details", "comments", "media"]
+
+
+def test_begin_social_account_catalog_backfill_launch_uses_running_status_for_inline_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "launch-group-inline")
+    monkeypatch.setattr(social_repo, "is_queue_enabled", lambda: False)
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: None)
+
+    def _reserve(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "run_id": "catalog-run-inline-placeholder",
+            "lock_wait_ms": 1.0,
+            "lock_held_ms": 2.0,
+        }
+
+    monkeypatch.setattr(social_repo, "_reserve_social_account_catalog_launch", _reserve)
+
+    payload = social_repo.begin_social_account_catalog_backfill_launch(
+        "instagram",
+        "bravotv",
+        source_scope="bravo",
+        allow_local_dev_inline_bypass=True,
+    )
+
+    assert captured["initial_status"] == "running"
+    assert payload["run_id"] == "catalog-run-inline-placeholder"
+    assert payload["status"] == "running"
+    assert payload["launch_state"] == "pending"
 
 
 def test_finalize_social_account_catalog_backfill_launch_reuses_existing_run_and_launch_group(
@@ -7002,6 +7865,7 @@ def test_launch_social_account_catalog_backfill_instagram_skips_detail_hydration
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_instagram_materialized_detail_gap_counts", _complete_instagram_detail_gap_counts)
     monkeypatch.setattr(
         social_repo,
@@ -7021,12 +7885,31 @@ def test_launch_social_account_catalog_backfill_instagram_skips_detail_hydration
     )
     monkeypatch.setattr(
         social_repo,
+        "_load_catalog_run_row_by_id",
+        lambda _run_id: {
+            "config": {
+                "required_runtime_version": {"execution_backend": "modal", "modal_image": "im-latest"},
+                "created_by_runtime_version": {"execution_backend": "local", "commit_sha": "abc123"},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
         "_merge_catalog_run_config",
         lambda *, run_id, metadata_updates: (
             merged_config_updates.append({"run_id": run_id, **metadata_updates})
             or {"id": run_id, "status": "queued", "config": metadata_updates}
         ),
     )
+    monkeypatch.setattr(
+        social_repo,
+        "_merge_catalog_run_config_with_conn",
+        lambda **kwargs: (
+            merged_config_updates.append({"run_id": kwargs["run_id"], **kwargs["metadata_updates"]})
+            or {"config": kwargs["metadata_updates"]}
+        ),
+    )
+    monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
     payload = social_repo.launch_social_account_catalog_backfill(
         "instagram",
@@ -7041,22 +7924,23 @@ def test_launch_social_account_catalog_backfill_instagram_skips_detail_hydration
     assert catalog_calls[0]["social_account_post_details_only"] is True
     assert catalog_calls[0]["details_refresh_skip_detail_fetch"] is True
     assert catalog_calls[0]["details_refresh_skip_media_followups"] is False
-    assert comments_calls[0]["refresh_policy"] == "all_saved_posts"
+    assert comments_calls == []
     assert merged_config_updates[-1]["selected_tasks"] == ["post_details", "comments", "media"]
     assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
-    assert merged_config_updates[-1]["comments_run_id"] == "comments-run-1"
+    assert merged_config_updates[-1]["deferred_comments_followup"]["state"] == "pending"
+    assert merged_config_updates[-1]["deferred_comments_followup"]["comments_enable_media_followups"] is True
     assert merged_config_updates[-1]["attached_followups"] == {
         "comments": {
-            "run_id": "comments-run-1",
+            "run_id": None,
             "state": "pending",
-            "status": "queued",
-            "source": "new_run",
+            "status": "pending",
+            "source": "deferred_after_catalog",
         },
         "media": {
             "attachment_id": "media-launch-group-ready",
             "state": "pending",
             "status": "queued",
-            "source": "comments_media_followups",
+            "source": "catalog_media_mirror",
             "enqueued_job_ids": [],
             "enqueued_job_count": 0,
         },
@@ -7072,6 +7956,7 @@ def test_launch_social_account_catalog_backfill_instagram_keeps_post_details_whe
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(
         social_repo,
         "_instagram_materialized_detail_gap_counts",
@@ -7122,6 +8007,7 @@ def test_launch_social_account_catalog_backfill_instagram_completes_existing_run
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_best_known_social_account_total_posts", lambda *_args, **_kwargs: 12)
     monkeypatch.setattr(social_repo, "_instagram_materialized_detail_gap_counts", _complete_instagram_detail_gap_counts)
     monkeypatch.setattr(
         social_repo,
@@ -7244,6 +8130,74 @@ def test_launch_social_account_catalog_backfill_reuses_active_comments_run_confl
     assert len(catalog_calls) == 1
     assert merged_config_updates[-1]["comments_run_id"] == "comments-run-existing"
     assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
+    assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
+
+
+def test_launch_social_account_catalog_backfill_reused_comments_tolerates_media_enqueue_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    merged_config_updates: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "launch-group-existing-comments")
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts_for_window", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_materialized_social_account_total_posts", lambda *_args, **_kwargs: 12)
+    monkeypatch.setattr(social_repo, "_instagram_materialized_detail_gap_counts", _complete_instagram_detail_gap_counts)
+    monkeypatch.setattr(
+        social_repo,
+        "start_social_account_catalog_backfill",
+        lambda platform, account_handle, **kwargs: {"run_id": "catalog-run-1", "status": "queued"},
+    )
+
+    def _raise_active_comments(*_args: Any, **_kwargs: Any) -> Any:
+        raise social_repo.SocialIngestConflictError(
+            "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE",
+            "Comments scrape run comments-run-existing is already active for @bravotv.",
+            detail={"run_id": "comments-run-existing", "status": "running"},
+        )
+
+    def _raise_media_enqueue_timeout(**_kwargs: Any) -> Any:
+        raise TimeoutError("media mirror enqueue timed out")
+
+    monkeypatch.setattr(social_repo, "start_social_account_comments_scrape", _raise_active_comments)
+    monkeypatch.setattr(social_repo, "_enqueue_instagram_account_media_repair_jobs", _raise_media_enqueue_timeout)
+    monkeypatch.setattr(
+        social_repo,
+        "_merge_catalog_run_config",
+        lambda *, run_id, metadata_updates: (
+            merged_config_updates.append({"run_id": run_id, **metadata_updates})
+            or {"id": run_id, "status": "queued", "config": metadata_updates}
+        ),
+    )
+
+    payload = social_repo.launch_social_account_catalog_backfill(
+        "instagram",
+        "bravotv",
+        source_scope="bravo",
+        selected_tasks=["post_details", "comments", "media"],
+    )
+
+    assert payload["catalog_run_id"] == "catalog-run-1"
+    assert payload["comments_run_id"] == "comments-run-existing"
+    assert payload["comments_status"] == "running"
+    assert payload["comments_deferred_until_catalog_complete"] is False
+    assert payload["attached_followups"] == {
+        "comments": {
+            "run_id": "comments-run-existing",
+            "state": "running",
+            "status": "running",
+            "source": "reused_run",
+        },
+        "media": {
+            "attachment_id": "media-launch-group-existing-comments",
+            "state": "failed",
+            "status": "failed",
+            "source": "catalog_media_mirror",
+            "enqueued_job_ids": [],
+            "enqueued_job_count": 0,
+        },
+    }
+    assert merged_config_updates[-1]["comments_run_id"] == "comments-run-existing"
     assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
 
 
@@ -7493,6 +8447,65 @@ def test_maybe_enqueue_shared_catalog_classify_jobs_after_fetch_skips_when_follo
     )
 
     assert created == 0
+
+
+def test_repair_catalog_launch_metadata_restores_missing_ready_followups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    merged_updates: list[dict[str, Any]] = []
+    run_row = {
+        "id": "catalog-run-ready-missing-followups",
+        "source_scope": "bravo",
+        "status": "running",
+        "config": {
+            "pipeline_ingest_mode": social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            "source_scope": "bravo",
+            "launch_state": "ready",
+            "launch_task_resolution_pending": False,
+            "launch_group_id": "launch-group-ready",
+            "selected_tasks": ["post_details", "comments", "media"],
+            "effective_selected_tasks": ["comments", "media"],
+            "catalog_followups_disabled": True,
+        },
+    }
+    job_rows = [
+        {
+            "id": "catalog-job-ready",
+            "platform": "instagram",
+            "job_type": social_repo.SHARED_ACCOUNT_POSTS_JOB_TYPE,
+            "status": "running",
+            "config": {"account": "thetraitorsus", "stage": social_repo.SHARED_ACCOUNT_POSTS_STAGE},
+            "metadata": {},
+        }
+    ]
+
+    monkeypatch.setattr(
+        social_repo,
+        "_resolve_effective_runtime_version",
+        lambda **_kwargs: {"execution_backend": "modal", "source": "test"},
+    )
+    monkeypatch.setattr(social_repo, "_resolve_runtime_version_stamp", lambda: {"app_version": "test-runtime"})
+
+    def _fake_merge_catalog_run_config(*, run_id: str, metadata_updates: Mapping[str, Any]) -> dict[str, Any]:
+        merged_updates.append(dict(metadata_updates))
+        return {"config": {**run_row["config"], **dict(metadata_updates)}}
+
+    monkeypatch.setattr(social_repo, "_merge_catalog_run_config", _fake_merge_catalog_run_config)
+
+    repaired = social_repo._repair_finalizing_catalog_launch_after_jobs(
+        run_row=run_row,
+        job_rows=job_rows,
+        platform="instagram",
+        account_handle="thetraitorsus",
+    )
+
+    assert repaired is not None
+    assert merged_updates[0]["launch_state"] == "ready"
+    assert merged_updates[0]["catalog_followups_disabled"] is False
+    assert merged_updates[0]["deferred_comments_followup"]["state"] == "pending"
+    assert merged_updates[0]["deferred_comments_followup"]["comments_enable_media_followups"] is True
+    assert merged_updates[0]["attached_followups"]["comments"]["source"] == "deferred_after_catalog"
+    assert merged_updates[0]["attached_followups"]["media"]["source"] == "catalog_media_mirror"
 
 
 @pytest.mark.parametrize("platform", ["instagram", "tiktok", "twitter", "youtube", "facebook", "threads"])
@@ -9704,6 +10717,8 @@ def test_get_social_account_profile_comments_reuses_read_connection_for_comment_
             assert "count(*) over()::int as full_count" not in normalized_sql
             assert "comment_total as (" in normalized_sql
             assert "page_ids as (" in normalized_sql
+            assert "to_jsonb(c) -> 'media_urls'" in sql
+            assert "to_jsonb(c) -> 'hosted_media_urls'" in sql
             return [
                 {
                     "id": "comment-1",
@@ -9721,6 +10736,8 @@ def test_get_social_account_profile_comments_reuses_read_connection_for_comment_
                     "text": "hello",
                     "likes": 3,
                     "replies_count": 2,
+                    "media_urls": ["https://images.example/source-comment.gif"],
+                    "hosted_media_urls": ["https://cdn.example/comment.gif"],
                     "is_reply": False,
                     "created_at": datetime(2026, 4, 1, tzinfo=UTC),
                     "parent_comment_id": None,
@@ -9741,6 +10758,8 @@ def test_get_social_account_profile_comments_reuses_read_connection_for_comment_
     assert payload["items"][0]["timestamp"] == datetime(2026, 4, 1, tzinfo=UTC)
     assert payload["items"][0]["likesCount"] == 3
     assert payload["items"][0]["repliesCount"] == 2
+    assert payload["items"][0]["media_urls"] == ["https://images.example/source-comment.gif"]
+    assert payload["items"][0]["hosted_media_urls"] == ["https://cdn.example/comment.gif"]
     assert payload["items"][0]["replies"] == []
     assert payload["items"][0]["owner"]["profile_pic_url"] == "https://images.example/source-avatar.jpg"
     assert payload["items"][0]["owner"]["hosted_profile_pic_url"] == "https://cdn.example/hosted-avatar.jpg"
@@ -10702,6 +11721,28 @@ def test_get_social_account_profile_summary_lite_includes_header_stats_without_f
     )
     monkeypatch.setattr(social_repo, "_shared_catalog_summary_totals", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(social_repo, "_catalog_recent_runs", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        social_repo,
+        "_social_account_comments_recent_runs",
+        lambda *_args, **_kwargs: [
+            {
+                "run_id": "comments-run-active",
+                "status": "running",
+                "created_at": "2026-04-29T02:40:00+00:00",
+                "completed_at": None,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_social_account_comments_target_counts",
+        lambda *_args, **_kwargs: {
+            "available_posts": 12,
+            "eligible_posts": 8,
+            "missing_posts": 3,
+            "stale_posts": 1,
+        },
+    )
     monkeypatch.setattr(social_repo, "_social_account_profile_optional_identity_fields", lambda *_args, **_kwargs: {})
     monkeypatch.setattr(social_repo, "_avatar_registry_lookup_any", lambda **_kwargs: {})
 
@@ -10758,7 +11799,20 @@ def test_get_social_account_profile_summary_lite_includes_header_stats_without_f
         "retrieved_comment_posts": 12,
         "saved_comment_media_files": 7,
     }
-    assert payload["comments_coverage"] is None
+    assert payload["comments_coverage"] == {
+        "available_posts": 12,
+        "eligible_posts": 8,
+        "missing_posts": 3,
+        "stale_posts": 1,
+        "last_comments_run_at": "2026-04-29T02:40:00+00:00",
+        "last_comments_run_status": "running",
+        "effective_status": "running",
+        "effective_label": "Running",
+        "historical_failure": False,
+        "last_attempt_status": "running",
+        "last_attempt_at": "2026-04-29T02:40:00+00:00",
+        "active_run_id": "comments-run-active",
+    }
     assert payload["media_coverage"] == {
         "saved_files": 1289,
         "total_files": 1400,
@@ -11740,6 +12794,27 @@ def test_social_account_profile_post_item_includes_catalog_media_fields() -> Non
     assert payload["post_format"] == "carousel"
 
 
+def test_social_account_profile_post_item_uses_instagram_raw_caption_fallback() -> None:
+    payload = social_repo._social_account_profile_post_item(
+        "instagram",
+        {
+            "id": "materialized-1",
+            "source_id": "DXuqLQzjODD",
+            "caption": "",
+            "text": None,
+            "posted_at": "2026-04-29T20:31:10Z",
+            "raw_data": {
+                "caption": "Foreshadowing at its finest.\n\nAll episodes of #TheTraitorsUS are streaming on Peacock.",
+            },
+            "comments_count": 24,
+            "_profile_source_surface": "materialized",
+        },
+        account_handle="thetraitorsus",
+    )
+
+    assert payload["content"] == "Foreshadowing at its finest.\n\nAll episodes of #TheTraitorsUS are streaming on Peacock."
+
+
 def test_touch_shared_account_source_serializes_datetime_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
@@ -11849,7 +12924,11 @@ def test_get_social_account_profile_hashtags_uses_canonical_catalog_aggregate_he
             {"hashtag": "housewives", "usage_count": 45},
         ],
     )
-    monkeypatch.setattr(social_repo, "_fetch_instagram_social_account_profile_entity_rows", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        social_repo,
+        "_fetch_instagram_social_account_profile_entity_rows",
+        lambda *_args, **_kwargs: [],
+    )
 
     payload = social_repo.get_social_account_profile_hashtags("instagram", "bravotv")
 
@@ -11879,7 +12958,11 @@ def test_get_social_account_profile_hashtags_forwards_window_to_helper(
         return [{"hashtag": "bravo", "usage_count": 12, "first_seen_at": "2026-03-01T00:00:00Z"}]
 
     monkeypatch.setattr(social_repo, "_social_account_profile_hashtag_items", _fake_hashtag_items)
-    monkeypatch.setattr(social_repo, "_fetch_instagram_social_account_profile_entity_rows", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        social_repo,
+        "_fetch_instagram_social_account_profile_entity_rows",
+        lambda *_args, **_kwargs: [],
+    )
 
     payload = social_repo.get_social_account_profile_hashtags("instagram", "bravotv", window="30d")
 
@@ -12529,6 +13612,77 @@ def test_catalog_recent_runs_batches_attached_followup_resolution(monkeypatch: p
 
     assert rows[0]["attached_followups"]["comments"]["status"] == "completed"
     assert rows[0]["attached_followups"]["media"]["status"] == "completed"
+
+
+def test_resolve_attached_followups_uses_terminal_parent_for_stale_deferred_children() -> None:
+    payload = social_repo._resolve_run_attached_followups(
+        run_config={
+            "attached_followups": {
+                "comments": {
+                    "run_id": None,
+                    "state": "pending",
+                    "status": "pending",
+                    "source": "deferred_after_catalog",
+                },
+                "media": {
+                    "attachment_id": "media-launch-group-1",
+                    "state": "running",
+                    "status": "running",
+                    "source": "catalog_media_mirror",
+                    "enqueued_job_ids": [],
+                    "enqueued_job_count": 0,
+                },
+            }
+        },
+        run_id="catalog-run-cancelled-1",
+        run_status="cancelled",
+        run_status_by_id={},
+        media_jobs_by_id={},
+        media_jobs_by_run_id={"catalog-run-cancelled-1": []},
+    )
+
+    assert payload["comments"]["status"] == "cancelled"
+    assert payload["comments"]["state"] == "cancelled"
+    assert payload["media"]["status"] == "cancelled"
+    assert payload["media"]["state"] == "cancelled"
+
+
+def test_catalog_recent_runs_header_resolves_terminal_attached_followups(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_all",
+        lambda *_args, **_kwargs: [
+            {
+                "job_id": "job-cancelled-1",
+                "run_id": "run-cancelled-1",
+                "status": "cancelled",
+                "created_at": datetime(2026, 4, 30, 11, 13, tzinfo=UTC),
+                "started_at": datetime(2026, 4, 30, 11, 13, tzinfo=UTC),
+                "completed_at": datetime(2026, 4, 30, 14, 21, tzinfo=UTC),
+                "error_message": "Remote Modal dispatch lease expired before any worker claimed the job.",
+                "run_config": {
+                    "pipeline_ingest_mode": social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+                    "attached_followups": {
+                        "comments": {"state": "pending", "status": "pending", "source": "deferred_after_catalog"},
+                        "media": {
+                            "attachment_id": "media-launch-1",
+                            "state": "running",
+                            "status": "running",
+                            "source": "catalog_media_mirror",
+                            "enqueued_job_ids": [],
+                            "enqueued_job_count": 0,
+                        },
+                    },
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(social_repo, "_load_media_followup_jobs_for_run", lambda *_args, **_kwargs: [])
+
+    rows = social_repo._catalog_recent_runs_header("instagram", "bravotv", limit=3)
+
+    assert rows[0]["attached_followups"]["comments"]["status"] == "cancelled"
+    assert rows[0]["attached_followups"]["media"]["status"] == "cancelled"
 
 
 def test_count_visible_failed_runs_interpolates_run_dismissal_predicate(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -17892,7 +19046,7 @@ def test_upsert_tweet_without_run_id_preserves_last_seen_run(monkeypatch) -> Non
 
     monkeypatch.setattr(social_repo, "_pg_upsert", _fake_upsert)
     monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda table: table == "twitter_tweets")
-    monkeypatch.setattr(social_repo, "_platform_posts_has_column", lambda _platform, _column: True)
+    monkeypatch.setattr(social_repo, "_platform_posts_has_column", lambda *_args, **_kwargs: True)
 
     context = SeasonContext(
         season_id="season-1",
@@ -17933,7 +19087,7 @@ def test_upsert_tweet_batch_uses_bulk_upsert_and_dedupes(monkeypatch) -> None:
         return [{"id": f"row-{tweet_id}", "tweet_id": tweet_id} for tweet_id in chunk_ids]
 
     monkeypatch.setattr(social_repo, "_pg_upsert_many", _fake_bulk)
-    monkeypatch.setattr(social_repo, "_platform_posts_has_column", lambda _platform, _column: True)
+    monkeypatch.setattr(social_repo, "_platform_posts_has_column", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda _table: True)
 
     context = SeasonContext(
@@ -18669,6 +19823,9 @@ def test_recover_stale_running_jobs_updates_worker_state_and_run_summaries(monke
     assert _count_unescaped_placeholders(sql_text) == len(params)
     assert "claimed_at = null" in sql_text
     assert "worker_id = null" in sql_text
+    assert "comments_retry_rebalance" in sql_text
+    assert "remaining_target_source_ids" in sql_text
+    assert social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE in params
 
 
 def test_recover_stale_running_jobs_uses_exponential_power_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -18767,8 +19924,9 @@ def test_recover_stale_running_jobs_releases_matching_frontier_lease(monkeypatch
     ]
 
 
-def test_default_job_claim_batch_size_for_posts_is_single_claim() -> None:
+def test_default_job_claim_batch_size_for_sequential_stages_is_single_claim() -> None:
     assert social_repo._default_job_claim_batch_size_for_stage("posts") == 1
+    assert social_repo._default_job_claim_batch_size_for_stage("comments_scrapling") == 1
     assert (
         social_repo._default_job_claim_batch_size_for_stage("comments")
         == social_repo.SOCIAL_JOB_CLAIM_BATCH_SIZE_DEFAULT
@@ -19789,8 +20947,111 @@ def test_modal_dispatch_stage_caps_follow_worker_pool_env(monkeypatch: pytest.Mo
 
     assert social_repo._modal_dispatch_stage_global_cap("posts") == 13
     assert social_repo._modal_dispatch_stage_global_cap("comments") == 11
+    assert social_repo._modal_dispatch_stage_global_cap(social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE) == 11
+    assert social_repo._modal_dispatch_platform_cap(social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE, "instagram") == 2
     assert social_repo._modal_dispatch_stage_global_cap("media_mirror") == 7
     assert social_repo._modal_dispatch_stage_global_cap("comment_media_mirror") == 5
+
+
+def test_dispatch_due_social_jobs_caps_comments_scrapling_as_comments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOCIAL_QUEUE_ENABLED", "1")
+    monkeypatch.setenv("TRR_JOB_PLANE_MODE", "remote")
+    monkeypatch.setenv("TRR_REMOTE_EXECUTOR", "modal")
+    monkeypatch.setenv("TRR_MODAL_ENABLED", "1")
+
+    candidates = [
+        {
+            "id": "job-comments-3",
+            "run_id": "run-comments",
+            "platform": "instagram",
+            "job_type": "comments",
+            "config": {
+                "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                "account": "thetraitorsus",
+            },
+            "metadata": {},
+        }
+    ]
+
+    monkeypatch.setattr(social_repo, "recover_dispatch_blocked_no_progress_jobs", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        social_repo,
+        "_modal_social_dispatch_resolution",
+        lambda: {
+            "resolved": True,
+            "reason": None,
+            "app_name": "trr-backend-jobs",
+            "function_name": "run_social_job",
+        },
+    )
+    monkeypatch.setattr(social_repo, "recover_stale_unclaimed_dispatched_jobs", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        social_repo,
+        "_list_candidate_jobs_for_modal_dispatch",
+        lambda *, run_id=None, limit=200: list(candidates),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_current_modal_dispatch_running_counts",
+        lambda: (
+            {"comments": 2},
+            {("comments", "instagram"): 2},
+            {"run-comments": 2},
+            {},
+            {("comments", "instagram"): {"thetraitorsus"}},
+        ),
+    )
+    monkeypatch.setattr(social_repo, "_touch_modal_social_dispatcher_heartbeat", lambda **kwargs: {})
+    monkeypatch.setattr(
+        social_repo,
+        "dispatch_social_job",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("comments_scrapling should be capped as comments work")
+        ),
+    )
+
+    result = social_repo.dispatch_due_social_jobs(run_id="run-comments", limit=4)
+
+    assert result["dispatched_job_ids"] == []
+    assert result["dispatch_attempts"] == 0
+
+
+def test_recover_failed_instagram_comments_capacity_jobs_requeues_matching_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    finalized: list[tuple[str, bool]] = []
+    captured_params: list[list[object]] = []
+    captured_sql: list[str] = []
+    run_id = "11111111-1111-1111-1111-111111111111"
+
+    def _fake_fetch_all(_sql: str, params: list[object]) -> list[dict[str, object]]:
+        captured_sql.append(_sql)
+        captured_params.append(list(params))
+        return [{"id": "job-capacity-1", "run_id": run_id, "platform": "instagram", "status": "retrying"}]
+
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+    monkeypatch.setattr(
+        social_repo,
+        "_finalize_run_status",
+        lambda recovered_run_id, force_recompute=False: finalized.append((recovered_run_id, force_recompute)) or {},
+    )
+
+    rows = social_repo.recover_failed_instagram_comments_capacity_jobs(run_id=run_id, limit=3)
+
+    assert rows == [{"id": "job-capacity-1", "run_id": run_id, "platform": "instagram", "status": "retrying"}]
+    assert captured_params[0] == [social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE, run_id, run_id, 3]
+    assert "instagram_comments_warmup_transport_error" in captured_sql[0]
+    assert "sslerror" in captured_sql[0]
+    assert "[ssl]" in captured_sql[0]
+    assert "ssl.c" in captured_sql[0]
+    assert "record layer failure" in captured_sql[0]
+    assert "wrong version number" in captured_sql[0]
+    assert "ssl connection" in captured_sql[0]
+    assert "closed unexpectedly" in captured_sql[0]
+    assert "transport_recovered" in captured_sql[0]
+    assert finalized == [(run_id, True)]
 
 
 def test_claim_and_process_social_job_dispatches_follow_up_work(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -22550,7 +23811,7 @@ def test_platform_comment_media_needs_mirror_twitter_detects_missing_hosted_asse
 def test_update_platform_post_media_mirror_fields_writes_hosted_media_urls_as_jsonb(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    monkeypatch.setattr(social_repo, "_platform_posts_has_column", lambda _platform, _column: True)
+    monkeypatch.setattr(social_repo, "_platform_posts_has_column", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(social_repo.pg, "db_cursor", lambda conn=None: nullcontext("cur"))
 
     def _fake_fetch_one_with_cursor(cur, sql: str, params: list[object]):  # noqa: ANN001
@@ -26328,7 +27589,7 @@ def test_persist_shared_catalog_posts_batch_materializes_instagram_posts_and_enq
             "account": "bravotv",
             "post_id": "post-1",
             "parent_job_id": "job-1",
-            "conn_present": False,
+            "conn_present": True,
             "week_index": None,
         }
     ]
@@ -27464,6 +28725,515 @@ def test_get_social_account_catalog_run_progress_groups_shards_under_one_handle(
     assert posts_handle["jobs_total"] == 2
     assert posts_handle["jobs_running"] == 2
     assert posts_handle["runner_lanes"] == ["A", "B"]
+
+
+def test_get_social_account_catalog_run_progress_counts_comments_scrapling_posts_from_stage_counters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "22222222-2222-2222-2222-222222222222"
+    run_row = {
+        "run_id": run_id,
+        "season_id": None,
+        "status": "running",
+        "source_scope": "bravo",
+        "config": {
+            "platform": "instagram",
+            "account": "thetraitorsus",
+            "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+        },
+        "summary": {"total_jobs": 1, "completed_jobs": 0, "failed_jobs": 0, "active_jobs": 1},
+        "created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+        "started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+        "completed_at": None,
+    }
+    job_rows = [
+        {
+            "id": "job-comments",
+            "platform": "instagram",
+            "job_type": "comments",
+            "status": "running",
+            "items_found": 16263,
+            "error_message": None,
+            "created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+            "completed_at": None,
+            "config": {
+                "account": "thetraitorsus",
+                "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+            },
+            "metadata": {
+                "activity": {
+                    "phase": "comments_scrapling_running",
+                    "posts_checked": 431,
+                    "matched_posts": 136,
+                    "saved_posts": 136,
+                    "total_posts": 431,
+                },
+                "stage_counters": {"posts": 136, "comments": 16127},
+                "persist_counters": {"posts_upserted": 136, "comments_upserted": 8138},
+            },
+            "worker_id": "modal:social-comments:test",
+        }
+    ]
+
+    monkeypatch.setattr(social_repo, "_relation_exists", lambda _name: True)
+    monkeypatch.setattr(social_repo, "_scrape_jobs_features", lambda: {"has_run_id": True, "has_queue_fields": True})
+    monkeypatch.setattr(social_repo, "_run_progress_summary_needs_refresh", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(social_repo, "_finalize_run_status", lambda *_args, **_kwargs: {"status": "running"})
+    monkeypatch.setattr(social_repo, "_cached_live_profile_total_posts", lambda *_args, **_kwargs: 431)
+    monkeypatch.setattr(social_repo, "_social_account_profile_total_posts", lambda *_args, **_kwargs: 431)
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 431)
+    monkeypatch.setattr(social_repo, "_shared_account_partition_progress", lambda **_kwargs: {})
+    monkeypatch.setattr(social_repo, "_shared_account_frontier_progress", lambda **_kwargs: {})
+    monkeypatch.setattr(social_repo, "_load_shared_account_source_row", lambda **_kwargs: {})
+    monkeypatch.setattr(
+        social_repo,
+        "_shared_profile_contract",
+        lambda **kwargs: {
+            "source_scope": kwargs["source_scope"],
+            "profile_kind": "network_streaming",
+            "network_name": "Bravo",
+            "assignment_mode": "multi_show_match",
+            "assignment_rules": {},
+            "account_handle": kwargs["account_handle"],
+            "platform": kwargs["platform"],
+        },
+    )
+    monkeypatch.setattr(social_repo.pg, "fetch_one", lambda *_args, **_kwargs: run_row)
+    monkeypatch.setattr(social_repo.pg, "fetch_all", lambda *_args, **_kwargs: job_rows)
+
+    payload = social_repo.get_social_account_catalog_run_progress("instagram", "thetraitorsus", run_id)
+
+    assert payload["stages"]["comments"]["jobs_running"] == 1
+    assert payload["stages"]["comments"]["scraped_count"] == 16263
+    assert payload["post_progress"] == {
+        "completed_posts": 136,
+        "matched_posts": 136,
+        "total_posts": 431,
+    }
+
+
+def test_social_account_comments_scrape_run_progress_aggregates_shards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "11111111-1111-1111-1111-111111111111"
+    rows = [
+        {
+            "run_id": run_id,
+            "run_status": "running",
+            "run_config": {
+                "target_source_ids_count": 431,
+                "comments_shard_count": 8,
+                "recommended_comments_shard_count": 8,
+            },
+            "created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+            "completed_at": datetime(2026, 4, 28, 18, 50, tzinfo=UTC),
+            "summary": {"total_jobs": 8, "completed_jobs": 1, "failed_jobs": 0, "active_jobs": 7},
+            "job_id": "job-1",
+            "job_status": "completed",
+            "items_found": 5000,
+            "job_created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "job_started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+            "job_completed_at": datetime(2026, 4, 28, 18, 50, tzinfo=UTC),
+            "error_message": None,
+            "config": {
+                "target_source_ids": ["A"],
+                "comments_shard_index": 1,
+                "comments_shard_count": 8,
+                "comments_shard_target_count": 54,
+            },
+            "metadata": {"stage_counters": {"posts": 54, "comments": 4946}, "activity": {"posts_checked": 54}},
+        },
+        {
+            "run_id": run_id,
+            "run_status": "running",
+            "run_config": {
+                "target_source_ids_count": 431,
+                "comments_shard_count": 8,
+                "recommended_comments_shard_count": 8,
+            },
+            "created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+            "completed_at": datetime(2026, 4, 28, 18, 50, tzinfo=UTC),
+            "summary": {"total_jobs": 8, "completed_jobs": 1, "failed_jobs": 0, "active_jobs": 7},
+            "job_id": "job-2",
+            "job_status": "running",
+            "items_found": 1000,
+            "job_created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "job_started_at": datetime(2026, 4, 28, 18, 41, tzinfo=UTC),
+            "job_completed_at": None,
+            "error_message": "Remote Modal dispatch lease expired before any worker claimed the job.",
+            "last_error_code": "stale_modal_dispatch_unclaimed",
+            "config": {
+                "target_source_ids": ["B"],
+                "comments_shard_index": 2,
+                "comments_shard_count": 8,
+                "comments_shard_target_count": 54,
+            },
+            "metadata": {"stage_counters": {"posts": 12, "comments": 988}, "activity": {"posts_checked": 12}},
+        },
+    ]
+    monkeypatch.setattr(social_repo.pg, "fetch_all", lambda *_args, **_kwargs: rows)
+    monkeypatch.setattr(social_repo, "_now_utc", lambda: datetime(2026, 4, 28, 18, 50, tzinfo=UTC))
+
+    payload = social_repo.get_social_account_comments_scrape_run_progress(
+        "instagram",
+        "thetraitorsus",
+        run_id,
+    )
+
+    assert payload["post_progress"] == {
+        "completed_posts": 66,
+        "matched_posts": 66,
+        "total_posts": 431,
+    }
+    assert payload["comments_shard_count"] == 8
+    assert payload["recommended_comments_shard_count"] == 8
+    assert payload["completed_comment_jobs"] == 1
+    assert payload["active_comment_jobs"] == 1
+    assert payload["queued_comment_jobs"] == 0
+    assert payload["target_source_ids_count"] == 431
+    assert payload["throughput"] == {
+        "elapsed_seconds": 600,
+        "posts_per_minute": 6.6,
+        "comments_per_minute": 600.0,
+    }
+    assert payload["cancellation_summary"] == {
+        "cancelled_jobs": 0,
+        "failed_jobs": 0,
+        "remaining_target_source_ids_count": 0,
+        "resume_recommendation": None,
+    }
+    assert payload["comment_shards"] == [
+        {
+            "job_id": "job-1",
+            "shard_index": 1,
+            "shard_count": 8,
+            "status": "completed",
+            "target_count": 54,
+            "target_source_ids_count": 54,
+            "comments_shard_target_count": 54,
+            "processed_post_count": 54,
+            "completed_posts": 54,
+            "matched_posts": 54,
+            "remaining_target_count": 0,
+            "queue_wait_seconds": 60,
+            "posts_per_minute": 5.4,
+            "comments_per_minute": 500.0,
+            "items_found_total": 5000,
+            "error_message": None,
+            "latest_failure_reason": None,
+        },
+        {
+            "job_id": "job-2",
+            "shard_index": 2,
+            "shard_count": 8,
+            "status": "running",
+            "target_count": 54,
+            "target_source_ids_count": 54,
+            "comments_shard_target_count": 54,
+            "processed_post_count": 12,
+            "completed_posts": 12,
+            "matched_posts": 12,
+            "remaining_target_count": 42,
+            "queue_wait_seconds": 120,
+            "posts_per_minute": 1.33,
+            "comments_per_minute": 111.11,
+            "items_found_total": 1000,
+            "error_message": None,
+            "latest_failure_reason": None,
+        },
+    ]
+    assert payload["shards"] == payload["comment_shards"]
+    assert payload["shard_progress"] == payload["comment_shards"]
+    assert payload["timing"] == {
+        "queue_wait_seconds_max": 120,
+        "queue_wait_seconds_avg": 90.0,
+    }
+
+
+def test_social_account_comments_scrape_run_progress_recomputes_stale_summary_and_clamps_posts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_id = "11111111-1111-1111-1111-111111111111"
+    rows = [
+        {
+            "run_id": run_id,
+            "run_status": "running",
+            "run_config": {"target_source_ids_count": 2, "comments_shard_count": 2},
+            "created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+            "completed_at": None,
+            "summary": {"total_jobs": 4, "completed_jobs": 0, "failed_jobs": 0, "active_jobs": 4},
+            "job_id": "job-1",
+            "job_status": "retrying",
+            "items_found": 20,
+            "job_created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "job_started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+            "job_completed_at": None,
+            "error_message": None,
+            "config": {
+                "target_source_ids": ["A", "B"],
+                "comments_shard_index": 1,
+                "comments_shard_count": 2,
+                "comments_shard_target_count": 2,
+            },
+            "metadata": {"stage_counters": {"posts": 2, "comments": 18}, "activity": {"posts_checked": 2}},
+        },
+        {
+            "run_id": run_id,
+            "run_status": "running",
+            "run_config": {"target_source_ids_count": 2, "comments_shard_count": 2},
+            "created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "started_at": datetime(2026, 4, 28, 18, 40, tzinfo=UTC),
+            "completed_at": None,
+            "summary": {"total_jobs": 4, "completed_jobs": 0, "failed_jobs": 0, "active_jobs": 4},
+            "job_id": "job-2",
+            "job_status": "running",
+            "items_found": 10,
+            "job_created_at": datetime(2026, 4, 28, 18, 39, tzinfo=UTC),
+            "job_started_at": datetime(2026, 4, 28, 18, 41, tzinfo=UTC),
+            "job_completed_at": None,
+            "error_message": None,
+            "config": {
+                "target_source_ids": ["A", "B"],
+                "comments_shard_index": 2,
+                "comments_shard_count": 2,
+                "comments_shard_target_count": 2,
+            },
+            "metadata": {"stage_counters": {"posts": 2, "comments": 8}, "activity": {"posts_checked": 2}},
+        },
+    ]
+    monkeypatch.setattr(social_repo.pg, "fetch_all", lambda *_args, **_kwargs: rows)
+    monkeypatch.setattr(social_repo, "_now_utc", lambda: datetime(2026, 4, 28, 18, 50, tzinfo=UTC))
+
+    payload = social_repo.get_social_account_comments_scrape_run_progress(
+        "instagram",
+        "thetraitorsus",
+        run_id,
+    )
+
+    assert payload["summary"] == {
+        "total_jobs": 2,
+        "completed_jobs": 0,
+        "failed_jobs": 0,
+        "active_jobs": 2,
+        "items_found_total": 30,
+    }
+    assert payload["post_progress"] == {
+        "completed_posts": 2,
+        "matched_posts": 2,
+        "total_posts": 2,
+    }
+
+
+def test_rebalance_failed_instagram_comments_shard_creates_smaller_retry_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_jobs: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: {
+            "job_id": "failed-job",
+            "run_id": "run-1",
+            "platform": "instagram",
+            "source_scope": "bravo",
+            "initiated_by": "test",
+            "config": {
+                "account": "thetraitorsus",
+                "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                "comments_shard_count": 8,
+            },
+            "metadata": {
+                "retry_rebalance": {
+                    "remaining_target_source_ids": ["A", "B", "C", "D", "E"],
+                    "eligible": True,
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs)) or f"retry-{len(created_jobs)}",
+    )
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "retry-group-1")
+
+    payload = social_repo.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=2,
+    )
+
+    assert payload["created_job_ids"] == ["retry-1", "retry-2", "retry-3"]
+    assert payload["retry_group_id"] == "retry-group-1"
+    assert [job["config"]["target_source_ids"] for job in created_jobs] == [["A", "B"], ["C", "D"], ["E"]]
+    assert {job["priority"] for job in created_jobs} == {110}
+
+
+def test_rebalance_failed_instagram_comments_shard_falls_back_to_job_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_jobs: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: {
+            "job_id": "failed-job",
+            "run_id": "run-1",
+            "platform": "instagram",
+            "source_scope": "bravo",
+            "initiated_by": "test",
+            "items_found": 0,
+            "config": {
+                "account": "thetraitorsus",
+                "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                "comments_shard_count": 8,
+                "target_source_ids": ["A", "B", "C"],
+            },
+            "metadata": {},
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs)) or f"retry-{len(created_jobs)}",
+    )
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "retry-group-1")
+
+    payload = social_repo.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=2,
+    )
+
+    assert payload["created_job_ids"] == ["retry-1", "retry-2"]
+    assert [job["config"]["target_source_ids"] for job in created_jobs] == [["A", "B"], ["C"]]
+
+
+def test_repair_instagram_comments_scrape_run_target_gaps_creates_missing_target_jobs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_jobs: list[dict[str, Any]] = []
+    dispatch_calls: list[dict[str, Any]] = []
+    run_id = "11111111-1111-1111-1111-111111111111"
+
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: {
+            "run_id": run_id,
+            "source_scope": "bravo",
+            "initiated_by": "test",
+            "config": {
+                "account": "thetraitorsus",
+                "source_scope": "bravo",
+                "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                "refresh_policy": "all_saved_posts",
+                "comments_shard_count": 4,
+                "target_source_ids_count": 5,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_all",
+        lambda *_args, **_kwargs: [
+            {
+                "status": "running",
+                "config": {"target_source_ids": ["A", "B"], "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE},
+            },
+            {
+                "status": "queued",
+                "config": {"target_source_ids": ["C"], "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE},
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_social_account_comment_target_shortcodes",
+        lambda *_args, **_kwargs: ["A", "B", "C", "D", "E"],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs)) or f"repair-{len(created_jobs)}",
+    )
+    monkeypatch.setattr(social_repo, "dispatch_due_social_jobs", lambda **kwargs: dispatch_calls.append(dict(kwargs)))
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "repair-group-1")
+
+    payload = social_repo.repair_instagram_comments_scrape_run_target_gaps(
+        run_id=run_id,
+        max_retry_shard_size=1,
+    )
+
+    assert payload["created_job_ids"] == ["repair-1", "repair-2"]
+    assert payload["missing_target_source_ids_count"] == 2
+    assert [job["config"]["target_source_ids"] for job in created_jobs] == [["D"], ["E"]]
+    assert [job["config"]["comments_shard_index"] for job in created_jobs] == [5, 6]
+    assert {job["config"]["comments_shard_count"] for job in created_jobs} == {6}
+    assert dispatch_calls == [{"run_id": run_id}]
+
+
+def test_repair_instagram_comments_scrape_run_target_gaps_retries_finished_stale_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created_jobs: list[dict[str, Any]] = []
+    run_id = "11111111-1111-1111-1111-111111111111"
+
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: {
+            "run_id": run_id,
+            "source_scope": "bravo",
+            "initiated_by": "test",
+            "config": {
+                "account": "thetraitorsus",
+                "source_scope": "bravo",
+                "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                "refresh_policy": "stale_or_missing",
+                "comments_shard_count": 2,
+                "target_source_ids_count": 3,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_all",
+        lambda *_args, **_kwargs: [
+            {
+                "status": "completed",
+                "config": {"target_source_ids": ["A"], "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE},
+            },
+            {
+                "status": "running",
+                "config": {"target_source_ids": ["B"], "stage": social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE},
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_instagram_social_account_comment_target_shortcodes",
+        lambda *_args, **_kwargs: ["A", "B", "C"],
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **kwargs: created_jobs.append(dict(kwargs)) or f"repair-{len(created_jobs)}",
+    )
+    monkeypatch.setattr(social_repo, "dispatch_due_social_jobs", lambda **_kwargs: None)
+    monkeypatch.setattr(social_repo, "uuid4", lambda: "repair-group-1")
+
+    payload = social_repo.repair_instagram_comments_scrape_run_target_gaps(
+        run_id=run_id,
+        max_retry_shard_size=10,
+    )
+
+    assert payload["created_job_ids"] == ["repair-1"]
+    assert payload["missing_target_source_ids_count"] == 2
+    assert created_jobs[0]["config"]["target_source_ids"] == ["A", "C"]
+    assert payload["assigned_target_source_ids_count"] == 1
 
 
 def test_get_social_account_catalog_run_progress_includes_discovery_partition_summary(
@@ -28745,6 +30515,35 @@ def test_finalize_run_status_fails_catalog_run_when_fetch_stage_completed_with_t
     assert set_status_calls == [(run_id, "failed", lock_conn)]
 
 
+def test_shared_account_catalog_scrape_complete_requires_expected_catalog_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(social_repo, "_shared_catalog_total_posts", lambda *_args, **_kwargs: 431)
+
+    assert (
+        social_repo._shared_account_catalog_scrape_complete(
+            run_config={
+                "pipeline_ingest_mode": social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+                "platforms": ["instagram"],
+                "accounts_override": ["thetraitorsus"],
+                "expected_total_posts_by_account": {"instagram:thetraitorsus": 436},
+            },
+            summary={
+                "stage_counts": {
+                    social_repo.SHARED_ACCOUNT_POSTS_STAGE: {
+                        "total": 1,
+                        "completed": 1,
+                        "failed": 0,
+                        "active": 0,
+                    }
+                }
+            },
+            conn=object(),
+        )
+        is False
+    )
+
+
 def test_finalize_run_status_starts_deferred_comments_followup_without_ui(monkeypatch: pytest.MonkeyPatch) -> None:
     from trr_backend.socials.control_plane import run_lifecycle
 
@@ -28843,6 +30642,88 @@ def test_finalize_run_status_starts_deferred_comments_followup_without_ui(monkey
         "state": "pending",
         "status": "queued",
         "source": "deferred_after_catalog",
+    }
+    assert merged_configs[-1][1] is lock_conn
+
+
+def test_finalize_run_status_reuses_active_deferred_comments_followup(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.control_plane import run_lifecycle
+
+    run_id = "66666666-6666-6666-6666-666666666667"
+    lock_conn = object()
+    summary = {
+        "total_jobs": 1,
+        "completed_jobs": 1,
+        "failed_jobs": 0,
+        "active_jobs": 0,
+        "stage_counts": {
+            social_repo.SHARED_ACCOUNT_POSTS_STAGE: {"total": 1, "completed": 1, "failed": 0, "active": 0},
+        },
+    }
+    merged_configs: list[dict[str, Any]] = []
+
+    @contextmanager
+    def _fake_advisory_lock(_lock_key: int, *, label: str, pool_name: str = "default"):
+        assert label == "run-finalize-lock"
+        assert pool_name == run_lifecycle.SOCIAL_CONTROL_POOL_NAME
+        yield lock_conn
+
+    def _fake_fetch_one(sql: str, params: list[Any] | None = None, *, conn: Any | None = None):  # noqa: ANN001
+        normalized = " ".join(sql.split()).lower()
+        assert conn is lock_conn
+        if "select status, config from social.scrape_runs" in normalized:
+            return {
+                "status": "running",
+                "config": {
+                    "pipeline_ingest_mode": social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+                    "source_scope": "bravo",
+                    "deferred_comments_followup": {
+                        "state": "pending",
+                        "platform": "instagram",
+                        "account_handle": "thetraitorsus",
+                        "source_scope": "bravo",
+                        "launch_group_id": "launch-group-1",
+                        "comments_enable_media_followups": True,
+                    },
+                },
+            }
+        raise AssertionError(f"Unexpected query: {normalized} params={params}")
+
+    monkeypatch.setattr(run_lifecycle.legacy.pg, "advisory_session_lock", _fake_advisory_lock)
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(run_lifecycle, "_update_run_summary", lambda *_args, **_kwargs: summary)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_run_job_status_breakdown",
+        lambda _run_id, *, conn=None: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0},
+    )
+    monkeypatch.setattr(run_lifecycle, "_set_run_status", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(social_repo, "_column_exists", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(social_repo, "_maybe_enqueue_shared_catalog_classify_jobs_after_fetch", lambda **_kwargs: 0)
+    monkeypatch.setattr(social_repo, "_shared_catalog_fetch_has_terminal_error", lambda *_args, **_kwargs: False)
+
+    def _raise_active_comments(*_args, **_kwargs):
+        raise social_repo.SocialIngestConflictError(
+            "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE",
+            "Comments run already active",
+            detail={"run_id": "comments-active-1", "status": "queued"},
+        )
+
+    monkeypatch.setattr(run_lifecycle.legacy, "start_social_account_comments_scrape", _raise_active_comments)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_merge_run_config",
+        lambda _run_id, *, config_updates, conn=None: merged_configs.append((config_updates, conn)) or config_updates,
+    )
+
+    social_repo._finalize_run_status(run_id, force_recompute=True)
+
+    assert merged_configs[-1][0]["deferred_comments_followup"]["comments_run_id"] == "comments-active-1"
+    assert merged_configs[-1][0]["attached_followups"]["comments"] == {
+        "run_id": "comments-active-1",
+        "state": "pending",
+        "status": "queued",
+        "source": "reused_run",
     }
     assert merged_configs[-1][1] is lock_conn
 
@@ -30826,28 +32707,25 @@ def test_cancel_social_account_catalog_run_validates_account_membership(monkeypa
     assert cancel_calls == [(run_id, "admin@example.com")]
 
 
-def test_request_cancel_social_account_catalog_run_marks_run_and_jobs_cancelling(
+def test_request_cancel_social_account_catalog_run_cancels_with_valid_run_and_job_statuses(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     run_id = "22222222-2222-2222-2222-222222222222"
-    fetch_one_calls: list[tuple[str, list[Any] | None]] = []
-    execute_calls: list[tuple[str, list[Any] | None]] = []
+    cancel_calls: list[dict[str, Any]] = []
 
     monkeypatch.setattr(
         social_repo,
         "_load_social_account_catalog_run_row",
         lambda **_kwargs: {"id": run_id},
     )
-
-    def _fake_fetch_one(sql: str, params: list[Any] | None = None):  # noqa: ANN001
-        fetch_one_calls.append((" ".join(sql.split()).lower(), params))
-        return {"id": run_id, "status": "cancelling"}
-
-    def _fake_execute(sql: str, params: list[Any] | None = None):  # noqa: ANN001
-        execute_calls.append((" ".join(sql.split()).lower(), params))
-
-    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
-    monkeypatch.setattr(social_repo.pg, "execute", _fake_execute)
+    monkeypatch.setattr(
+        social_repo,
+        "cancel_shared_run",
+        lambda *args, **kwargs: (
+            cancel_calls.append({"args": args, "kwargs": kwargs})
+            or {"run_id": run_id, "status": "cancelled", "cancelled_jobs": 1}
+        ),
+    )
     monkeypatch.setattr(social_repo, "_invalidate_queue_status_cache", lambda: None)
 
     payload = social_repo.request_cancel_social_account_catalog_run(
@@ -30858,10 +32736,10 @@ def test_request_cancel_social_account_catalog_run_marks_run_and_jobs_cancelling
     )
 
     assert payload["run_id"] == run_id
-    assert payload["status"] == "cancelling"
+    assert payload["status"] == "cancelled"
     assert payload["accepted"] is True
-    assert any("update social.scrape_runs" in sql for sql, _params in fetch_one_calls)
-    assert any("update social.scrape_jobs" in sql for sql, _params in execute_calls)
+    assert payload["cancelled_jobs"] == 1
+    assert cancel_calls == [{"args": (run_id,), "kwargs": {"cancelled_by": "admin@example.com"}}]
 
 
 def test_cancel_shared_run_invalidates_queue_status_cache(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31810,6 +33688,51 @@ def test_run_shared_account_posts_stage_raises_for_incomplete_single_runner_fall
     assert exc_info.value.runtime_metadata["retrieval_meta"]["expected_total_posts"] == 16_454
     assert exc_info.value.runtime_metadata["retrieval_meta"]["completion_missing_posts"] == 16_442
     assert exc_info.value.runtime_metadata["retrieval_meta"]["completion_tolerance_posts"] == 0
+
+
+def test_run_shared_account_posts_stage_fails_catalog_details_refresh_when_expected_total_exceeds_saved_posts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(social_repo, "_emit_job_progress", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        social_repo,
+        "_scrape_shared_posts_for_account",
+        lambda **_kwargs: (
+            [{"source_id": f"instagram-{index}"} for index in range(431)],
+            {
+                "source": "db_metrics_refresh",
+                "posts_checked": 431,
+                "total_posts": 436,
+                "persist_counters": {"posts_upserted": 431, "comments_upserted": 0},
+            },
+        ),
+    )
+
+    with pytest.raises(social_repo.SharedStageRuntimeError) as exc_info:
+        social_repo._run_shared_account_posts_stage(
+            run_id="33333333-3333-3333-3333-333333333333",
+            platform="instagram",
+            source_scope="bravo",
+            account_handle="thetraitorsus",
+            config={
+                "stage": social_repo.SHARED_ACCOUNT_POSTS_STAGE,
+                "platform": "instagram",
+                "source_scope": "bravo",
+                "account": "thetraitorsus",
+                "ingest_mode": "details_refresh",
+                "catalog_action_scope": "full_history",
+                "expected_total_posts": 436,
+                "pipeline_ingest_mode": social_repo.SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE,
+            },
+            job_id="44444444-4444-4444-4444-444444444444",
+        )
+
+    assert exc_info.value.error_code == "catalog_incomplete"
+    assert exc_info.value.retryable is True
+    meta = exc_info.value.runtime_metadata["retrieval_meta"]
+    assert meta["completion_failure_reason"] == "details_refresh_missing_catalog_posts"
+    assert meta["expected_total_posts"] == 436
+    assert meta["completion_missing_posts"] == 5
 
 
 def test_run_shared_account_posts_stage_tolerates_tiktok_empty_body_near_complete_fallback(

--- a/tests/scripts/test_instagram_comments_worker.py
+++ b/tests/scripts/test_instagram_comments_worker.py
@@ -6,8 +6,8 @@ import scripts.socials.instagram.comments_worker as comments_worker
 def test_comments_worker_sets_lane_and_forwards_args(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
-    def _fake_worker_main(argv):  # noqa: ANN001
-        captured["argv"] = list(argv)
+    def _fake_worker_main():
+        captured["argv"] = list(comments_worker.sys.argv)
         captured["lane"] = comments_worker.os.environ.get("SOCIAL_WORKER_LANE")
         captured["script"] = comments_worker.os.environ.get("SOCIAL_WORKER_SCRIPT")
         return 7

--- a/tests/scripts/test_social_worker.py
+++ b/tests/scripts/test_social_worker.py
@@ -750,8 +750,9 @@ def test_main_queue_once_returns_nonzero_when_claiming_jobs_fails(monkeypatch) -
     assert rc == 1
 
 
-def test_default_claim_batch_size_for_posts_is_single_claim() -> None:
+def test_default_claim_batch_size_for_sequential_stages_is_single_claim() -> None:
     assert worker._default_claim_batch_size_for_stage("posts") == 1
+    assert worker._default_claim_batch_size_for_stage("comments_scrapling") == 1
     assert worker._default_claim_batch_size_for_stage("comments") == 2
 
 

--- a/tests/socials/instagram/posts_scrapling/test_persistence.py
+++ b/tests/socials/instagram/posts_scrapling/test_persistence.py
@@ -56,8 +56,8 @@ def test_adapt_graph_node_carousel():
     }
     dto = _graph_node_to_post_dto(node, account_handle="testuser")
     assert dto.post_type == "carousel"
-    # display_url + child display_urls + child video_url (deduped)
-    assert len(dto.media_urls) >= 3
+    assert dto.thumbnail_url == "https://example.com/img.jpg"
+    assert dto.media_urls == ["https://example.com/1.jpg", "https://example.com/2.mp4"]
 
 
 def test_adapt_graph_node_image():
@@ -114,8 +114,7 @@ def test_adapt_xdt_media_dict_video():
     assert dto.caption == "Hello world #fyp"  # from caption.text dict
     assert dto.username == "bravotv"  # from user.username
     assert dto.pk == "3875927249152668787"  # prefers pk over composite id
-    assert "https://cdn.example.com/thumb1.jpg" in dto.media_urls
-    assert "https://cdn.example.com/video1.mp4" in dto.media_urls
+    assert dto.media_urls == ["https://cdn.example.com/video1.mp4"]
     assert dto.thumbnail_url == "https://cdn.example.com/thumb1.jpg"
 
 
@@ -143,7 +142,7 @@ def test_adapt_xdt_media_dict_carousel():
     }
     dto = _graph_node_to_post_dto(node, account_handle="u")
     assert dto.post_type == "carousel"  # media_type=8 → carousel
-    assert len(dto.media_urls) >= 3  # 2 image urls + 1 video url
+    assert dto.media_urls == ["https://cdn.example.com/c1.jpg", "https://cdn.example.com/c2.mp4"]
 
 
 def test_persist_instagram_posts_tracks_skip_reasons_and_accumulates_job_metadata(

--- a/tests/socials/instagram/test_instagram_normalizers.py
+++ b/tests/socials/instagram/test_instagram_normalizers.py
@@ -95,8 +95,8 @@ def test_normalize_xdt_post_extracts_rich_post_fields() -> None:
     assert post.tagged_users[0].tag_x == 0.25
     assert post.tagged_users[0].tag_y == 0.75
     assert post.collaborators[0].username == "iss"
-    assert "https://cdn.example.com/thumb-1080.jpg" in post.media_urls
-    assert "https://cdn.example.com/video.mp4" in post.media_urls
+    assert post.thumbnail_url == "https://cdn.example.com/thumb-1080.jpg"
+    assert post.media_urls == ["https://cdn.example.com/video.mp4"]
     assert post.width == 1080
     assert post.height == 1350
     assert post.location is not None
@@ -172,7 +172,8 @@ def test_normalize_media_info_shortcode_style_fixture_extracts_children() -> Non
     assert post.child_posts[0].media_type == "image"
     assert post.child_posts[0].alt_text == "Earth from space"
     assert post.child_posts[1].media_type == "video"
-    assert "https://cdn.example.com/child-2.mp4" in post.media_urls
+    assert post.thumbnail_url == "https://cdn.example.com/cover.jpg"
+    assert post.media_urls == ["https://cdn.example.com/child-1.jpg", "https://cdn.example.com/child-2.mp4"]
     assert post.tagged_users[0].username == "earthobservatory"
     assert post.tagged_users[0].tag_position_source == "rest_usertags.position_object"
 

--- a/tests/socials/test_comment_scraper_fixes.py
+++ b/tests/socials/test_comment_scraper_fixes.py
@@ -2770,15 +2770,21 @@ def test_instagram_parse_comment_supports_actor_style_payload_with_nested_replie
         "id": "17949788698583607",
         "text": "Imagine scrolling to find the end of these comments! 😂",
         "ownerUsername": "gabriel2005120",
+        "ownerFullName": "Gabriel Viewer",
         "ownerProfilePicUrl": "https://scontent.example/profile.jpg",
+        "ownerProfilePicUrlHd": "https://scontent.example/profile_pic_url_hd.jpg",
         "timestamp": "2021-11-19T13:54:13.000Z",
         "likesCount": 12,
         "repliesCount": 1,
+        "media_urls": ["https://scontent.example/comment.gif"],
         "replies": [
             {
                 "id": "17891234567890123",
                 "text": "@gabriel2005120 right? It never ends 😅",
                 "ownerUsername": "maria_adventures",
+                "ownerFullName": "Maria Adventures",
+                "ownerProfilePicUrl": "https://scontent.example/reply-profile.jpg",
+                "ownerProfilePicUrlHd": "https://scontent.example/reply-profile-hd.jpg",
                 "timestamp": "2021-11-19T14:02:45.000Z",
                 "likesCount": 3,
                 "repliesCount": 0,
@@ -2796,14 +2802,103 @@ def test_instagram_parse_comment_supports_actor_style_payload_with_nested_replie
     assert parsed.username == "gabriel2005120"
     assert parsed.likes == 12
     assert parsed.reply_count == 1
-    assert parsed.owner_profile_pic_url == "https://scontent.example/profile.jpg"
+    assert parsed.reply_depth == 0
+    assert parsed.media_urls == ["https://scontent.example/comment.gif"]
+    assert parsed.owner_full_name == "Gabriel Viewer"
+    assert parsed.owner_profile_pic_url == "https://scontent.example/profile_pic_url_hd.jpg"
+    assert parsed.owner_profile_pic_url_hd == "https://scontent.example/profile_pic_url_hd.jpg"
     assert len(parsed.replies) == 1
     reply = parsed.replies[0]
     assert reply.is_reply is True
     assert reply.parent_comment_id == parsed.comment_id
+    assert reply.reply_depth == 1
     assert reply.comment_id == "17891234567890123"
     assert reply.username == "maria_adventures"
+    assert reply.owner_full_name == "Maria Adventures"
+    assert reply.owner_profile_pic_url == "https://scontent.example/reply-profile-hd.jpg"
+    assert reply.owner_profile_pic_url_hd == "https://scontent.example/reply-profile-hd.jpg"
     assert reply.likes == 3
+
+
+def test_instagram_parse_comment_synthetic_comment_media_payload_extracts_urls() -> None:
+    scraper = InstagramScraper(cookies={})
+    comment_payload = {
+        # Synthetic fixture: representative comment-media shapes seen across actor/API payload families.
+        "id": "17900000000000001",
+        "text": "media comment",
+        "owner": {
+            "id": "1001",
+            "username": "media_owner",
+            "full_name": "Media Owner",
+            "profilePicUrl": "https://scontent.example/s96x96/avatar-source.jpg",
+            "hd_profile_pic_url_info": {"url": "https://scontent.example/profile_pic_hd_1080.jpg"},
+        },
+        "timestamp": 1735689600,
+        "likes": "7",
+        "reply_count": 1,
+        "commentMedia": {
+            "image_versions2": {
+                "candidates": [
+                    {"url": "https://scontent.example/comment-image-1080.jpg"},
+                    {"url": "https://scontent.example/comment-image-640.jpg"},
+                ]
+            }
+        },
+        "attachments": [
+            {"videoUrl": "https://scontent.example/comment-video.mp4"},
+            {"mediaUrl": "https://scontent.example/comment-sticker.webp"},
+        ],
+        "hostedMediaUrls": ["https://cdn.example/comment-image-1080.jpg"],
+        "child_comments": [
+            {
+                "pk": "17900000000000002",
+                "text": "nested reply",
+                "user": {
+                    "pk": "2002",
+                    "username": "reply_owner",
+                    "fullName": "Reply Owner",
+                    "profilePicUrlHd": "https://scontent.example/reply-hd.jpg",
+                },
+                "created_at": 1735689700,
+                "comment_like_count": 2,
+            }
+        ],
+    }
+
+    parsed = scraper._parse_comment(  # noqa: SLF001
+        comment_payload,
+        "COMMENTMEDIA",
+        "https://www.instagram.com/p/COMMENTMEDIA/",
+    )
+
+    assert parsed.comment_id == "17900000000000001"
+    assert parsed.username == "media_owner"
+    assert parsed.user_id == "1001"
+    assert parsed.owner_full_name == "Media Owner"
+    assert parsed.owner_profile_pic_url == "https://scontent.example/profile_pic_hd_1080.jpg"
+    assert parsed.owner_profile_pic_url_hd == "https://scontent.example/profile_pic_hd_1080.jpg"
+    assert parsed.created_at == 1735689600
+    assert parsed.likes == 7
+    assert parsed.reply_count == 1
+    assert parsed.reply_depth == 0
+    assert parsed.media_urls == [
+        "https://scontent.example/comment-image-1080.jpg",
+        "https://scontent.example/comment-video.mp4",
+        "https://scontent.example/comment-sticker.webp",
+    ]
+    assert parsed.hosted_media_urls == ["https://cdn.example/comment-image-1080.jpg"]
+
+    reply = parsed.replies[0]
+    assert reply.is_reply is True
+    assert reply.parent_comment_id == parsed.comment_id
+    assert reply.reply_depth == 1
+    assert reply.username == "reply_owner"
+    assert reply.user_id == "2002"
+    assert reply.owner_full_name == "Reply Owner"
+    assert reply.owner_profile_pic_url == "https://scontent.example/reply-hd.jpg"
+    assert reply.owner_profile_pic_url_hd == "https://scontent.example/reply-hd.jpg"
+    assert reply.created_at == 1735689700
+    assert reply.likes == 2
 
 
 def test_instagram_scrape_graphql_backfills_owner_avatar_from_profile_payload(

--- a/tests/socials/test_instagram_auth_resolver.py
+++ b/tests/socials/test_instagram_auth_resolver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import fcntl
 import multiprocessing as mp
 import time
@@ -34,6 +35,10 @@ def _clear_auth_resolver_state(monkeypatch: pytest.MonkeyPatch) -> None:
         "INSTAGRAM_COOKIES_FILE",
         "SOCIAL_INSTAGRAM_SESSION_ACCOUNT_ID",
         "SOCIAL_INSTAGRAM_COOKIE_VALIDATION_USERNAME",
+        "SOCIAL_AUTH_INSTAGRAM_USERNAME",
+        "SOCIAL_AUTH_INSTAGRAM_PASSWORD",
+        "INSTAGRAM_USERNAME",
+        "INSTAGRAM_PASSWORD",
         "SOCIAL_BROWSER_SESSION_DIR",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -93,6 +98,124 @@ def test_resolve_instagram_auth_session_normalizes_invalid_session_key(
     assert auth_session.caller_context == "comment-avatar-refresh"
     assert auth_session.cookies["sessionid"] == "browser-session"
     assert auth_session.source in {"browser_session", "browser_session_promoted"}
+
+
+def test_resolve_instagram_auth_session_uses_login_account_for_target_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("SOCIAL_BROWSER_SESSION_DIR", str(tmp_path))
+    monkeypatch.setenv("SOCIAL_AUTH_INSTAGRAM_USERNAME", "thommycodex")
+
+    manager = AccountBrowserSessionManager(platform="instagram", cookie_domains=(".instagram.com",))
+    manager.import_bootstrapped_session(
+        "thommycodex",
+        {"sessionid": "browser-session", "csrftoken": "browser-csrf", "ds_user_id": "456"},
+    )
+
+    auth_session = resolve_instagram_auth_session(
+        browser_account_id="thetraitorsus",
+        require_validation=False,
+        browser_session_manager=manager,
+    )
+
+    assert auth_session.session_account_id == "thommycodex"
+    assert auth_session.caller_context == "thetraitorsus"
+    assert auth_session.cookies["sessionid"] == "browser-session"
+    assert auth_session.source in {"browser_session", "browser_session_promoted"}
+
+
+def test_resolve_instagram_auth_session_validates_against_target_handle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("SOCIAL_BROWSER_SESSION_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COOKIES_FILE", str(tmp_path / "instagram-cookies.json"))
+    monkeypatch.setenv("SOCIAL_AUTH_INSTAGRAM_USERNAME", "thommycodex")
+
+    manager = AccountBrowserSessionManager(platform="instagram", cookie_domains=(".instagram.com",))
+    manager.import_bootstrapped_session(
+        "thommycodex",
+        {"sessionid": "browser-session", "csrftoken": "browser-csrf", "ds_user_id": "456"},
+    )
+
+    captured: dict[str, object] = {}
+
+    class _FakeInstagramScraper:
+        def __init__(self, *, cookies: dict[str, str] | None = None, browser_account_id: str | None = None) -> None:
+            captured["browser_account_id"] = browser_account_id
+            captured["cookies"] = dict(cookies or {})
+            self.last_retrieval_meta = {}
+
+        def fetch_posts_graphql(self, username: str, **_kwargs: object) -> dict[str, object]:
+            captured["validation_username"] = username
+            return {
+                "data": {
+                    "xdt_api__v1__feed__user_timeline_graphql_connection": {
+                        "edges": [{"node": {"id": "post"}}],
+                    },
+                },
+            }
+
+    monkeypatch.setattr("trr_backend.socials.instagram.scraper.InstagramScraper", _FakeInstagramScraper)
+
+    auth_session = resolve_instagram_auth_session(
+        browser_account_id="thetraitorsus",
+        caller_context="comments_scrapling:gap:thetraitorsus",
+        require_validation=True,
+        browser_session_manager=manager,
+    )
+
+    assert auth_session.session_account_id == "thommycodex"
+    assert auth_session.caller_context == "comments_scrapling:gap:thetraitorsus"
+    assert auth_session.validated is True
+    assert captured["browser_account_id"] == "thommycodex"
+    assert captured["validation_username"] == "thetraitorsus"
+
+
+def test_refresh_interactively_skips_sync_playwright_inside_async_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from trr_backend.socials.instagram import auth_resolver
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_INTERACTIVE_LOGIN", "1")
+
+    def _unexpected_interactive_login(**_kwargs: object) -> dict[str, str]:
+        raise AssertionError("interactive login should not run inside async worker loop")
+
+    monkeypatch.setattr(auth_resolver, "interactive_chrome_login", _unexpected_interactive_login)
+
+    async def _probe() -> tuple[dict[str, str], str | None]:
+        return auth_resolver._refresh_interactively(
+            session_account_id="thommycodex",
+            cookie_file_path=tmp_path / "cookies.json",
+        )
+
+    assert asyncio.run(_probe()) == ({}, None)
+
+
+def test_credential_refresh_skips_sync_playwright_inside_async_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from trr_backend.socials.instagram import auth_resolver
+
+    monkeypatch.setenv("SOCIAL_AUTH_INSTAGRAM_USERNAME", "thommycodex")
+    monkeypatch.setenv("SOCIAL_AUTH_INSTAGRAM_PASSWORD", "secret")
+
+    def _unexpected_refresh(**_kwargs: object) -> dict[str, str]:
+        raise AssertionError("credential refresh should not run inside async worker loop")
+
+    monkeypatch.setattr(auth_resolver, "refresh_instagram_cookies", _unexpected_refresh)
+
+    async def _probe() -> tuple[dict[str, str], str | None]:
+        return auth_resolver._refresh_with_credentials(
+            session_account_id="thommycodex",
+            cookie_file_path=tmp_path / "cookies.json",
+        )
+
+    assert asyncio.run(_probe()) == ({}, None)
 
 
 def test_resolve_instagram_auth_session_promotes_browser_session_with_strict_file_permissions(

--- a/tests/socials/test_instagram_comments_scrapling.py
+++ b/tests/socials/test_instagram_comments_scrapling.py
@@ -114,6 +114,24 @@ def test_select_comments_proxy_adds_decodo_sticky_session_and_duration(monkeypat
     assert config.fingerprint == "gate.decodo.com:7000:decodo"
 
 
+def test_select_comments_proxy_shard_sessions_do_not_force_sticky_affinity(monkeypatch) -> None:
+    monkeypatch.delenv("SOCIAL_INSTAGRAM_COMMENTS_PROXY_URLS", raising=False)
+    monkeypatch.delenv("SOCIAL_INSTAGRAM_COMMENTS_USE_STICKY_PROXY", raising=False)
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROXY_PROVIDER", "decodo")
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROXY_SHARD_SESSIONS", "1")
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROXY_SESSION_TTL_SECONDS", "600")
+    monkeypatch.setenv("DECODO_USERNAME", "user-username")
+    monkeypatch.setenv("DECODO_PASSWORD", "secret")
+    monkeypatch.setenv("DECODO_GATEWAY", "gate.decodo.com:7000")
+
+    config = select_comments_proxy(session_key="thetraitorsus:comments:3")
+
+    assert config is not None
+    assert isinstance(config.browser_proxy, dict)
+    assert config.browser_proxy["username"] == "user-username"
+    assert config.session_mode == "rotating"
+
+
 def test_select_comments_proxy_ignores_sticky_env_for_explicit_proxy_urls(monkeypatch) -> None:
     monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROXY_URLS", "http://user:pass@proxy-one:8000")
     monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_USE_STICKY_PROXY", "true")

--- a/tests/socials/test_instagram_comments_scrapling_contract.py
+++ b/tests/socials/test_instagram_comments_scrapling_contract.py
@@ -47,10 +47,12 @@ def test_stealth_session_contains_all_kwargs_we_use() -> None:
         "headless",
         "network_idle",
         "load_dom",
+        "page_action",
         "proxy_rotator",
         "retries",
         "retry_delay",
         "timeout",
+        "wait",
         # capture_xhr removed - Scrapling 0.4.x types it as `str | None`.
         # (XHR URL pattern), not bool. We don't need XHR capture for
         # comments so we dropped it from the _fetch call entirely.

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -1,14 +1,11 @@
-"""Retry/backoff, cookie bridge, redirect handling, and partial-progress tests.
-
-Mocks target `_fetch_api` (httpx path) for JSON tests, not the old `_fetch`
-(browser path). The browser path is only used by warmup().
-"""
+"""Retry/backoff, cookie bridge, redirect handling, and partial-progress tests."""
 
 from __future__ import annotations
 
 import asyncio
 import json
 from contextlib import nullcontext
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,6 +17,7 @@ from trr_backend.socials.instagram.comments_scrapling.fetcher import (
     InstagramCommentsFetchResult,
     InstagramCommentsScraplingFetcher,
     InstagramCommentsWarmupError,
+    _extract_rendered_permalink_comments,
 )
 from trr_backend.socials.instagram.scraper import InstagramComment
 
@@ -49,6 +47,132 @@ def _build_fetcher() -> InstagramCommentsScraplingFetcher:
         # Pre-build httpx client so tests don't need warmup.
         asyncio.run(fetcher._rebuild_http_client())
         return fetcher
+
+
+def test_extract_rendered_hidden_comment_from_post_dom() -> None:
+    html = """
+    <div>
+      <a href="/thriller_book_junkie/">profile</a>
+      <a href="/p/DXpWUKECX3t/c/18109809979882642/" role="link">
+        <time datetime="2026-04-27T21:16:21.000Z">3d</time>
+      </a>
+      <span dir="auto">
+        Rob was the best traitor ever.
+        I don't think anyone will ever be able to play this game better than he did
+      </span>
+      <span dir="auto">2 likes</span>
+      <span dir="auto">Reply</span>
+    </div>
+    """
+
+    comments = _extract_rendered_permalink_comments(
+        html,
+        shortcode="DXpWUKECX3t",
+        post_url="https://www.instagram.com/p/DXpWUKECX3t/",
+    )
+
+    assert len(comments) == 1
+    assert comments[0].comment_id == "18109809979882642"
+    assert comments[0].username == "thriller_book_junkie"
+    assert comments[0].text == (
+        "Rob was the best traitor ever. I don't think anyone will ever be able to play this game better than he did"
+    )
+    assert comments[0].likes == 2
+    assert comments[0].created_at == int(datetime(2026, 4, 27, 21, 16, 21, tzinfo=UTC).timestamp())
+
+
+def test_fetch_comments_reveals_hidden_comments_when_api_is_short(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    visible_comment = InstagramComment(
+        comment_id="visible",
+        text="visible",
+        username="alpha",
+        user_id="1",
+        created_at=1,
+        date_time="1970-01-01 00:00:01",
+        likes=0,
+        is_reply=False,
+        parent_comment_id=None,
+        reply_count=0,
+    )
+    hidden_comment = InstagramComment(
+        comment_id="18109809979882642",
+        text="Rob was the best traitor ever.",
+        username="thriller_book_junkie",
+        user_id="",
+        created_at=1,
+        date_time="1970-01-01 00:00:01",
+        likes=2,
+        is_reply=False,
+        parent_comment_id=None,
+        reply_count=0,
+    )
+    fetcher._parser._parse_comment = MagicMock(return_value=visible_comment)
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {"comments": [{"id": "visible"}], "has_more_comments": False},
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[hidden_comment])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "DXpWUKECX3t",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=2,
+        )
+    )
+
+    assert [comment.comment_id for comment in result.comments] == ["visible", "18109809979882642"]
+    assert result.fetch_failed is False
+    assert result.reported_comment_count == 2
+    assert fetcher._fetch_rendered_comments_after_revealing_hidden.await_count == 1
+    assert fetcher.runtime_metadata["hidden_comments"]["merged_comments"] == 1
+
+
+def test_fetch_comments_skips_hidden_reveal_when_api_matches_reported_count(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        return_value=InstagramComment(
+            comment_id="visible",
+            text="visible",
+            username="alpha",
+            user_id="1",
+            created_at=1,
+            date_time="1970-01-01 00:00:01",
+            likes=0,
+            is_reply=False,
+            parent_comment_id=None,
+            reply_count=0,
+        )
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {"comments": [{"id": "visible"}], "has_more_comments": False},
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "DXpWUKECX3t",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=1,
+        )
+    )
+
+    assert len(result.comments) == 1
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_not_awaited()
 
 
 def test_rebuild_http_client_closes_previous_client(monkeypatch) -> None:
@@ -126,6 +250,240 @@ def test_fetch_comments_preserves_reply_failure_across_later_pages(monkeypatch) 
     assert result.fetch_reason == "reply_timeout"
 
 
+def test_fetch_comments_stops_reply_requests_after_retryable_reply_failure(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            InstagramComment(
+                comment_id="c1",
+                text="one",
+                username="alpha",
+                user_id="1",
+                created_at=1,
+                date_time="1970-01-01T00:00:01+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=1,
+            ),
+            InstagramComment(
+                comment_id="c2",
+                text="two",
+                username="beta",
+                user_id="2",
+                created_at=2,
+                date_time="1970-01-01T00:00:02+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=1,
+            ),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c1"}, {"id": "c2"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    fetcher._fetch_comment_replies = AsyncMock(
+        return_value=InstagramCommentsFetchResult(
+            comments=[],
+            fetch_failed=True,
+            auth_failed=False,
+            fetch_reason="http_429",
+            request_count=1,
+            retryable=True,
+        )
+    )
+
+    result = asyncio.run(fetcher.fetch_comments_for_shortcode("ABC123", max_comments=10, fetch_replies=True))
+
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "http_429"
+    assert len(result.comments) == 2
+    assert fetcher._fetch_comment_replies.await_count == 1
+    assert fetcher.runtime_metadata["retry_reason_counts"]["reply_fetch_circuit_open"] == 1
+
+
+def test_fetch_comments_marks_repeated_cursor_retryable(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            InstagramComment(
+                comment_id="c1",
+                text="one",
+                username="alpha",
+                user_id="1",
+                created_at=1,
+                date_time="1970-01-01T00:00:01+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+            InstagramComment(
+                comment_id="c2",
+                text="two",
+                username="beta",
+                user_id="2",
+                created_at=2,
+                date_time="1970-01-01T00:00:02+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c2"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+
+    result = asyncio.run(fetcher.fetch_comments_for_shortcode("ABC123", max_comments=10, fetch_replies=True))
+
+    assert len(result.comments) == 2
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "pagination_repeated_cursor"
+
+
+def test_fetch_comment_replies_marks_page_cap_retryable(monkeypatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES", "1")
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        return_value=InstagramComment(
+            comment_id="r1",
+            text="reply",
+            username="alpha",
+            user_id="1",
+            created_at=1,
+            date_time="1970-01-01T00:00:01+00:00",
+            likes=0,
+            is_reply=True,
+            parent_comment_id="c1",
+            reply_count=0,
+        )
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "child_comments": [{"id": "r1"}],
+                "has_more_tail_child_comments": True,
+                "next_min_child_cursor": "reply-cursor-2",
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    result = asyncio.run(
+        fetcher._fetch_comment_replies(
+            media_id="media-1",
+            comment_id="c1",
+            shortcode="ABC123",
+            post_url="https://www.instagram.com/p/ABC123/",
+        )
+    )
+
+    assert len(result.comments) == 1
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "pagination_page_cap_reached"
+    assert result.reply_checkpoints == [
+        {
+            "platform": "instagram",
+            "target_shortcode": "ABC123",
+            "source_id": "ABC123",
+            "media_id": "media-1",
+            "parent_comment_id": "c1",
+            "stop_reason": "pagination_page_cap_reached",
+            "attempt_count": 0,
+            "last_error_code": "pagination_page_cap_reached",
+            "next_reply_cursor": "reply-cursor-2",
+            "saved_reply_count_observed": 1,
+            "pages_seen": 1,
+            "retryable": True,
+            "updated_at": result.reply_checkpoints[0]["updated_at"],
+        }
+    ]
+    checkpoint_metadata = fetcher.runtime_metadata["reply_checkpoint_metadata"]
+    assert checkpoint_metadata["total_count"] == 1
+    assert checkpoint_metadata["dropped_count"] == 0
+    assert checkpoint_metadata["truncated"] is False
+    assert checkpoint_metadata["items"] == result.reply_checkpoints
+
+
+def test_reply_checkpoint_metadata_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_REPLY_CHECKPOINT_MAX_ITEMS", "2")
+    fetcher = _build_fetcher()
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": None,
+            "failed": True,
+            "auth_failed": False,
+            "reason": "http_429",
+            "retryable": True,
+            "attempt_count": 4,
+        }
+    )
+
+    for comment_id in ("c1", "c2", "c3"):
+        result = asyncio.run(
+            fetcher._fetch_comment_replies(
+                media_id="media-1",
+                comment_id=comment_id,
+                shortcode="ABC123",
+                post_url="https://www.instagram.com/p/ABC123/",
+                expected_reply_count=5,
+            )
+        )
+        assert result.fetch_failed is True
+        assert result.retryable is True
+        assert result.reply_checkpoints[0]["parent_comment_id"] == comment_id
+        assert result.reply_checkpoints[0]["expected_reply_count"] == 5
+        assert result.reply_checkpoints[0]["attempt_count"] == 4
+
+    checkpoint_metadata = fetcher.runtime_metadata["reply_checkpoint_metadata"]
+    assert checkpoint_metadata["total_count"] == 3
+    assert checkpoint_metadata["max_items"] == 2
+    assert checkpoint_metadata["dropped_count"] == 1
+    assert checkpoint_metadata["truncated"] is True
+    assert [item["parent_comment_id"] for item in checkpoint_metadata["items"]] == ["c2", "c3"]
+
+
 def _mock_httpx_response(
     *,
     status_code: int = 200,
@@ -174,6 +532,40 @@ def test_fetch_retries_on_429_then_succeeds() -> None:
     assert result["retryable"] is False
 
 
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2590)",
+        "SSL connection has been closed unexpectedly\n",
+    ],
+)
+def test_fetch_retries_raw_ssl_oserror_then_succeeds(error_message: str) -> None:
+    """TLS/proxy errors can escape httpx as raw OSError; keep them in the
+    bounded request retry path instead of failing the shard immediately."""
+    fetcher = _build_fetcher()
+    fetcher._fetch_api = AsyncMock(
+        side_effect=[
+            OSError(error_message),
+            _mock_httpx_response(status_code=200, json_data={"status": "ok"}),
+        ]
+    )
+    fetcher._rebuild_http_client = AsyncMock()
+
+    with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.asyncio.sleep", AsyncMock()):
+        result = asyncio.run(
+            fetcher._fetch_json_response(
+                "https://www.instagram.com/api/v1/media/1/comments/",
+                referer="https://www.instagram.com/p/ABC/",
+            )
+        )
+
+    assert fetcher._fetch_api.await_count == 2
+    assert result["failed"] is False
+    assert result["retryable"] is False
+    assert fetcher.runtime_metadata["retry_reason_counts"]["transport_error"] == 1
+    fetcher._rebuild_http_client.assert_awaited_once()
+
+
 def test_fetch_gives_up_after_max_retries_with_retryable_true() -> None:
     """Exhausting retries surfaces retryable=True for queue requeue."""
     fetcher = _build_fetcher()
@@ -195,6 +587,49 @@ def test_fetch_gives_up_after_max_retries_with_retryable_true() -> None:
         InstagramCommentsScraplingFetcher._MAX_TRANSIENT_RETRIES + 1
     )
     assert fetcher._fetch_api.await_count == InstagramCommentsScraplingFetcher._MAX_TRANSIENT_RETRIES + 1
+
+
+def test_fetch_retry_count_can_be_raised_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_TRANSIENT_RETRIES", "7")
+    fetcher = _build_fetcher()
+    responses = [_mock_httpx_response(status_code=429, headers={"retry-after": "0"}) for _ in range(10)]
+    fetcher._fetch_api = AsyncMock(side_effect=responses)
+
+    with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.asyncio.sleep", AsyncMock()):
+        result = asyncio.run(
+            fetcher._fetch_json_response(
+                "https://www.instagram.com/api/v1/media/1/comments/",
+                referer="https://www.instagram.com/p/ABC/",
+            )
+        )
+
+    assert result["failed"] is True
+    assert result["retryable"] is True
+    assert fetcher.runtime_metadata["max_transient_retries"] == 7
+    assert fetcher._fetch_api.await_count == 8
+
+
+def test_reply_fetch_retry_count_can_stay_lower_than_top_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_TRANSIENT_RETRIES", "9")
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_REPLY_TRANSIENT_RETRIES", "2")
+    fetcher = _build_fetcher()
+    responses = [_mock_httpx_response(status_code=429, headers={"retry-after": "0"}) for _ in range(10)]
+    fetcher._fetch_api = AsyncMock(side_effect=responses)
+
+    with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.asyncio.sleep", AsyncMock()):
+        result = asyncio.run(
+            fetcher._fetch_json_response(
+                "https://www.instagram.com/api/v1/media/1/comments/2/child_comments/",
+                referer="https://www.instagram.com/p/ABC/",
+                max_retries=fetcher._reply_max_transient_retries,
+            )
+        )
+
+    assert result["failed"] is True
+    assert result["retryable"] is True
+    assert fetcher.runtime_metadata["max_transient_retries"] == 9
+    assert fetcher.runtime_metadata["reply_max_transient_retries"] == 2
+    assert fetcher._fetch_api.await_count == 3
 
 
 def test_fetch_4xx_validation_is_not_retryable() -> None:
@@ -421,7 +856,8 @@ def test_3xx_redirect_to_homepage_rewarms_permalink_and_retries_once() -> None:
     assert fetcher.runtime_metadata["retry_reason_counts"]["homepage_redirect_recovery"] == 1
 
 
-def test_3xx_redirect_to_homepage_marks_auth_failed_after_recovery_retry() -> None:
+def test_3xx_redirect_to_homepage_marks_auth_failed_after_recovery_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK", "0")
     fetcher = _build_fetcher()
     fetcher._fetch_api = AsyncMock(
         side_effect=[
@@ -442,6 +878,64 @@ def test_3xx_redirect_to_homepage_marks_auth_failed_after_recovery_retry() -> No
     assert result["failed"] is True
     assert result["auth_failed"] is True
     assert result["reason"] == "redirect_to_homepage"
+
+
+def test_3xx_redirect_to_homepage_uses_browser_api_fallback_after_recovery_retry() -> None:
+    fetcher = _build_fetcher()
+    fetcher._fetch_api = AsyncMock(
+        side_effect=[
+            _mock_httpx_response(status_code=302, location="/"),
+            _mock_httpx_response(status_code=302, location="/"),
+        ]
+    )
+    fetcher._fetch_page = AsyncMock(return_value=_mock_httpx_response(status_code=200))
+    fetcher._rebuild_http_client = AsyncMock()
+    fetcher._fetch_api_with_browser = AsyncMock(
+        return_value=_mock_httpx_response(status_code=200, json_data=_fixture_json("comments_success.json"))
+    )
+
+    result = asyncio.run(
+        fetcher._fetch_json_response(
+            "https://www.instagram.com/api/v1/media/1/comments/",
+            referer="https://www.instagram.com/p/DXpWUKECX3t/",
+            params={"can_support_threading": "true", "permalink_enabled": "false"},
+        )
+    )
+
+    assert result["failed"] is False
+    assert result["payload"]["status"] == "ok"
+    fetcher._fetch_api_with_browser.assert_awaited_once_with(
+        "https://www.instagram.com/api/v1/media/1/comments/",
+        referer="https://www.instagram.com/p/DXpWUKECX3t/",
+        params={"can_support_threading": "true", "permalink_enabled": "false"},
+    )
+    assert fetcher.runtime_metadata["retry_reason_counts"]["browser_api_fallback"] == 1
+
+
+def test_3xx_redirect_to_homepage_can_disable_browser_api_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK", "0")
+    fetcher = _build_fetcher()
+    fetcher._fetch_api = AsyncMock(
+        side_effect=[
+            _mock_httpx_response(status_code=302, location="/"),
+            _mock_httpx_response(status_code=302, location="/"),
+        ]
+    )
+    fetcher._fetch_page = AsyncMock(return_value=_mock_httpx_response(status_code=200))
+    fetcher._rebuild_http_client = AsyncMock()
+    fetcher._fetch_api_with_browser = AsyncMock()
+
+    result = asyncio.run(
+        fetcher._fetch_json_response(
+            "https://www.instagram.com/api/v1/media/1/comments/",
+            referer="https://www.instagram.com/p/DXpWUKECX3t/",
+        )
+    )
+
+    assert result["failed"] is True
+    assert result["auth_failed"] is True
+    assert result["reason"] == "redirect_to_homepage"
+    fetcher._fetch_api_with_browser.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -537,6 +1031,36 @@ def test_warmup_raises_when_no_cookies_are_bridged() -> None:
     fetcher._rebuild_http_client.assert_not_awaited()
 
 
+def test_warmup_transport_ssl_error_is_retryable() -> None:
+    fetcher = _build_fetcher()
+    fetcher._fetch_page = AsyncMock(side_effect=OSError("[SSL: WRONG_VERSION_NUMBER] wrong version number"))
+    fetcher._rebuild_http_client = AsyncMock()
+
+    with pytest.raises(InstagramCommentsWarmupError) as exc_info:
+        asyncio.run(fetcher.warmup())
+
+    assert exc_info.value.error_code == "instagram_comments_warmup_transport_error"
+    assert exc_info.value.retryable is True
+    assert fetcher.runtime_metadata["retry_reason_counts"]["warmup_transport_error"] == 1
+    fetcher._rebuild_http_client.assert_not_awaited()
+
+
+def test_warmup_transport_http_response_code_failure_is_retryable() -> None:
+    fetcher = _build_fetcher()
+    fetcher._fetch_page = AsyncMock(
+        side_effect=RuntimeError("Page.goto: net::ERR_HTTP_RESPONSE_CODE_FAILURE at https://www.instagram.com/")
+    )
+    fetcher._rebuild_http_client = AsyncMock()
+
+    with pytest.raises(InstagramCommentsWarmupError) as exc_info:
+        asyncio.run(fetcher.warmup())
+
+    assert exc_info.value.error_code == "instagram_comments_warmup_transport_error"
+    assert exc_info.value.retryable is True
+    assert fetcher.runtime_metadata["retry_reason_counts"]["warmup_transport_error"] == 1
+    fetcher._rebuild_http_client.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # Proxy identity test
 # ---------------------------------------------------------------------------
@@ -583,6 +1107,90 @@ def test_select_comments_proxy_decodo_sticky_session(monkeypatch) -> None:
     assert "sessionduration-10" in result.api_proxy_url
 
 
+def test_job_runner_uses_shard_proxy_session_only_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    selected_session_keys: list[str | None] = []
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": 1}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        jr,
+        "persist_instagram_comments_for_post",
+        lambda **_kwargs: PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        ),
+    )
+    monkeypatch.setattr(
+        jr,
+        "select_comments_proxy",
+        lambda *, session_key=None: selected_session_keys.append(session_key),
+    )
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: _fake_comments_session())
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    base_job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "comments_shard_index": 2,
+            "comments_shard_count": 4,
+            "comments_shard_target_count": 1,
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "completed"},
+    ):
+        jr.run_instagram_comments_scrapling_job(base_job, worker_id="test-worker")
+        disabled_string_job = {
+            **base_job,
+            "id": "job-2",
+            "config": {**base_job["config"], "comments_proxy_shard_sessions": "false"},
+        }
+        jr.run_instagram_comments_scrapling_job(disabled_string_job, worker_id="test-worker")
+        shard_session_job = {
+            **base_job,
+            "id": "job-3",
+            "config": {**base_job["config"], "comments_proxy_shard_sessions": True},
+        }
+        jr.run_instagram_comments_scrapling_job(shard_session_job, worker_id="test-worker")
+
+    assert selected_session_keys == ["testaccount", "testaccount", "bravotv:comments:2"]
+
+
 # ---------------------------------------------------------------------------
 # Partial-progress persistence (job_runner integration)
 # ---------------------------------------------------------------------------
@@ -593,8 +1201,212 @@ def _fake_comments_session() -> MagicMock:
     fake_session.cookies = []
     fake_session.auth_session.cookies = {}
     fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.auth_session.source = "browser_session"
+    fake_session.auth_session.browser_account_id = "testaccount"
+    fake_session.auth_session.session_account_id = "testaccount"
+    fake_session.auth_session.validation_category = "validated"
+    fake_session.auth_session.validation_reason = None
+    fake_session.auth_session.validated = True
+    fake_session.auth_session.stale_ok = False
+    fake_session.auth_session.resolver_version = 2
     fake_session.browser_account_id = "testaccount"
     return fake_session
+
+
+def test_job_runner_aborts_queued_sibling_shards_after_run_level_auth_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    finish_calls: list[dict[str, Any]] = []
+
+    class _FakeRepo:
+        @staticmethod
+        def _finish_job(job_id: str, **kwargs: Any) -> None:
+            finish_calls.append({"job_id": job_id, **kwargs})
+
+    monkeypatch.setattr(
+        jr.pg,
+        "fetch_all",
+        lambda *_args, **_kwargs: [
+            {"id": "sibling-1", "items_found": 0},
+            {"id": "sibling-2", "items_found": 3},
+        ],
+    )
+
+    aborted = jr._abort_queued_sibling_shards_after_run_fatal_error(
+        repo=_FakeRepo,
+        run_id="11111111-1111-1111-1111-111111111111",
+        failed_job_id="22222222-2222-2222-2222-222222222222",
+        stage="comments_scrapling",
+        account_handle="thetraitorsus",
+        mode="profile",
+        source_scope="bravo",
+        error_code="instagram_comments_auth_failed",
+        error_class="CommentsScraplingRuntimeError",
+        error_message="Instagram auth failed while fetching comments for DUvvcUSFmI0.",
+    )
+
+    assert aborted == 2
+    assert [call["job_id"] for call in finish_calls] == ["sibling-1", "sibling-2"]
+    assert {call["status"] for call in finish_calls} == {"failed"}
+    assert {call["last_error_code"] for call in finish_calls} == {"instagram_comments_auth_failed"}
+    assert finish_calls[0]["metadata"]["aborted_by_sibling_job_id"] == "22222222-2222-2222-2222-222222222222"
+    assert finish_calls[0]["metadata"]["account"] == "thetraitorsus"
+
+
+def test_job_runner_skips_isolated_post_auth_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    persist_calls: list[str] = []
+
+    def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append(shortcode)
+        return PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    fetch_results = [
+        InstagramCommentsFetchResult(
+            comments=[],
+            fetch_failed=True,
+            auth_failed=True,
+            fetch_reason="html_challenge_or_auth_required",
+        ),
+        InstagramCommentsFetchResult(comments=[object()], fetch_failed=False),
+    ]
+    fetch_call_idx = {"i": 0}
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": fetch_call_idx["i"]}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            idx = fetch_call_idx["i"]
+            fetch_call_idx["i"] += 1
+            return fetch_results[idx]
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: _fake_comments_session())
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["AUTHFAIL", "OKPOST"],
+            "max_comments_per_post": 10,
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "running"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert finish_calls[-1]["status"] == "completed"
+    assert persist_calls == ["OKPOST"]
+    metadata = finish_calls[-1]["metadata"]
+    assert [sample["shortcode"] for sample in metadata["post_latency"]["samples"]] == ["AUTHFAIL", "OKPOST"]
+    assert metadata["post_latency"]["samples"][0]["completion_reason"] == "post_auth_failed_skipped"
+    assert metadata["post_auth_failures"]["target_source_ids"] == ["AUTHFAIL"]
+    assert metadata["post_auth_failures"]["fetch_reasons"] == {
+        "AUTHFAIL": "html_challenge_or_auth_required"
+    }
+
+
+def test_job_runner_fails_after_post_auth_failure_circuit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    finish_calls: list[dict[str, Any]] = []
+    fetch_calls: list[str] = []
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": len(fetch_calls)}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, shortcode: str, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_calls.append(shortcode)
+            return InstagramCommentsFetchResult(
+                comments=[],
+                fetch_failed=True,
+                auth_failed=True,
+                fetch_reason="html_challenge_or_auth_required",
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: _fake_comments_session())
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["AUTH1", "AUTH2", "AUTH3", "AUTH4"],
+            "post_auth_failure_circuit_limit": 3,
+            "max_comments_per_post": 10,
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "running"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert finish_calls[-1]["status"] == "failed"
+    assert fetch_calls == ["AUTH1", "AUTH2", "AUTH3"]
+    finish_kwargs = finish_calls[-1]
+    assert finish_kwargs["last_error_code"] == "instagram_comments_auth_failed"
+    metadata = finish_kwargs["metadata"]
+    assert metadata["post_auth_failures"]["target_source_ids"] == ["AUTH1", "AUTH2", "AUTH3"]
+    assert metadata["post_auth_failures"]["circuit_limit"] == 3
 
 
 def test_comments_job_runner_stops_before_targets_when_warmup_has_no_cookies(
@@ -672,8 +1484,73 @@ def test_comments_job_runner_stops_before_targets_when_warmup_has_no_cookies(
     assert finish_kwargs["last_error_code"] == "instagram_comments_warmup_no_cookies"
     metadata = finish_kwargs["metadata"]
     assert metadata["error_code"] == "instagram_comments_warmup_no_cookies"
+    assert metadata["auth_context"]["session_source"] == "browser_session"
+    assert metadata["auth_context"]["session_account_id"] == "testaccount"
+    assert metadata["auth_context"]["validation_category"] == "validated"
     assert metadata["runtime_metadata"]["warmup_cookie_count"] == 0
     assert metadata["fetcher_runtime"]["warmup_cookie_count"] == 0
+
+
+def test_comments_job_runner_retries_raw_warmup_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    finish_calls: list[dict[str, Any]] = []
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": 1}
+
+        async def warmup(self) -> None:
+            raise OSError("[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2590)")
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            raise AssertionError("targets should not be fetched after warmup transport failure")
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: _fake_comments_session())
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "max_comments_per_post": 10,
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 2,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "retrying"},
+    ):
+        payload = jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert payload["status"] == "retrying"
+    finish_kwargs = finish_calls[-1]
+    assert finish_kwargs["status"] == "retrying"
+    assert finish_kwargs["last_error_code"] == "instagram_comments_transport_error"
+    assert finish_kwargs["metadata"]["error_code"] == "instagram_comments_transport_error"
+
+
+def test_comments_job_runner_treats_closed_ssl_connection_as_transport_error() -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    assert jr._is_comments_transport_error(Exception("SSL connection has been closed unexpectedly"))
 
 
 def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -682,6 +1559,7 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
     from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
 
+    finish_calls: list[dict[str, Any]] = []
     persist_calls: list[str] = []
 
     def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
@@ -707,7 +1585,7 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
     ]
     fetch_call_idx = {"i": 0}
 
-    async def fake_fetch_method(shortcode, *, max_comments, fetch_replies):
+    async def fake_fetch_method(shortcode, *, max_comments, fetch_replies, expected_comment_count=None):
         idx = fetch_call_idx["i"]
         fetch_call_idx["i"] += 1
         return fetch_results[idx]
@@ -740,7 +1618,7 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
 
     monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
-    monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
     monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
@@ -752,6 +1630,9 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
             "mode": "profile",
             "account": "bravotv",
             "target_source_ids": ["SHORT1", "SHORT2", "SHORT3"],
+            "comments_shard_index": 1,
+            "comments_shard_count": 3,
+            "comments_shard_target_count": 3,
             "max_comments_per_post": 10,
             "fetch_replies": False,
         },
@@ -768,6 +1649,202 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
     assert persist_calls == ["SHORT1", "SHORT2"], (
         f"Expected partial persists for 1 and 2 before SHORT3 failure; got {persist_calls}"
     )
+    metadata = finish_calls[-1]["metadata"]
+    assert metadata["comments_shard_index"] == 1
+    assert metadata["comments_shard_count"] == 3
+    assert metadata["comments_shard_target_count"] == 3
+    assert metadata["post_latency"]["sample_count"] == 2
+    assert [sample["shortcode"] for sample in metadata["post_latency"]["samples"]] == ["SHORT1", "SHORT2"]
+    assert metadata["comment_completeness"]["complete_posts"] == 2
+    assert metadata["retry_rebalance"] == {
+        "remaining_target_source_ids": ["SHORT3"],
+        "eligible": True,
+    }
+
+
+def test_job_runner_reports_actual_comments_posts_checked(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    progress_activities: list[dict[str, Any] | None] = []
+
+    def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 2
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(
+        repo,
+        "_emit_job_progress",
+        lambda **kwargs: progress_activities.append(kwargs.get("activity")),
+    )
+    monkeypatch.setattr(repo, "_finish_job", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "max_comments_per_post": 10,
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 1,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "completed"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert progress_activities[0] == {
+        "phase": "comments_scrapling_start",
+        "posts_checked": 0,
+        "matched_posts": 0,
+        "saved_posts": 0,
+        "total_posts": 2,
+        "comments_shard_index": 1,
+        "comments_shard_count": 1,
+        "comments_shard_target_count": 2,
+    }
+    assert progress_activities[-1] == {
+        "phase": "comments_scrapling_running",
+        "posts_checked": 2,
+        "matched_posts": 2,
+        "saved_posts": 2,
+        "total_posts": 2,
+        "comments_shard_index": 1,
+        "comments_shard_count": 1,
+        "comments_shard_target_count": 2,
+    }
+
+
+def test_job_runner_retry_skips_already_complete_targets(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    fetch_calls: list[str] = []
+    persist_calls: list[str] = []
+    finish_calls: list[dict[str, Any]] = []
+    progress_activities: list[dict[str, Any] | None] = []
+
+    def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append(shortcode)
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 1
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, shortcode: str, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_calls.append(shortcode)
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(repo, "_instagram_filter_incomplete_comment_targets", lambda *_args, **_kwargs: ["SHORT2"])
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(
+        repo,
+        "_emit_job_progress",
+        lambda **kwargs: progress_activities.append(kwargs.get("activity")),
+    )
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "comments_retry_rebalance": True,
+            "max_comments_per_post": 10,
+            "fetch_replies": False,
+        },
+        "attempt_count": 2,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "completed"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert fetch_calls == ["SHORT2"]
+    assert persist_calls == ["SHORT2"]
+    assert progress_activities[-1]["posts_checked"] == 2
+    assert finish_calls[-1]["status"] == "completed"
+    assert finish_calls[-1]["metadata"]["skipped_complete_target_source_ids"] == ["SHORT1"]
+    assert finish_calls[-1]["metadata"]["post_latency"]["samples"][0]["completion_reason"] == "already_complete"
 
 
 def test_job_runner_marks_uncapped_success_complete(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -921,6 +1998,290 @@ def test_job_runner_keeps_capped_success_incomplete_when_local_cap_is_hit(monkey
     assert captured_is_complete == [False]
 
 
+def test_job_runner_retries_only_retryable_incomplete_posts(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    config_update_calls: list[dict[str, Any]] = []
+    persist_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, shortcode: str, is_complete: bool, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append({"shortcode": shortcode, "is_complete": is_complete})
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 4
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {
+                "transport": "test",
+                "request_count": self._request_count,
+                "reply_checkpoint_metadata": {
+                    "items": [
+                        {
+                            "platform": "instagram",
+                            "target_shortcode": "SHORT1",
+                            "source_id": "SHORT1",
+                            "parent_comment_id": "parent-1",
+                            "stop_reason": "http_429",
+                            "attempt_count": 3,
+                            "last_error_code": "http_429",
+                            "saved_reply_count_observed": 2,
+                            "expected_reply_count": 5,
+                            "retryable": True,
+                            "updated_at": "2026-04-30T12:00:00+00:00",
+                        }
+                    ],
+                    "total_count": 1,
+                    "max_items": 25,
+                    "dropped_count": 0,
+                    "truncated": False,
+                },
+            }
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, shortcode: str, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            if shortcode == "SHORT1":
+                return InstagramCommentsFetchResult(
+                    comments=[object()],
+                    fetch_failed=True,
+                    auth_failed=False,
+                    fetch_reason="http_429",
+                    request_count=3,
+                    retryable=True,
+                )
+            return InstagramCommentsFetchResult(
+                comments=[object()],
+                fetch_failed=False,
+                auth_failed=False,
+                request_count=4,
+                retryable=False,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(repo, "_retry_backoff_seconds", lambda *_args, **_kwargs: 0)
+
+    def fake_update_job_config(_job_id: str, *, config_updates: dict[str, Any]) -> dict[str, Any]:
+        config_update_calls.append(dict(config_updates))
+        return {}
+
+    monkeypatch.setattr(repo, "_update_job_config", fake_update_job_config)
+    monkeypatch.setattr(
+        repo,
+        "_finish_job",
+        lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}),
+    )
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "fetch_replies": True,
+            "comments_shard_index": 1,
+            "comments_shard_count": 2,
+            "comments_shard_target_count": 2,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "retrying"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert persist_calls == [
+        {"shortcode": "SHORT1", "is_complete": False},
+        {"shortcode": "SHORT2", "is_complete": True},
+    ]
+    assert config_update_calls == [
+        {
+            "target_source_ids": ["SHORT1"],
+            "comments_shard_target_count": 1,
+            "comments_retry_incomplete": True,
+            "comments_retry_incomplete_source_job_id": "job-1",
+        }
+    ]
+    assert finish_calls[-1]["status"] == "retrying"
+    assert finish_calls[-1]["last_error_code"] == "instagram_comments_incomplete_retryable"
+    assert finish_calls[-1]["metadata"]["retry_rebalance"] == {
+        "remaining_target_source_ids": ["SHORT1"],
+        "eligible": True,
+    }
+    assert finish_calls[-1]["metadata"]["reply_checkpoint_summary"] == {
+        "total_count": 1,
+        "retained_count": 1,
+        "dropped_count": 0,
+        "truncated": False,
+        "stop_reasons": {"http_429": 1},
+        "latest": {
+            "platform": "instagram",
+            "target_shortcode": "SHORT1",
+            "source_id": "SHORT1",
+            "parent_comment_id": "parent-1",
+            "stop_reason": "http_429",
+            "attempt_count": 3,
+            "last_error_code": "http_429",
+            "saved_reply_count_observed": 2,
+            "expected_reply_count": 5,
+            "retryable": True,
+            "updated_at": "2026-04-30T12:00:00+00:00",
+        },
+    }
+
+
+def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    config_update_calls: list[dict[str, Any]] = []
+    persist_calls: list[str] = []
+
+    def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append(shortcode)
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 3
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, shortcode: str, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            if shortcode == "SHORT2":
+                return InstagramCommentsFetchResult(
+                    comments=[],
+                    fetch_failed=True,
+                    auth_failed=False,
+                    fetch_reason="http_429",
+                    request_count=3,
+                    retryable=True,
+                )
+            return InstagramCommentsFetchResult(
+                comments=[object()],
+                fetch_failed=False,
+                auth_failed=False,
+                request_count=2,
+                retryable=False,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    def fake_update_job_config(_job_id: str, *, config_updates: dict[str, Any]) -> dict[str, Any]:
+        config_update_calls.append(dict(config_updates))
+        return {}
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(repo, "_retry_backoff_seconds", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(repo, "_update_job_config", fake_update_job_config)
+    monkeypatch.setattr(
+        repo,
+        "_finish_job",
+        lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}),
+    )
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2", "SHORT3"],
+            "fetch_replies": True,
+            "comments_shard_index": 1,
+            "comments_shard_count": 2,
+            "comments_shard_target_count": 3,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        return_value={"id": "job-1", "status": "retrying"},
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert persist_calls == ["SHORT1"]
+    assert config_update_calls == [
+        {
+            "target_source_ids": ["SHORT2", "SHORT3"],
+            "comments_shard_target_count": 2,
+            "comments_retry_incomplete": True,
+            "comments_retry_incomplete_source_job_id": "job-1",
+        }
+    ]
+    assert finish_calls[-1]["status"] == "retrying"
+    assert finish_calls[-1]["last_error_code"] == "http_429"
+    assert finish_calls[-1]["metadata"]["retry_rebalance"] == {
+        "remaining_target_source_ids": ["SHORT2", "SHORT3"],
+        "eligible": True,
+    }
+
+
 def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: pytest.MonkeyPatch) -> None:
     from trr_backend.repositories import social_season_analytics as repo
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
@@ -983,6 +2344,9 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
             "mode": "profile",
             "account": "bravotv",
             "target_source_ids": ["SHORT1"],
+            "comments_shard_index": 2,
+            "comments_shard_count": 4,
+            "comments_shard_target_count": 1,
             "fetch_replies": False,
         },
         "attempt_count": 1,
@@ -998,6 +2362,20 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
     metadata = finish_calls[-1]["metadata"]
     assert metadata["fetch_counters"]["request_count"] == 4
     assert metadata["fetcher_runtime"]["request_count"] == 4
+    assert metadata["comments_shard_index"] == 2
+    assert metadata["comments_shard_count"] == 4
+    assert metadata["comments_shard_target_count"] == 1
+    assert metadata["post_latency"]["sample_count"] == 1
+    assert metadata["post_latency"]["samples"][0]["shortcode"] == "SHORT1"
+    assert metadata["post_latency"]["slowest"][0]["shortcode"] == "SHORT1"
+    assert metadata["comment_completeness"] == {
+        "complete_posts": 1,
+        "incomplete_posts": 0,
+        "completion_reasons": {"pagination_exhausted": 1},
+    }
+    assert metadata["timing"]["job_runner_started_at"] is not None
+    assert metadata["timing"]["warmup_completed_at"] is not None
+    assert metadata["timing"]["first_post_persisted_at"] is not None
 
 
 def test_job_runner_persists_partial_success_when_auth_failed_but_comments_present(

--- a/tests/socials/test_profile_dashboard.py
+++ b/tests/socials/test_profile_dashboard.py
@@ -44,7 +44,7 @@ def test_active_catalog_run_fetches_progress(monkeypatch: pytest.MonkeyPatch) ->
 
     assert payload["data"]["catalog_run_progress"] == {"run_id": "run-active", "status": "running"}
     assert payload["operational_alerts"] == [{"code": "needs_review"}]
-    assert calls == [(("instagram", "thetraitorsus", "run-active"), {"recent_log_limit": 12})]
+    assert calls == [(("instagram", "thetraitorsus", "run-active"), {"recent_log_limit": 12, "fast": True})]
 
 
 def test_terminal_catalog_run_does_not_fetch_progress(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -94,7 +94,7 @@ def test_explicit_run_id_overrides_inferred_active_run(monkeypatch: pytest.Monke
     )
 
     assert payload["data"]["catalog_run_progress"] == {"run_id": "run-explicit"}
-    assert calls == [(("instagram", "thetraitorsus", "run-explicit"), {"recent_log_limit": 25})]
+    assert calls == [(("instagram", "thetraitorsus", "run-explicit"), {"recent_log_limit": 25, "fast": True})]
 
 
 def test_progress_call_receives_account_identity_run_id_and_log_limit(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -131,7 +131,7 @@ def test_progress_call_receives_account_identity_run_id_and_log_limit(monkeypatc
         "account_handle": "bravotv",
         "detail": "full",
     }
-    assert progress_calls == [(("tiktok", "bravotv", "run-from-id"), {"recent_log_limit": 100})]
+    assert progress_calls == [(("tiktok", "bravotv", "run-from-id"), {"recent_log_limit": 100, "fast": True})]
 
 
 def test_summary_exception_is_not_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/trr_backend/db/pg.py
+++ b/trr_backend/db/pg.py
@@ -94,13 +94,15 @@ def _pool_size_env_names(pool_name: str) -> tuple[str, str]:
         return "TRR_SOCIAL_PROFILE_DB_POOL_MINCONN", "TRR_SOCIAL_PROFILE_DB_POOL_MAXCONN"
     if pool_name == "social_control":
         return "TRR_SOCIAL_CONTROL_DB_POOL_MINCONN", "TRR_SOCIAL_CONTROL_DB_POOL_MAXCONN"
+    if pool_name == "social_progress":
+        return "TRR_SOCIAL_PROGRESS_DB_POOL_MINCONN", "TRR_SOCIAL_PROGRESS_DB_POOL_MAXCONN"
     if pool_name == "health":
         return "TRR_HEALTH_DB_POOL_MINCONN", "TRR_HEALTH_DB_POOL_MAXCONN"
     return "TRR_DB_POOL_MINCONN", "TRR_DB_POOL_MAXCONN"
 
 
 def _known_pool_names() -> tuple[str, ...]:
-    return ("default", "social_profile", "social_control", "health")
+    return ("default", "social_profile", "social_control", "social_progress", "health")
 
 
 def _session_pooler_warning_maxconn(pool_name: str) -> int:

--- a/trr_backend/repositories/social_season_analytics.py
+++ b/trr_backend/repositories/social_season_analytics.py
@@ -67,15 +67,20 @@ from trr_backend.socials.twitter import TwitterScrapeConfig, TwitterScraper
 
 logger = logging.getLogger(__name__)
 
+SOCIAL_CATALOG_PROGRESS_POOL_NAME = "social_progress"
+
 _SOCIAL_PROFILE_TOTAL_POSTS_CACHE: dict[tuple[str, str], tuple[float, int | None]] = {}
 _SOCIAL_PROFILE_TOTAL_POSTS_CACHE_LOCK = Lock()
 _SOCIAL_PROFILE_SNAPSHOT_CACHE: dict[tuple[str, str], tuple[float, dict[str, Any]]] = {}
 _SOCIAL_PROFILE_SNAPSHOT_CACHE_LOCK = Lock()
 _SOCIAL_HOT_PATH_CACHE: dict[tuple[Any, ...], tuple[float, Any]] = {}
 _SOCIAL_HOT_PATH_CACHE_LOCK = Lock()
+_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE: dict[tuple[Any, ...], tuple[float, dict[str, Any]]] = {}
+_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_LOCK = Lock()
 
 SUPPORTED_PLATFORMS = SOCIAL_SUPPORTED_PLATFORMS
 SUPPORTED_SCOPES = ("bravo", "creator", "community")
+SOCIAL_ACCOUNT_PROFILE_COMMENT_FILTERS = {"commentable", "incomplete", "not_commentable"}
 SHARED_PROFILE_KIND_BY_SCOPE = {
     "bravo": "network_streaming",
     "creator": "creator",
@@ -130,6 +135,7 @@ SOCIAL_CATALOG_RUN_IN_FLIGHT_CAP_DEFAULT = 16
 SOCIAL_QUEUE_STATUS_CACHE_TTL_SECONDS_DEFAULT = 20
 SOCIAL_WORKER_HEALTH_CACHE_TTL_SECONDS_DEFAULT = 5
 SOCIAL_INSTAGRAM_COOKIE_VALIDATION_TTL_SECONDS_DEFAULT = 900
+SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS_DEFAULT = 60
 SOCIAL_INSTAGRAM_COOKIE_REFRESH_TIMEOUT_SECONDS_DEFAULT = 120
 SOCIAL_QUEUE_STATUS_STALE_FALLBACK_SECONDS_DEFAULT = 120
 SOCIAL_QUEUE_STATUS_STUCK_JOBS_LIMIT_DEFAULT = 100
@@ -717,7 +723,11 @@ def _shared_account_prefers_frontier_strategy(
         bounded_window=bounded_window,
     ):
         return False
-    return bool(resume_frontier_requested)
+    if resume_frontier_requested:
+        return True
+    expected_total = _normalize_non_negative_int(expected_total_posts)
+    catalog_total = _normalize_non_negative_int(catalog_total_posts)
+    return expected_total > 0 and catalog_total < expected_total
 
 
 def _shared_account_uses_frontier_strategy(config: Mapping[str, Any] | None, *, platform: str | None = None) -> bool:
@@ -1760,7 +1770,7 @@ def _modal_dispatch_retry_delay_seconds() -> int:
 
 
 def _modal_dispatch_stage_global_cap(stage: str | None) -> int:
-    normalized_stage = _normalize_social_job_stage_for_stale(stage) or "unknown"
+    normalized_stage = _modal_dispatch_capacity_stage(stage)
     env_map = {
         "posts": ("SOCIAL_WORKER_POOL_POSTS", 8),
         "comments": ("SOCIAL_WORKER_POOL_COMMENTS", 8),
@@ -1777,7 +1787,7 @@ def _modal_dispatch_stage_global_cap(stage: str | None) -> int:
 
 
 def _modal_dispatch_platform_cap(stage: str | None, platform: str | None) -> int | None:
-    normalized_stage = _normalize_social_job_stage_for_stale(stage)
+    normalized_stage = _modal_dispatch_capacity_stage(stage)
     normalized_platform = _normalize_platform_name(platform)
     if normalized_platform not in SUPPORTED_PLATFORMS:
         return None
@@ -1817,6 +1827,13 @@ def _modal_dispatch_platform_cap(stage: str | None, platform: str | None) -> int
     if normalized_stage in {INSTAGRAM_MEDIA_MIRROR_STAGE, COMMENT_MEDIA_MIRROR_STAGE}:
         return _resolve_positive_int_env("SOCIAL_MIRROR_PLATFORM_CAP", 2, minimum=1)
     return None
+
+
+def _modal_dispatch_capacity_stage(stage: Any) -> str:
+    normalized = _normalize_social_job_stage_for_stale(stage) or "unknown"
+    if normalized == INSTAGRAM_COMMENTS_SCRAPLING_STAGE:
+        return "comments"
+    return normalized
 
 
 def _resolve_dispatch_account_handle(config: dict[str, Any]) -> str | None:
@@ -3934,6 +3951,169 @@ def recover_dispatch_blocked_no_progress_jobs(*, limit: int = 100) -> list[dict[
 recover_dispatch_blocked_no_progress_jobs.__trr_delegates_to_control_plane__ = True
 
 
+def recover_failed_instagram_comments_capacity_jobs(
+    *,
+    run_id: str | None = None,
+    limit: int = 25,
+) -> list[dict[str, Any]]:
+    """Requeue retryable Instagram comments shards that failed before exhausting job attempts."""
+
+    safe_limit = max(1, min(int(limit or 25), 250))
+    try:
+        normalized_run_id = str(UUID(str(run_id))) if str(run_id or "").strip() else None
+    except (TypeError, ValueError):
+        return []
+    rows = pg.fetch_all(
+        """
+        with candidates as (
+          select
+            j.id,
+            case
+              when lower(coalesce(j.last_error_code, '')) = 'stale_modal_dispatch_unclaimed'
+                or (
+                  lower(coalesce(j.error_message, '')) like '%%modal dispatch lease expired%%'
+                  and lower(coalesce(j.error_message, '')) like '%%before any worker claimed%%'
+                )
+                then 'stale_modal_dispatch_unclaimed'
+              when lower(coalesce(j.last_error_code, '')) in (
+                  'instagram_comments_transport_error',
+                  'instagram_comments_warmup_transport_error',
+                  'transport_error'
+                )
+                or lower(coalesce(j.last_error_class, '')) = 'sslerror'
+                or lower(coalesce(j.error_message, '')) like '%%wrong_version_number%%'
+                or lower(coalesce(j.error_message, '')) like '%%wrong version number%%'
+                or lower(coalesce(j.error_message, '')) like '%%[ssl]%%'
+                or lower(coalesce(j.error_message, '')) like '%%ssl.c%%'
+                or lower(coalesce(j.error_message, '')) like '%%record layer failure%%'
+                or lower(coalesce(j.error_message, '')) like '%%ssl:%%'
+                or lower(coalesce(j.error_message, '')) like '%%ssl connection%%'
+                or lower(coalesce(j.error_message, '')) like '%%closed unexpectedly%%'
+                or lower(coalesce(j.error_message, '')) like '%%proxy error%%'
+                or lower(coalesce(j.error_message, '')) like '%%connecterror%%'
+                or lower(coalesce(j.error_message, '')) like '%%readerror%%'
+                or lower(coalesce(j.error_message, '')) like '%%connection reset%%'
+                or lower(coalesce(j.error_message, '')) like '%%server disconnected%%'
+                then 'transport_error'
+              else 'database_capacity'
+            end as recovery_reason
+          from social.scrape_jobs j
+          where j.status = 'failed'
+            and j.platform = 'instagram'
+            and coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
+            and (%s::uuid is null or j.run_id = %s::uuid)
+            and coalesce(j.attempt_count, 0) < coalesce(j.max_attempts, 1)
+            and (
+              (
+                coalesce(j.items_found, 0) = 0
+                and (
+                  lower(coalesce(j.error_message, '')) like '%%emaxconnsession%%'
+                  or lower(coalesce(j.error_message, '')) like '%%max clients reached%%'
+                  or lower(coalesce(j.error_message, '')) like '%%pool exhausted%%'
+                  or lower(coalesce(j.error_message, '')) like '%%database pool%%'
+                )
+              )
+              or lower(coalesce(j.last_error_code, '')) = 'stale_modal_dispatch_unclaimed'
+              or (
+                lower(coalesce(j.error_message, '')) like '%%modal dispatch lease expired%%'
+                and lower(coalesce(j.error_message, '')) like '%%before any worker claimed%%'
+              )
+              or lower(coalesce(j.last_error_code, '')) in (
+                'instagram_comments_transport_error',
+                'instagram_comments_warmup_transport_error',
+                'transport_error'
+              )
+              or lower(coalesce(j.last_error_class, '')) = 'sslerror'
+              or lower(coalesce(j.error_message, '')) like '%%wrong_version_number%%'
+              or lower(coalesce(j.error_message, '')) like '%%wrong version number%%'
+              or lower(coalesce(j.error_message, '')) like '%%[ssl]%%'
+              or lower(coalesce(j.error_message, '')) like '%%ssl.c%%'
+              or lower(coalesce(j.error_message, '')) like '%%record layer failure%%'
+              or lower(coalesce(j.error_message, '')) like '%%ssl:%%'
+              or lower(coalesce(j.error_message, '')) like '%%ssl connection%%'
+              or lower(coalesce(j.error_message, '')) like '%%closed unexpectedly%%'
+              or lower(coalesce(j.error_message, '')) like '%%proxy error%%'
+              or lower(coalesce(j.error_message, '')) like '%%connecterror%%'
+              or lower(coalesce(j.error_message, '')) like '%%readerror%%'
+              or lower(coalesce(j.error_message, '')) like '%%connection reset%%'
+              or lower(coalesce(j.error_message, '')) like '%%server disconnected%%'
+            )
+          order by coalesce(j.completed_at, j.created_at) asc
+          limit %s
+        )
+        update social.scrape_jobs j
+        set
+          status = 'retrying',
+          available_at = now(),
+          completed_at = null,
+          error_message = null,
+          last_error_code = null,
+          last_error_class = null,
+          metadata = coalesce(j.metadata, '{}'::jsonb)
+            || jsonb_build_object(
+              'capacity_recovery',
+              jsonb_build_object(
+                'reason', candidates.recovery_reason,
+                'recovered_at', to_jsonb(now()),
+                'source', 'recover_failed_instagram_comments_capacity_jobs'
+              ),
+              'retryable_failure_recovery',
+              jsonb_build_object(
+                'reason', candidates.recovery_reason,
+                'recovered_at', to_jsonb(now()),
+                'source', 'recover_failed_instagram_comments_capacity_jobs'
+              ),
+              'dispatch',
+              coalesce(j.metadata->'dispatch', '{}'::jsonb)
+                || jsonb_build_object(
+                  'remote_invocation_id', null,
+                  'remote_invocation_status', null,
+                  'remote_invocation_checked_at', null,
+                  'remote_task_id', null,
+                  'remote_pending_since', null,
+                  'remote_blocked_reason', null,
+                  'lease_expires_at', null,
+                  'last_dispatch_error', null,
+                  'last_dispatch_error_code', null,
+                  'last_dispatch_error_at', null,
+                  'dispatch_attempt_count', 0,
+                  'dispatch_blocked_failure_count', 0,
+                  'dispatch_blocked_terminalized_at', null,
+                  'stale_unclaimed_dispatch_exhausted', false
+                ),
+              'activity',
+              coalesce(j.metadata->'activity', '{}'::jsonb)
+                || jsonb_build_object(
+                  'phase',
+                  case
+                    when candidates.recovery_reason = 'database_capacity' then 'capacity_recovered'
+                    when candidates.recovery_reason = 'transport_error' then 'transport_recovered'
+                    else 'stale_dispatch_recovered'
+                  end,
+                  'last_progress_at',
+                  to_jsonb(now())
+                )
+            )
+        from candidates
+        where j.id = candidates.id
+        returning
+          j.id::text as id,
+          j.run_id::text as run_id,
+          j.platform,
+          j.status,
+          candidates.recovery_reason
+        """,
+        [INSTAGRAM_COMMENTS_SCRAPLING_STAGE, normalized_run_id, normalized_run_id, safe_limit],
+    )
+    finalized_run_ids: set[str] = set()
+    for row in rows:
+        recovered_run_id = str(row.get("run_id") or "").strip()
+        if recovered_run_id and recovered_run_id not in finalized_run_ids:
+            _finalize_run_status(recovered_run_id, force_recompute=True)
+            finalized_run_ids.add(recovered_run_id)
+    return rows
+
+
 def get_queue_status(
     *,
     recent_failures_limit: int = 20,
@@ -5174,21 +5354,21 @@ def _run_counter_columns_ready() -> bool:
     return _run_counter_columns_cache
 
 
-def _instagram_posts_has_column(column: str) -> bool:
+def _instagram_posts_has_column(column: str, *, conn: Any | None = None) -> bool:
     """Best-effort schema guard for additive instagram_posts columns."""
     try:
-        return _column_exists("social", "instagram_posts", column)
+        return _column_exists("social", "instagram_posts", column, conn=conn)
     except Exception:
         # Fall back to existing behavior if schema introspection is unavailable.
         return True
 
 
-def _platform_posts_has_column(platform: str, column: str) -> bool:
+def _platform_posts_has_column(platform: str, column: str, *, conn: Any | None = None) -> bool:
     table = PLATFORM_POST_TABLES.get((platform or "").strip().lower())
     if not table:
         return False
     try:
-        return _column_exists("social", table, column)
+        return _column_exists("social", table, column, conn=conn)
     except Exception:
         return True
 
@@ -10145,7 +10325,7 @@ def _insert_job_with_conflict_target(
         if inserted and inserted.get("id"):
             job_id = str(inserted["id"])
             if run_id:
-                _increment_run_counters_on_job_create(run_id=run_id, stage=stage, status=status)
+                _increment_run_counters_on_job_create(run_id=run_id, stage=stage, status=status, conn=conn)
             return job_id
         existing = pg.fetch_one_with_cursor(cur, existing_lookup_sql, list(existing_lookup_params))
         return str(existing["id"]) if existing and existing.get("id") else None
@@ -10651,16 +10831,19 @@ def _create_run(
     initiated_by: str | None,
     config: dict[str, Any],
     status: str,
+    conn: Any | None = None,
 ) -> str:
     from trr_backend.socials.control_plane.run_lifecycle import _create_run as impl
 
-    return impl(
-        context,
-        source_scope=source_scope,
-        initiated_by=initiated_by,
-        config=config,
-        status=status,
-    )
+    kwargs: dict[str, Any] = {
+        "source_scope": source_scope,
+        "initiated_by": initiated_by,
+        "config": config,
+        "status": status,
+    }
+    if conn is not None:
+        kwargs["conn"] = conn
+    return impl(context, **kwargs)
 
 
 def _set_run_status(run_id: str, status: str) -> None:
@@ -10718,6 +10901,7 @@ def _shared_account_catalog_scrape_complete(
     *,
     run_config: Mapping[str, Any] | None,
     summary: Mapping[str, Any] | None,
+    conn: Any | None = None,
 ) -> bool:
     config = _metadata_dict(run_config)
     if str(config.get("pipeline_ingest_mode") or "").strip().lower() != SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE:
@@ -10726,12 +10910,41 @@ def _shared_account_catalog_scrape_complete(
     posts_stage = dict(stage_counts.get(SHARED_ACCOUNT_POSTS_STAGE) or {})
     posts_total = _normalize_non_negative_int(posts_stage.get("total"))
     posts_completed = _normalize_non_negative_int(posts_stage.get("completed"))
-    return (
+    stage_complete = (
         posts_total > 0
         and posts_completed >= posts_total
         and _normalize_non_negative_int(posts_stage.get("failed")) <= 0
         and _normalize_non_negative_int(posts_stage.get("active")) <= 0
     )
+    if not stage_complete:
+        return False
+    platform_values = config.get("platforms")
+    if not isinstance(platform_values, (list, tuple, set)):
+        platform_values = []
+    platforms = [str(item).strip().lower() for item in platform_values if str(item).strip()]
+    account_values = config.get("accounts_override") or config.get("accounts")
+    if not isinstance(account_values, (list, tuple, set)):
+        account_values = []
+    accounts = [
+        _normalize_social_account_profile_handle(item)
+        for item in account_values
+        if str(item).strip()
+    ]
+    bounded_window = _catalog_backfill_has_bounded_window(
+        date_start=_coerce_dt(config.get("date_start")),
+        date_end=_coerce_dt(config.get("date_end")),
+    )
+    if len(platforms) == 1 and len(accounts) == 1 and not bounded_window:
+        expected_total_posts = _shared_account_expected_total_posts_from_config(
+            config,
+            platform=platforms[0],
+            account_handle=accounts[0],
+        )
+        if expected_total_posts > 0:
+            catalog_total_posts = _shared_catalog_total_posts(platforms[0], accounts[0], conn=conn)
+            if catalog_total_posts < expected_total_posts:
+                return False
+    return True
 
 
 def _shared_account_catalog_background_classify_only(
@@ -10789,10 +11002,16 @@ def _increment_stage_counter(
     return impl(stage_counts, stage=stage, key=key, delta=delta)
 
 
-def _increment_run_counters_on_job_create(*, run_id: str, stage: str, status: str) -> None:
+def _increment_run_counters_on_job_create(
+    *,
+    run_id: str,
+    stage: str,
+    status: str,
+    conn: Any | None = None,
+) -> None:
     from trr_backend.socials.control_plane.run_lifecycle import _increment_run_counters_on_job_create as impl
 
-    impl(run_id=run_id, stage=stage, status=status)
+    impl(run_id=run_id, stage=stage, status=status, conn=conn)
 
 
 def _increment_run_counters_on_job_finish(
@@ -10858,6 +11077,72 @@ def _normalize_non_negative_int(value: Any) -> int:
         return max(0, int(value or 0))
     except (TypeError, ValueError):
         return 0
+
+
+def _coerce_instagram_reported_comment_candidate(value: Any) -> int:
+    if value is None or isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return _normalize_non_negative_int(value)
+    if isinstance(value, Mapping):
+        return max(
+            _coerce_instagram_reported_comment_candidate(value.get("count")),
+            _coerce_instagram_reported_comment_candidate(value.get("total_count")),
+        )
+    text = str(value or "").strip()
+    if not text:
+        return 0
+    digits = re.sub(r"[^0-9]", "", text)
+    return _normalize_non_negative_int(digits) if digits else 0
+
+
+def _instagram_reported_comment_count_from_payload(payload: Any) -> int:
+    if not isinstance(payload, Mapping):
+        return 0
+
+    candidates: list[int] = []
+
+    def add(value: Any) -> None:
+        candidates.append(_coerce_instagram_reported_comment_candidate(value))
+
+    for key in ("comments_count", "comments", "comment_count", "commentsCount"):
+        add(payload.get(key))
+    for key in ("edge_media_to_comment", "edge_media_to_parent_comment", "edge_media_preview_comment"):
+        add(payload.get(key))
+    for nested_key in ("media", "node", "graphql", "metrics"):
+        nested = payload.get(nested_key)
+        if isinstance(nested, Mapping):
+            for key in ("comments_count", "comments", "comment_count", "commentsCount"):
+                add(nested.get(key))
+            add(nested.get("edge_media_to_comment"))
+
+    return max(candidates or [0])
+
+
+def _sql_json_text_non_negative_int(expr: str) -> str:
+    return f"coalesce(nullif(regexp_replace(coalesce({expr}, ''), '[^0-9]', '', 'g'), '')::bigint, 0)"
+
+
+def _instagram_reported_comments_sql(alias: str = "p") -> str:
+    safe_alias = str(alias or "p").strip() or "p"
+    raw = f"coalesce({safe_alias}.raw_data, '{{}}'::jsonb)"
+    raw_candidates = [
+        f"{raw} ->> 'comments_count'",
+        f"{raw} ->> 'comments'",
+        f"{raw} ->> 'comment_count'",
+        f"{raw} ->> 'commentsCount'",
+        f"{raw} -> 'edge_media_to_comment' ->> 'count'",
+        f"{raw} -> 'edge_media_to_parent_comment' ->> 'count'",
+        f"{raw} -> 'edge_media_preview_comment' ->> 'count'",
+        f"{raw} -> 'media' ->> 'comments_count'",
+        f"{raw} -> 'media' ->> 'comments'",
+        f"{raw} -> 'media' ->> 'comment_count'",
+        f"{raw} -> 'media' ->> 'commentsCount'",
+        f"{raw} -> 'metrics' ->> 'comments_count'",
+        f"{raw} -> 'metrics' ->> 'comments'",
+    ]
+    raw_expr = ", ".join(_sql_json_text_non_negative_int(expr) for expr in raw_candidates)
+    return f"greatest(coalesce({safe_alias}.comments_count, 0), {raw_expr})"
 
 
 def _new_job_progress_state() -> dict[str, Any]:
@@ -11046,7 +11331,9 @@ def _default_job_claim_batch_size_for_stage(stage: Any) -> int:
     # Claimed jobs are marked running immediately; claiming multiple post jobs per
     # worker causes later jobs in the batch to age into false stale-heartbeat rows
     # before execution reaches them. Keep queue workers single-claim by default.
-    return 1 if normalized_stage == "posts" else SOCIAL_JOB_CLAIM_BATCH_SIZE_DEFAULT
+    if normalized_stage in {"posts", INSTAGRAM_COMMENTS_SCRAPLING_STAGE}:
+        return 1
+    return SOCIAL_JOB_CLAIM_BATCH_SIZE_DEFAULT
 
 
 def _resolve_job_claim_batch_size(default: int | None = None, *, stage: Any = None) -> int:
@@ -11176,6 +11463,37 @@ def recover_stale_running_jobs(
             when j.attempt_count < j.max_attempts then 'retrying'
             else 'failed'
           end,
+          config = case
+            when coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
+              and jsonb_array_length(
+                case
+                  when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
+                    then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
+                  else '[]'::jsonb
+                end
+              ) > 0
+            then coalesce(j.config, '{{}}'::jsonb) || jsonb_build_object(
+              'target_source_ids',
+              case
+                when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
+                  then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
+                else '[]'::jsonb
+              end,
+              'comments_retry_rebalance',
+              true,
+              'comments_retry_rebalance_source_job_id',
+              j.id::text,
+              'comments_shard_target_count',
+              jsonb_array_length(
+                case
+                  when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
+                    then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
+                  else '[]'::jsonb
+                end
+              )
+            )
+            else j.config
+          end,
           completed_at = case
             when j.attempt_count < j.max_attempts then j.completed_at
             else now()
@@ -11226,6 +11544,7 @@ def recover_stale_running_jobs(
             platform,
             platform,
             stale_limit,
+            INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
             *stale_seconds_params,
             *stale_seconds_params,
         ],
@@ -13423,7 +13742,7 @@ def _mirror_platform_media_to_s3_result(
         media_retrieval_meta = getattr(post, "media_retrieval_meta", None)
         if not isinstance(media_retrieval_meta, dict):
             media_retrieval_meta = {}
-            setattr(post, "media_retrieval_meta", media_retrieval_meta)
+            post.media_retrieval_meta = media_retrieval_meta
         attempted_keys = media_retrieval_meta.setdefault("cdn_reresolved_urls", [])
         guard_key = redact_signed_url(current_source_url)
         if not isinstance(attempted_keys, list):
@@ -13435,9 +13754,10 @@ def _mirror_platform_media_to_s3_result(
         media_retrieval_meta["cdn_reresolved"] = True
 
         if instagram_refresh_scraper is None:
+            post_context_id = str(getattr(post, "shortcode", "") or getattr(post, "id", "") or "unknown")
             instagram_refresh_scraper = _build_instagram_scraper_with_auth_fallback(
                 browser_account_id=str(getattr(post, "username", "") or "").strip() or None,
-                caller_context=f"media_mirror:{str(getattr(post, 'shortcode', '') or getattr(post, 'id', '') or 'unknown')}",
+                caller_context=f"media_mirror:{post_context_id}",
             )
 
         if instagram_refresh_scraper is None:
@@ -13455,7 +13775,7 @@ def _mirror_platform_media_to_s3_result(
         media_retrieval_meta = getattr(post, "media_retrieval_meta", None)
         if not isinstance(media_retrieval_meta, dict):
             media_retrieval_meta = {}
-            setattr(post, "media_retrieval_meta", media_retrieval_meta)
+            post.media_retrieval_meta = media_retrieval_meta
         media_retrieval_meta["cdn_reresolved"] = True
         refreshed_attempted_keys = media_retrieval_meta.setdefault("cdn_reresolved_urls", [])
         if not isinstance(refreshed_attempted_keys, list):
@@ -15920,6 +16240,8 @@ def _expected_comment_count_for_platform(
         quotes = _normalize_non_negative_int(row_or_post.get("quotes"))
         return replies + quotes
     expected = _normalize_non_negative_int(row_or_post.get("comments_count"))
+    if normalized_platform == "instagram":
+        expected = max(expected, _instagram_reported_comment_count_from_payload(row_or_post.get("raw_data")))
     if normalized_platform == "youtube" and expected <= 0 and snapshot is not None:
         return _normalize_non_negative_int(snapshot.active_count)
     return expected
@@ -16813,6 +17135,10 @@ def _upsert_instagram_post(
             "attempts": _normalize_instagram_mirror_attempts(media_retrieval_meta.get("attempts")),
         }
 
+    reported_comments = max(
+        _normalize_non_negative_int(getattr(post, "comments", 0)),
+        _instagram_reported_comment_count_from_payload(raw_data),
+    )
     payload = {
         "shortcode": shortcode,
         "media_id": getattr(post, "pk", None),
@@ -16823,7 +17149,7 @@ def _upsert_instagram_post(
         "media_urls": media_urls,
         "thumbnail_url": thumbnail_url,
         "likes": int(getattr(post, "likes", 0) or 0),
-        "comments_count": int(getattr(post, "comments", 0) or 0),
+        "comments_count": reported_comments,
         "views": resolved_views,
         "posted_at": posted_at,
         "scraped_at": _now_utc(),
@@ -16930,35 +17256,37 @@ def _upsert_instagram_post(
         "child_posts_data": child_posts_data if child_posts_data else [],
     }
     for key, value in optional_payload.items():
-        if _instagram_posts_has_column(key):
+        if _instagram_posts_has_column(key, conn=conn):
             payload[key] = value
 
     # Preserve hosted URLs unless new hosted values are explicitly supplied.
-    if hosted_thumbnail_url and _instagram_posts_has_column("hosted_thumbnail_url"):
+    if hosted_thumbnail_url and _instagram_posts_has_column("hosted_thumbnail_url", conn=conn):
         payload["hosted_thumbnail_url"] = hosted_thumbnail_url
-    if hosted_media_urls and _instagram_posts_has_column("hosted_media_urls"):
+    if hosted_media_urls and _instagram_posts_has_column("hosted_media_urls", conn=conn):
         payload["hosted_media_urls"] = hosted_media_urls
-    if _instagram_posts_has_column("media_mirror_status"):
+    if _instagram_posts_has_column("media_mirror_status", conn=conn):
         payload["media_mirror_status"] = media_mirror_status
-    if _instagram_posts_has_column("media_mirror_error"):
+    if _instagram_posts_has_column("media_mirror_error", conn=conn):
         payload["media_mirror_error"] = media_mirror_error
-    if media_mirror_attempt_count is not None and _instagram_posts_has_column("media_mirror_attempt_count"):
+    if media_mirror_attempt_count is not None and _instagram_posts_has_column("media_mirror_attempt_count", conn=conn):
         payload["media_mirror_attempt_count"] = max(0, int(media_mirror_attempt_count))
-    if media_mirror_last_attempt_at is not None and _instagram_posts_has_column("media_mirror_last_attempt_at"):
+    if media_mirror_last_attempt_at is not None and _instagram_posts_has_column(
+        "media_mirror_last_attempt_at", conn=conn
+    ):
         payload["media_mirror_last_attempt_at"] = media_mirror_last_attempt_at
-    if media_mirror_last_job_id and _instagram_posts_has_column("media_mirror_last_job_id"):
+    if media_mirror_last_job_id and _instagram_posts_has_column("media_mirror_last_job_id", conn=conn):
         payload["media_mirror_last_job_id"] = media_mirror_last_job_id
 
     # Profile picture mirror fields (migration 0147)
     hosted_owner_pic = getattr(post, "hosted_owner_profile_pic_url", None)
-    if hosted_owner_pic and _instagram_posts_has_column("hosted_owner_profile_pic_url"):
+    if hosted_owner_pic and _instagram_posts_has_column("hosted_owner_profile_pic_url", conn=conn):
         payload["hosted_owner_profile_pic_url"] = hosted_owner_pic
     hosted_tagged_pics = getattr(post, "hosted_tagged_profile_pics", None)
-    if hosted_tagged_pics and _instagram_posts_has_column("hosted_tagged_profile_pics"):
+    if hosted_tagged_pics and _instagram_posts_has_column("hosted_tagged_profile_pics", conn=conn):
         payload["hosted_tagged_profile_pics"] = hosted_tagged_pics
-    if _instagram_posts_has_column("profile_pic_mirror_status"):
+    if _instagram_posts_has_column("profile_pic_mirror_status", conn=conn):
         payload["profile_pic_mirror_status"] = getattr(post, "profile_pic_mirror_status", None)
-    if _instagram_posts_has_column("profile_pic_mirror_error"):
+    if _instagram_posts_has_column("profile_pic_mirror_error", conn=conn):
         payload["profile_pic_mirror_error"] = getattr(post, "profile_pic_mirror_error", None)
 
     row = _pg_upsert("instagram_posts", payload, conflict_col="shortcode", conn=conn)
@@ -17081,24 +17409,29 @@ def _platform_post_avatar_urls(platform: str, post_row: dict[str, Any]) -> tuple
     return source_avatar_url, hosted_avatar_url
 
 
-def _extract_platform_post_asset_manifest(platform: str, post_row: dict[str, Any]) -> dict[str, Any]:
+def _extract_platform_post_asset_manifest(
+    platform: str,
+    post_row: dict[str, Any],
+    *,
+    conn: Any | None = None,
+) -> dict[str, Any]:
     normalized_platform = (platform or "").strip().lower()
     asset_manifest = post_row.get("asset_manifest")
     if isinstance(asset_manifest, dict) and (
-        not normalized_platform or _platform_posts_has_column(normalized_platform, "asset_manifest")
+        not normalized_platform or _platform_posts_has_column(normalized_platform, "asset_manifest", conn=conn)
     ):
         return dict(asset_manifest)
     return _extract_media_asset_meta_from_raw_data(post_row.get("raw_data"))
 
 
-def _platform_post_has_stale_media_asset_meta(post_row: dict[str, Any]) -> bool:
+def _platform_post_has_stale_media_asset_meta(post_row: dict[str, Any], *, conn: Any | None = None) -> bool:
     hosted_thumbnail_url = str(post_row.get("hosted_thumbnail_url") or "").strip()
     hosted_media_urls = _as_text_list(post_row.get("hosted_media_urls"))
     if not hosted_thumbnail_url and not hosted_media_urls:
         return False
 
     platform = str(post_row.get("platform") or post_row.get("_platform") or "").strip().lower()
-    media_asset_meta = _extract_platform_post_asset_manifest(platform, post_row)
+    media_asset_meta = _extract_platform_post_asset_manifest(platform, post_row, conn=conn)
     if not media_asset_meta:
         return False
     hosted_assets = media_asset_meta.get("hosted_assets") if isinstance(media_asset_meta, dict) else None
@@ -17156,7 +17489,12 @@ def _platform_post_avatar_repair_state(platform: str, post_row: dict[str, Any]) 
     }
 
 
-def _platform_post_repair_reasons(platform: str, post_row: dict[str, Any]) -> list[str]:
+def _platform_post_repair_reasons(
+    platform: str,
+    post_row: dict[str, Any],
+    *,
+    conn: Any | None = None,
+) -> list[str]:
     normalized_platform = (platform or "").strip().lower()
     hosted_thumbnail_url = str(post_row.get("hosted_thumbnail_url") or "").strip()
     hosted_media_urls = _as_text_list(post_row.get("hosted_media_urls"))
@@ -17218,7 +17556,7 @@ def _platform_post_repair_reasons(platform: str, post_row: dict[str, Any]) -> li
         reasons.append("missing_source_avatar")
     if avatar_state.get("missing_hosted_avatar"):
         reasons.append("missing_hosted_avatar")
-    if _platform_post_has_stale_media_asset_meta(post_row):
+    if _platform_post_has_stale_media_asset_meta(post_row, conn=conn):
         reasons.append("stale_media_metadata")
 
     deduped: list[str] = []
@@ -17287,18 +17625,23 @@ def _platform_post_needs_media_asset_repair(platform: str, post_row: dict[str, A
     return False
 
 
-def _platform_post_needs_media_mirror(platform: str, post_row: dict[str, Any]) -> bool:
+def _platform_post_needs_media_mirror(
+    platform: str,
+    post_row: dict[str, Any],
+    *,
+    conn: Any | None = None,
+) -> bool:
     if _platform_post_needs_media_asset_repair(platform, post_row):
         return True
     if _platform_post_avatar_repair_state(platform, post_row).get("needs_repair"):
         return True
-    if _platform_post_has_stale_media_asset_meta(post_row):
+    if _platform_post_has_stale_media_asset_meta(post_row, conn=conn):
         return True
     return False
 
 
-def _instagram_post_needs_media_mirror(post_row: dict[str, Any]) -> bool:
-    return _platform_post_needs_media_mirror("instagram", post_row)
+def _instagram_post_needs_media_mirror(post_row: dict[str, Any], *, conn: Any | None = None) -> bool:
+    return _platform_post_needs_media_mirror("instagram", post_row, conn=conn)
 
 
 def _platform_comment_media_needs_mirror(platform: str, comment_row: dict[str, Any]) -> bool:
@@ -17342,7 +17685,7 @@ def _update_platform_post_field(
     table = PLATFORM_POST_TABLES.get(normalized_platform)
     if not table or not field:
         return
-    if not _platform_posts_has_column(normalized_platform, field):
+    if not _platform_posts_has_column(normalized_platform, field, conn=conn):
         return
     sql = f"update social.{table} set {field} = %s where id = %s::uuid"
     with pg.db_cursor(conn=conn) as cur:
@@ -17379,27 +17722,31 @@ def _update_platform_post_media_mirror_fields(
         params.append(value)
 
     if hosted_thumbnail_url is not FIELD_UNSET and _platform_posts_has_column(
-        normalized_platform, "hosted_thumbnail_url"
+        normalized_platform, "hosted_thumbnail_url", conn=conn
     ):
         _add("hosted_thumbnail_url", hosted_thumbnail_url)
-    if hosted_media_urls is not FIELD_UNSET and _platform_posts_has_column(normalized_platform, "hosted_media_urls"):
+    if hosted_media_urls is not FIELD_UNSET and _platform_posts_has_column(
+        normalized_platform, "hosted_media_urls", conn=conn
+    ):
         _add("hosted_media_urls", list(hosted_media_urls or []), as_jsonb=True)
     if media_mirror_status is not FIELD_UNSET and _platform_posts_has_column(
-        normalized_platform, "media_mirror_status"
+        normalized_platform, "media_mirror_status", conn=conn
     ):
         _add("media_mirror_status", media_mirror_status)
-    if media_mirror_error is not FIELD_UNSET and _platform_posts_has_column(normalized_platform, "media_mirror_error"):
+    if media_mirror_error is not FIELD_UNSET and _platform_posts_has_column(
+        normalized_platform, "media_mirror_error", conn=conn
+    ):
         _add("media_mirror_error", media_mirror_error)
     if media_mirror_attempt_count is not FIELD_UNSET and _platform_posts_has_column(
-        normalized_platform, "media_mirror_attempt_count"
+        normalized_platform, "media_mirror_attempt_count", conn=conn
     ):
         _add("media_mirror_attempt_count", max(0, int(media_mirror_attempt_count)))
     if media_mirror_last_attempt_at is not FIELD_UNSET and _platform_posts_has_column(
-        normalized_platform, "media_mirror_last_attempt_at"
+        normalized_platform, "media_mirror_last_attempt_at", conn=conn
     ):
         _add("media_mirror_last_attempt_at", media_mirror_last_attempt_at)
     if media_mirror_last_job_id is not FIELD_UNSET and _platform_posts_has_column(
-        normalized_platform, "media_mirror_last_job_id"
+        normalized_platform, "media_mirror_last_job_id", conn=conn
     ):
         _add("media_mirror_last_job_id", media_mirror_last_job_id)
 
@@ -17449,8 +17796,8 @@ def _update_platform_post_media_asset_meta(
     table = PLATFORM_POST_TABLES.get(normalized_platform)
     if not table:
         return
-    has_raw_data = _platform_posts_has_column(normalized_platform, "raw_data")
-    has_asset_manifest = _platform_posts_has_column(normalized_platform, "asset_manifest")
+    has_raw_data = _platform_posts_has_column(normalized_platform, "raw_data", conn=conn)
+    has_asset_manifest = _platform_posts_has_column(normalized_platform, "asset_manifest", conn=conn)
     if not has_raw_data and not has_asset_manifest:
         return
     payload = dict(media_asset_meta or {})
@@ -17504,9 +17851,9 @@ def _update_instagram_post_source_media_fields(
         assignments.append(f"{column} = %s")
         params.append(value)
 
-    if thumbnail_url is not FIELD_UNSET and _instagram_posts_has_column("thumbnail_url"):
+    if thumbnail_url is not FIELD_UNSET and _instagram_posts_has_column("thumbnail_url", conn=conn):
         _add("thumbnail_url", thumbnail_url)
-    if media_urls is not FIELD_UNSET and _instagram_posts_has_column("media_urls"):
+    if media_urls is not FIELD_UNSET and _instagram_posts_has_column("media_urls", conn=conn):
         _add("media_urls", list(media_urls or []), as_jsonb=True)
 
     if not assignments:
@@ -17571,7 +17918,7 @@ def _enqueue_platform_media_mirror_job(
     source_id = _platform_source_id(normalized_platform, post_row)
     if not post_id:
         return None
-    if not _platform_post_needs_media_mirror(normalized_platform, post_row):
+    if not _platform_post_needs_media_mirror(normalized_platform, post_row, conn=conn):
         return None
 
     mirror_job_status = "queued" if is_queue_enabled() else "pending"
@@ -18370,7 +18717,11 @@ def _run_existing_post_details_refresh(
                             video_id,
                         )
         with pg.db_connection(label=f"{platform}-details-refresh-enqueue") as conn:
-            if not opts.details_refresh_skip_media_followups and _platform_post_needs_media_mirror(platform, post_row):
+            if not opts.details_refresh_skip_media_followups and _platform_post_needs_media_mirror(
+                platform,
+                post_row,
+                conn=conn,
+            ):
                 try:
                     mirror_job_id = _enqueue_platform_media_mirror_job(
                         context,
@@ -19279,7 +19630,7 @@ def _ingest_instagram(
                         if isinstance((gallery_metrics or {}).get("views_raw_candidates"), list)
                         else []
                     )
-                    needs_media_repair = _instagram_post_needs_media_mirror(existing_row)
+                    needs_media_repair = _instagram_post_needs_media_mirror(existing_row, conn=details_conn)
                     needs_detail_fetch = (
                         gallery_likes is None or gallery_comments is None or gallery_views is None or needs_media_repair
                     )
@@ -28003,6 +28354,18 @@ def _attached_followup_state_for_status(status: str | None, *, default: str = "p
     return default
 
 
+_ATTACHED_FOLLOWUP_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+_ATTACHED_FOLLOWUP_ACTIVE_STATES = {"queued", "pending", "retrying", "running", "attached", "cancelling"}
+
+
+def _coerce_attached_followup_state_for_status(status: str | None, state: str | None) -> str | None:
+    normalized_status = str(status or "").strip().lower()
+    normalized_state = str(state or "").strip().lower()
+    if normalized_status in _ATTACHED_FOLLOWUP_TERMINAL_STATUSES and normalized_state in _ATTACHED_FOLLOWUP_ACTIVE_STATES:
+        return normalized_status
+    return normalized_state or None
+
+
 def _build_attached_comments_followup(
     *,
     run_id: str | None,
@@ -28011,9 +28374,10 @@ def _build_attached_comments_followup(
     state: str | None = None,
 ) -> dict[str, Any]:
     normalized_status = str(status or "").strip().lower() or None
+    resolved_state = _coerce_attached_followup_state_for_status(normalized_status, state)
     return {
         "run_id": str(run_id or "").strip() or None,
-        "state": str(state or "").strip().lower() or _attached_followup_state_for_status(normalized_status),
+        "state": resolved_state or _attached_followup_state_for_status(normalized_status),
         "status": normalized_status or "pending",
         "source": str(source or "").strip().lower() or None,
     }
@@ -28030,13 +28394,13 @@ def _build_attached_media_followup(
 ) -> dict[str, Any]:
     normalized_job_ids = [str(item).strip() for item in list(enqueued_job_ids or []) if str(item).strip()]
     normalized_status = str(status or "").strip().lower() or None
+    resolved_state = _coerce_attached_followup_state_for_status(normalized_status, state)
     resolved_count = (
         _normalize_non_negative_int(enqueued_job_count) if enqueued_job_count is not None else len(normalized_job_ids)
     )
     return {
         "attachment_id": str(attachment_id or "").strip() or None,
-        "state": str(state or "").strip().lower()
-        or _attached_followup_state_for_status(normalized_status, default="pending"),
+        "state": resolved_state or _attached_followup_state_for_status(normalized_status, default="pending"),
         "status": normalized_status or ("completed" if resolved_count <= 0 else "queued"),
         "source": str(source or "").strip().lower() or None,
         "enqueued_job_ids": normalized_job_ids,
@@ -28214,6 +28578,8 @@ def _resolve_run_attached_followups(
     config = _metadata_dict(run_config)
     attached_followups = _normalize_attached_followups(config.get("attached_followups"))
     resolved: dict[str, dict[str, Any]] = {}
+    parent_status = str(run_status or "").strip().lower() or None
+    cancelled_or_failed_parent_status = parent_status if parent_status in {"cancelled", "failed"} else None
 
     comments_entry = dict(attached_followups.get("comments") or {})
     effective_comments_run_id = (
@@ -28229,11 +28595,16 @@ def _resolve_run_attached_followups(
             if effective_comments_run_id
             else str(comments_entry.get("status") or "").strip().lower() or None
         )
+        comments_source = str(comments_entry.get("source") or "new_run").strip().lower()
+        comments_state = str(comments_entry.get("state") or "").strip().lower() or None
+        if cancelled_or_failed_parent_status and not effective_comments_run_id and comments_source == "deferred_after_catalog":
+            effective_comments_status = cancelled_or_failed_parent_status
+            comments_state = cancelled_or_failed_parent_status
         resolved["comments"] = _build_attached_comments_followup(
             run_id=effective_comments_run_id,
             status=effective_comments_status or comments_entry.get("status"),
-            source=str(comments_entry.get("source") or "new_run"),
-            state=str(comments_entry.get("state") or "").strip().lower() or None,
+            source=comments_source,
+            state=comments_state,
         )
 
     media_entry = dict(attached_followups.get("media") or {})
@@ -28269,12 +28640,21 @@ def _resolve_run_attached_followups(
         else:
             media_job_rows = []
         resolved_media_status = _aggregate_attached_job_status(media_job_rows)
+        media_state = str(media_entry.get("state") or "").strip().lower() or None
+        if (
+            cancelled_or_failed_parent_status
+            and media_source == "catalog_media_mirror"
+            and not enqueued_job_ids
+            and not media_job_rows
+        ):
+            resolved_media_status = cancelled_or_failed_parent_status
+            media_state = cancelled_or_failed_parent_status
         if resolved_media_status is None and media_source == "comments_media_followups":
             resolved_media_status = str((resolved.get("comments") or {}).get("status") or "").strip().lower() or None
         if resolved_media_status is None:
             fallback_status = str(media_entry.get("status") or "").strip().lower() or None
             if media_source == "catalog_media_mirror":
-                run_fallback_status = str(run_status or "").strip().lower() or None
+                run_fallback_status = parent_status
                 if run_fallback_status in {
                     "queued",
                     "pending",
@@ -28293,7 +28673,7 @@ def _resolve_run_attached_followups(
         resolved["media"] = _build_attached_media_followup(
             attachment_id=str(media_entry.get("attachment_id") or "").strip(),
             source=media_source or "catalog_media_mirror",
-            state=str(media_entry.get("state") or "").strip().lower() or None,
+            state=media_state,
             status=resolved_media_status,
             enqueued_job_ids=enqueued_job_ids,
             enqueued_job_count=max(
@@ -28317,7 +28697,7 @@ def _enqueue_instagram_account_media_repair_jobs(
     rows = _load_existing_social_account_posts("instagram", normalized_account, None, None)
     enqueued_job_ids: list[str] = []
     for row in rows:
-        if not _platform_post_needs_media_mirror("instagram", row):
+        if not _platform_post_needs_media_mirror("instagram", row, conn=conn):
             continue
         mirror_job_id = _enqueue_instagram_media_mirror_job(
             None,
@@ -28668,7 +29048,13 @@ def _catalog_recent_runs_header(
             or selected_tasks
         )
         row["comments_run_id"] = str(run_config.get("comments_run_id") or "").strip() or None
-        row["attached_followups"] = _normalize_attached_followups(run_config.get("attached_followups"))
+        row["attached_followups"] = _resolve_run_attached_followups(
+            run_config=run_config,
+            run_id=str(row.get("run_id") or "").strip() or None,
+            run_status=str(row.get("status") or "").strip().lower() or None,
+            comments_run_id=row["comments_run_id"],
+            conn=conn,
+        )
         normalized_rows.append(_lite_social_account_catalog_run(row))
     return normalized_rows
 
@@ -28713,10 +29099,13 @@ def _load_social_account_catalog_run_row(
     account_handle: str,
     run_id: str,
     conn: Any | None = None,
+    verify_account: bool = True,
+    pool_name: str = "default",
 ) -> dict[str, Any]:
     normalized_platform = _normalize_social_account_profile_platform(platform)
     normalized_account = _normalize_social_account_profile_handle(account_handle)
-    _assert_social_account_profile_exists(normalized_platform, normalized_account)
+    if verify_account:
+        _assert_social_account_profile_exists(normalized_platform, normalized_account)
     run_row = pg.fetch_one(
         """
         select
@@ -28737,6 +29126,7 @@ def _load_social_account_catalog_run_row(
         """,
         [run_id, SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE],
         conn=conn,
+        pool_name=pool_name,
     )
     if not run_row:
         raise LookupError("Catalog run not found.")
@@ -28777,6 +29167,7 @@ def _load_social_account_catalog_jobs(
     platform: str,
     account_handle: str,
     features: Mapping[str, Any] | None = None,
+    pool_name: str = "default",
 ) -> list[dict[str, Any]]:
     normalized_platform = _normalize_social_account_profile_platform(platform)
     normalized_account = _normalize_social_account_profile_handle(account_handle)
@@ -28808,6 +29199,7 @@ def _load_social_account_catalog_jobs(
         order by coalesce(j.completed_at, j.started_at, j.created_at) desc, j.created_at desc
         """,
         [run_id, normalized_platform, normalized_account],
+        pool_name=pool_name,
     )
 
 
@@ -28832,16 +29224,6 @@ def _repair_finalizing_catalog_launch_after_jobs(
         return None
     run_config = _metadata_dict(run_row.get("config"))
     launch_state = str(run_config.get("launch_state") or "").strip().lower()
-    if launch_state != "finalizing" or not _catalog_launch_task_resolution_pending(
-        run_config.get("launch_task_resolution_pending")
-    ):
-        return None
-
-    run_id = str(run_row.get("run_id") or run_row.get("id") or "").strip()
-    if not run_id:
-        return None
-    normalized_platform = _normalize_social_account_profile_platform(platform)
-    normalized_account = _normalize_social_account_profile_handle(account_handle)
     selected_tasks = _normalize_optional_social_account_catalog_backfill_selected_tasks(
         run_config.get("selected_tasks")
     )
@@ -28850,8 +29232,23 @@ def _repair_finalizing_catalog_launch_after_jobs(
         or selected_tasks
     )
     launch_group_id = str(run_config.get("launch_group_id") or "").strip() or None
-    source_scope = str(run_config.get("source_scope") or run_row.get("source_scope") or "bravo").strip() or "bravo"
     attached_followups = _normalize_attached_followups(run_config.get("attached_followups"))
+    comments_followup_missing = "comments" in effective_selected_tasks and not attached_followups.get("comments")
+    media_followup_missing = bool(
+        "media" in effective_selected_tasks and launch_group_id and not attached_followups.get("media")
+    )
+    finalizing_metadata_incomplete = launch_state == "finalizing" and _catalog_launch_task_resolution_pending(
+        run_config.get("launch_task_resolution_pending")
+    )
+    if not finalizing_metadata_incomplete and not comments_followup_missing and not media_followup_missing:
+        return None
+
+    run_id = str(run_row.get("run_id") or run_row.get("id") or "").strip()
+    if not run_id:
+        return None
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    source_scope = str(run_config.get("source_scope") or run_row.get("source_scope") or "bravo").strip() or "bravo"
     metadata_updates: dict[str, Any] = {
         "launch_state": "ready",
         "launch_task_resolution_pending": False,
@@ -28859,14 +29256,16 @@ def _repair_finalizing_catalog_launch_after_jobs(
         "selected_tasks": selected_tasks,
         "effective_selected_tasks": effective_selected_tasks,
     }
+    if comments_followup_missing or media_followup_missing:
+        metadata_updates["catalog_followups_disabled"] = False
 
-    if "comments" in effective_selected_tasks and not attached_followups.get("comments"):
+    if comments_followup_missing:
         deferred_comments_followup = {
             "state": "pending",
             "platform": normalized_platform,
             "account_handle": normalized_account,
             "source_scope": source_scope,
-            "refresh_policy": "all_saved_posts",
+            "refresh_policy": "stale_or_missing",
             "comments_enable_media_followups": "media" in effective_selected_tasks,
             "allow_local_dev_inline_bypass": bool(run_config.get("allow_local_dev_inline_bypass")),
             "launch_group_id": launch_group_id,
@@ -28882,7 +29281,7 @@ def _repair_finalizing_catalog_launch_after_jobs(
             source="deferred_after_catalog",
             state="pending",
         )
-    if "media" in effective_selected_tasks and launch_group_id and not attached_followups.get("media"):
+    if media_followup_missing:
         attached_followups["media"] = _build_attached_media_followup(
             attachment_id=_catalog_media_attachment_id(launch_group_id),
             source="catalog_media_mirror",
@@ -30565,7 +30964,7 @@ def _persist_shared_catalog_posts_batch(
                     if not row:
                         continue
                     materialized_rows.append(row)
-                    if enable_media_followups and _platform_post_needs_media_mirror("instagram", row):
+                    if enable_media_followups and _platform_post_needs_media_mirror("instagram", row, conn=conn):
                         mirror_job_id = _enqueue_instagram_media_mirror_job(
                             None,
                             run_id=run_id,
@@ -30574,6 +30973,7 @@ def _persist_shared_catalog_posts_batch(
                             post_row=dict(row),
                             week_index=None,
                             parent_job_id=job_id,
+                            conn=conn,
                         )
                         if mirror_job_id:
                             media_mirror_jobs_enqueued += 1
@@ -31695,6 +32095,12 @@ def _scrape_shared_instagram_post_details_refresh(
             _coerce_dt(config.get("date_start")),
             _coerce_dt(config.get("date_end")),
         )
+        expected_total_posts = _shared_account_expected_total_posts_from_config(
+            config,
+            platform="instagram",
+            account_handle=account_handle,
+        )
+        progress_total_posts = max(len(existing_posts), expected_total_posts)
         skip_detail_fetch = bool(config.get("details_refresh_skip_detail_fetch"))
         metrics_pages_scanned = 0
         metrics_posts_checked = 0
@@ -31708,7 +32114,7 @@ def _scrape_shared_instagram_post_details_refresh(
                 "posts_checked": posts_checked,
                 "matched_posts": saved_posts,
                 "saved_posts": saved_posts,
-                "total_posts": len(existing_posts),
+                "total_posts": progress_total_posts,
             }
             progress_cb(payload)
 
@@ -31946,6 +32352,9 @@ def _scrape_shared_instagram_post_details_refresh(
 
     retrieval_meta: dict[str, Any] = {
         "source": "db_metrics_refresh",
+        "expected_total_posts": expected_total_posts or None,
+        "total_posts": progress_total_posts or None,
+        "completion_target_posts": progress_total_posts or None,
         "details_refreshed_posts": details_refreshed_posts,
         "details_refresh_views_updated": details_refresh_views_updated,
         "details_refresh_views_preserved_missing": details_refresh_views_preserved_missing,
@@ -34092,15 +34501,24 @@ def _run_shared_account_posts_stage(
     completion_tolerance_applied = (
         is_tiktok_empty_body_fallback and missing_posts > 0 and missing_posts <= completion_tolerance_posts
     )
+    normalized_platform = _normalize_platform_name(platform)
+    catalog_action_scope = str(config.get("catalog_action_scope") or "").strip().lower()
+    is_catalog_details_refresh = (
+        normalized_platform == "instagram"
+        and _shared_catalog_mode(config)
+        and str(config.get("ingest_mode") or "").strip().lower() == "details_refresh"
+        and catalog_action_scope in {"", "full_history"}
+    )
     if (
-        is_single_runner_fallback
+        (is_single_runner_fallback or is_catalog_details_refresh)
         and completion_target_posts > 0
         and missing_posts > 0
         and not completion_tolerance_applied
     ):
+        failure_context = "details refresh" if is_catalog_details_refresh else "fallback"
         raise SharedStageRuntimeError(
             (
-                f"Shared-account fallback ended early for @{account_handle}: "
+                f"Shared-account {failure_context} ended early for @{account_handle}: "
                 f"checked {scraped_posts} of {completion_target_posts} discovered posts"
             ),
             error_code="catalog_incomplete",
@@ -34108,6 +34526,11 @@ def _run_shared_account_posts_stage(
             runtime_metadata={
                 "retrieval_meta": {
                     **dict(retrieval_meta or {}),
+                    "completion_failure_reason": (
+                        "details_refresh_missing_catalog_posts"
+                        if is_catalog_details_refresh
+                        else "fallback_missing_catalog_posts"
+                    ),
                     "expected_total_posts": expected_total_posts,
                     "completion_target_posts": completion_target_posts,
                     "observed_posts_checked": scraped_posts,
@@ -35219,7 +35642,7 @@ def _current_modal_dispatch_running_counts() -> tuple[
     by_run_stage_platform: dict[tuple[str, str, str], int] = {}
     active_accounts_by_stage_platform: dict[tuple[str, str], set[str]] = {}
     for row in rows:
-        stage = _normalize_social_job_stage_for_stale(row.get("stage")) or "unknown"
+        stage = _modal_dispatch_capacity_stage(row.get("stage"))
         platform = _normalize_platform_name(row.get("platform")) or "unknown"
         run_id = str(row.get("run_id") or "").strip()
         ingest_mode = _resolve_pipeline_ingest_mode(row.get("pipeline_ingest_mode"))
@@ -35246,6 +35669,9 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
         return {"dispatched_job_ids": [], "dispatch_attempts": 0, "reason": "queue_disabled"}
     if not is_modal_remote_executor_enabled():
         return {"dispatched_job_ids": [], "dispatch_attempts": 0, "reason": "remote_executor_not_modal"}
+    recovered_capacity = (
+        recover_failed_instagram_comments_capacity_jobs(run_id=run_id, limit=max(safe_limit, 25)) if run_id else []
+    )
     recovered_blocked = recover_dispatch_blocked_no_progress_jobs(limit=max(safe_limit, 25))
     resolution = _modal_social_dispatch_resolution()
     ready = bool(resolution.get("resolved"))
@@ -35266,6 +35692,9 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
             "reason": reason,
             "recovered_dispatch_blocked_job_ids": [
                 str(row.get("id") or "").strip() for row in recovered_blocked if str(row.get("id") or "").strip()
+            ],
+            "recovered_capacity_job_ids": [
+                str(row.get("id") or "").strip() for row in recovered_capacity if str(row.get("id") or "").strip()
             ],
         }
 
@@ -35299,6 +35728,7 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
         if len(dispatched_job_ids) >= safe_limit:
             break
         stage = _job_stage_from_row(job)
+        capacity_stage = _modal_dispatch_capacity_stage(stage)
         platform = _normalize_platform_name(job.get("platform")) or "unknown"
         job_run_id = str(job.get("run_id") or "").strip()
         job_config = _metadata_dict(job.get("config"))
@@ -35321,26 +35751,30 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
             )
             inspection_status = str(inspection.get("status") or "").strip().lower()
             if _modal_invocation_is_nonterminal(inspection_status):
-                running_by_stage[stage] = running_by_stage.get(stage, 0) + 1
-                running_by_stage_platform[(stage, platform)] = running_by_stage_platform.get((stage, platform), 0) + 1
+                running_by_stage[capacity_stage] = running_by_stage.get(capacity_stage, 0) + 1
+                running_by_stage_platform[(capacity_stage, platform)] = (
+                    running_by_stage_platform.get((capacity_stage, platform), 0) + 1
+                )
                 nonterminal_account = _resolve_dispatch_account_handle(job_config)
                 if nonterminal_account:
-                    active_accounts_by_stage_platform.setdefault((stage, platform), set()).add(nonterminal_account)
+                    active_accounts_by_stage_platform.setdefault((capacity_stage, platform), set()).add(
+                        nonterminal_account
+                    )
                 if job_run_id:
                     running_by_run[job_run_id] = running_by_run.get(job_run_id, 0) + 1
                     if job_ingest_mode == SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE:
-                        key = (job_run_id, stage, platform)
+                        key = (job_run_id, capacity_stage, platform)
                         running_by_run_stage_platform[key] = running_by_run_stage_platform.get(key, 0) + 1
                 continue
             if inspection_status == "unknown":
                 continue
         if _dispatch_request_is_fresh(job):
             continue
-        if running_by_stage.get(stage, 0) >= _modal_dispatch_stage_global_cap(stage):
+        if running_by_stage.get(capacity_stage, 0) >= _modal_dispatch_stage_global_cap(stage):
             continue
         # Compute prospective account count: existing active accounts + this candidate
         candidate_account = _resolve_dispatch_account_handle(job_config)
-        sp_key = (stage, platform)
+        sp_key = (capacity_stage, platform)
         existing_accounts = active_accounts_by_stage_platform.get(sp_key, set())
         prospective_accounts = existing_accounts | {candidate_account} if candidate_account else existing_accounts
         effective_cap = _modal_dispatch_effective_platform_cap(
@@ -35414,14 +35848,16 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
                 dispatch_blocked_first_seen_at=None,
             )
             dispatched_job_ids.append(job_id)
-            running_by_stage[stage] = running_by_stage.get(stage, 0) + 1
-            running_by_stage_platform[(stage, platform)] = running_by_stage_platform.get((stage, platform), 0) + 1
+            running_by_stage[capacity_stage] = running_by_stage.get(capacity_stage, 0) + 1
+            running_by_stage_platform[(capacity_stage, platform)] = (
+                running_by_stage_platform.get((capacity_stage, platform), 0) + 1
+            )
             if candidate_account:
-                active_accounts_by_stage_platform.setdefault((stage, platform), set()).add(candidate_account)
+                active_accounts_by_stage_platform.setdefault((capacity_stage, platform), set()).add(candidate_account)
             if job_run_id:
                 running_by_run[job_run_id] = running_by_run.get(job_run_id, 0) + 1
                 if job_ingest_mode == SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE:
-                    key = (job_run_id, stage, platform)
+                    key = (job_run_id, capacity_stage, platform)
                     running_by_run_stage_platform[key] = running_by_run_stage_platform.get(key, 0) + 1
         else:
             dispatch_reason = str(dispatch_result.get("reason") or "dispatch_failed")
@@ -35505,6 +35941,9 @@ def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = N
         ],
         "recovered_dispatch_blocked_job_ids": [
             str(row.get("id") or "").strip() for row in recovered_blocked if str(row.get("id") or "").strip()
+        ],
+        "recovered_capacity_job_ids": [
+            str(row.get("id") or "").strip() for row in recovered_capacity if str(row.get("id") or "").strip()
         ],
         "reason": None,
     }
@@ -36315,8 +36754,6 @@ def _fetch_next_preclaimed_job(
 
 
 def _stage_claim_candidates(stage: str | None) -> tuple[str | None, ...]:
-    if stage == "comments":
-        return ("comments", "posts")
     return (stage,)
 
 
@@ -37274,6 +37711,7 @@ def ingest_shared_accounts(
         if details_refresh_skip_media_followups is not None
         else details_refresh_only
     )
+    catalog_followups_disabled = bool(details_refresh_only and effective_details_refresh_skip_media_followups)
     full_history_partition_enabled = (
         normalized_ingest_mode == SHARED_ACCOUNT_CATALOG_BACKFILL_INGEST_MODE
         and not bounded_window
@@ -37436,7 +37874,7 @@ def ingest_shared_accounts(
     run_config = {
         "pipeline_ingest_mode": normalized_ingest_mode,
         "ingest_mode_override": "details_refresh" if details_refresh_only else None,
-        "catalog_followups_disabled": details_refresh_only,
+        "catalog_followups_disabled": catalog_followups_disabled,
         "details_refresh_skip_detail_fetch": effective_details_refresh_skip_detail_fetch,
         "details_refresh_skip_media_followups": effective_details_refresh_skip_media_followups,
         "tiktok_comments_in_posts_stage": bool(tiktok_comments_in_posts_stage),
@@ -37559,7 +37997,7 @@ def ingest_shared_accounts(
                         "ingest_mode": "details_refresh" if details_refresh_only else None,
                         "max_posts_per_target": 0,
                         "pipeline_ingest_mode": normalized_ingest_mode,
-                        "catalog_followups_disabled": details_refresh_only,
+                        "catalog_followups_disabled": catalog_followups_disabled,
                         "details_refresh_skip_detail_fetch": effective_details_refresh_skip_detail_fetch,
                         "details_refresh_skip_media_followups": effective_details_refresh_skip_media_followups,
                         "tiktok_comments_in_posts_stage": bool(platform == "tiktok" and tiktok_comments_in_posts_stage),
@@ -37614,7 +38052,7 @@ def ingest_shared_accounts(
                 "shared_account_source_id": row.get("id"),
                 "ingest_mode": "details_refresh" if details_refresh_only else None,
                 "pipeline_ingest_mode": normalized_ingest_mode,
-                "catalog_followups_disabled": details_refresh_only,
+                "catalog_followups_disabled": catalog_followups_disabled,
                 "details_refresh_skip_detail_fetch": effective_details_refresh_skip_detail_fetch,
                 "details_refresh_skip_media_followups": effective_details_refresh_skip_media_followups,
                 "tiktok_comments_in_posts_stage": bool(platform == "tiktok" and tiktok_comments_in_posts_stage),
@@ -38420,7 +38858,7 @@ def requeue_media_mirror_jobs(
             if failed_only and mirror_status not in {"failed", "partial"}:
                 skipped += 1
                 continue
-            if not _platform_post_needs_media_mirror(normalized_platform, row):
+            if not _platform_post_needs_media_mirror(normalized_platform, row, conn=conn):
                 skipped += 1
                 continue
             week_index: int | None = None
@@ -38694,6 +39132,8 @@ def _normalize_run_progress_stage(stage: Any) -> str:
 
 
 def _run_progress_stage_bucket(stage: str) -> str:
+    if stage == INSTAGRAM_COMMENTS_SCRAPLING_STAGE:
+        return "comments"
     return (
         stage
         if stage
@@ -38871,6 +39311,25 @@ def _format_run_progress_activity_summary(metadata: dict[str, Any]) -> str:
     if "matched_posts" in activity:
         parts.append(f"{_normalize_non_negative_int(activity.get('matched_posts'))}match")
     return " · ".join(part for part in parts if part)
+
+
+def _run_progress_event_timestamp(row: Mapping[str, Any], metadata: Mapping[str, Any]) -> datetime | None:
+    completed_at = _coerce_dt(row.get("completed_at"))
+    if isinstance(completed_at, datetime):
+        return completed_at
+    activity = _metadata_dict(metadata.get("activity"))
+    for value in (
+        activity.get("last_progress_at"),
+        activity.get("updated_at"),
+        activity.get("heartbeat_at"),
+        activity.get("last_heartbeat_at"),
+        metadata.get("last_progress_at"),
+        metadata.get("updated_at"),
+    ):
+        timestamp = _coerce_dt(value)
+        if isinstance(timestamp, datetime):
+            return timestamp
+    return _coerce_dt(row.get("started_at") or row.get("created_at"))
 
 
 def _summarize_run_progress_job_rows(job_rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
@@ -39674,6 +40133,10 @@ def _build_run_progress_snapshot_payload(
         platform = _normalize_platform_name(row.get("platform")) or "unknown"
         status = str(row.get("status") or "").strip().lower() or "unknown"
         stage = _run_progress_stage_from_row(row)
+        configured_stage = _normalize_run_progress_stage(config.get("stage") or metadata.get("stage"))
+        is_comments_scrapling_stage = stage == INSTAGRAM_COMMENTS_SCRAPLING_STAGE or (
+            configured_stage == INSTAGRAM_COMMENTS_SCRAPLING_STAGE
+        )
         stage_bucket = _run_progress_stage_bucket(stage)
         account_handle = _run_progress_account_handle(config, metadata)
         scraped_count, saved_count = _run_progress_stage_counters(metadata, row.get("items_found"))
@@ -39692,14 +40155,17 @@ def _build_run_progress_snapshot_payload(
         stage_payload["scraped_count"] += scraped_count
         stage_payload["saved_count"] += saved_count
 
-        if stage_bucket in {"posts", SHARED_ACCOUNT_POSTS_STAGE}:
+        if stage_bucket in {"posts", SHARED_ACCOUNT_POSTS_STAGE} or is_comments_scrapling_stage:
             retrieval_meta = _metadata_dict(metadata.get("retrieval_meta"))
             retrieval_persist = _metadata_dict(retrieval_meta.get("persist_counters"))
+            stage_counter_posts = _normalize_non_negative_int((metadata.get("stage_counters") or {}).get("posts"))
             activity_posts_checked = _normalize_non_negative_int(activity.get("posts_checked"))
+            if is_comments_scrapling_stage and stage_counter_posts > 0:
+                activity_posts_checked = min(activity_posts_checked or stage_counter_posts, stage_counter_posts)
             if activity_posts_checked <= 0:
                 activity_posts_checked = max(
                     _normalize_non_negative_int(retrieval_meta.get("posts_checked")),
-                    _normalize_non_negative_int((metadata.get("stage_counters") or {}).get("posts")),
+                    stage_counter_posts,
                     _normalize_non_negative_int(row.get("items_found")),
                 )
             completed_posts += activity_posts_checked
@@ -39781,7 +40247,7 @@ def _build_run_progress_snapshot_payload(
         if status == "running" and worker_id:
             active_worker_ids.add(worker_id)
 
-        timestamp = _coerce_dt(row.get("completed_at") or row.get("started_at") or row.get("created_at"))
+        timestamp = _run_progress_event_timestamp(row, metadata)
         ts_for_sort = timestamp if isinstance(timestamp, datetime) else None
         ts_label = (
             ts_for_sort.astimezone(ZoneInfo("America/New_York")).strftime("%-I:%M %p")
@@ -40190,6 +40656,10 @@ def _build_terminal_catalog_run_progress_payload(
         row_platform = _normalize_platform_name(row.get("platform")) or "unknown"
         status = str(row.get("status") or "").strip().lower() or "unknown"
         stage = _run_progress_stage_from_row(row)
+        configured_stage = _normalize_run_progress_stage(config.get("stage") or metadata.get("stage"))
+        is_comments_scrapling_stage = stage == INSTAGRAM_COMMENTS_SCRAPLING_STAGE or (
+            configured_stage == INSTAGRAM_COMMENTS_SCRAPLING_STAGE
+        )
         stage_bucket = _run_progress_stage_bucket(stage)
         row_account_handle = _run_progress_account_handle(config, metadata)
         scraped_count, saved_count = _run_progress_stage_counters(metadata, row.get("items_found"))
@@ -40208,14 +40678,17 @@ def _build_terminal_catalog_run_progress_payload(
         stage_payload["scraped_count"] += scraped_count
         stage_payload["saved_count"] += saved_count
 
-        if stage_bucket in {"posts", SHARED_ACCOUNT_POSTS_STAGE}:
+        if stage_bucket in {"posts", SHARED_ACCOUNT_POSTS_STAGE} or is_comments_scrapling_stage:
             retrieval_meta = _metadata_dict(metadata.get("retrieval_meta"))
             retrieval_persist = _metadata_dict(retrieval_meta.get("persist_counters"))
+            stage_counter_posts = _normalize_non_negative_int((metadata.get("stage_counters") or {}).get("posts"))
             activity_posts_checked = _normalize_non_negative_int(activity.get("posts_checked"))
+            if is_comments_scrapling_stage and stage_counter_posts > 0:
+                activity_posts_checked = min(activity_posts_checked or stage_counter_posts, stage_counter_posts)
             if activity_posts_checked <= 0:
                 activity_posts_checked = max(
                     _normalize_non_negative_int(retrieval_meta.get("posts_checked")),
-                    _normalize_non_negative_int((metadata.get("stage_counters") or {}).get("posts")),
+                    stage_counter_posts,
                     _normalize_non_negative_int(row.get("items_found")),
                 )
             completed_posts += activity_posts_checked
@@ -40297,7 +40770,7 @@ def _build_terminal_catalog_run_progress_payload(
         if status == "running" and worker_id:
             active_worker_ids.add(worker_id)
 
-        timestamp = _coerce_dt(row.get("completed_at") or row.get("started_at") or row.get("created_at"))
+        timestamp = _run_progress_event_timestamp(row, metadata)
         ts_for_sort = timestamp if isinstance(timestamp, datetime) else None
         ts_label = (
             ts_for_sort.astimezone(ZoneInfo("America/New_York")).strftime("%-I:%M %p")
@@ -40525,6 +40998,12 @@ def _build_terminal_catalog_run_progress_payload(
     )
     if total_posts > 0:
         post_progress["total_posts"] = total_posts
+        post_progress["completed_posts"] = min(completed_posts, total_posts)
+        post_progress["matched_posts"] = min(
+            _normalize_non_negative_int(post_progress.get("matched_posts")),
+            total_posts,
+        )
+        completed_posts = _normalize_non_negative_int(post_progress.get("completed_posts"))
     completion_gap_posts = max(total_posts - completed_posts, 0) if total_posts > 0 else 0
     payload["post_progress"] = post_progress
     payload["expected_total_posts"] = total_posts or None
@@ -40688,23 +41167,30 @@ def get_social_account_catalog_run_progress(
     run_id: str,
     *,
     recent_log_limit: int = 20,
+    fast: bool = False,
 ) -> dict[str, Any]:
     safe_recent_log_limit = max(1, min(int(recent_log_limit), 100))
     normalized_platform = _normalize_social_account_profile_platform(platform)
     normalized_account = _normalize_social_account_profile_handle(account_handle)
     if normalized_platform not in set(CATALOG_SUPPORTED_PLATFORMS):
         raise ValueError("Catalog backfill is not supported for this platform.")
-    if not _relation_exists("social.scrape_runs") or not _relation_exists("social.scrape_jobs"):
-        raise ValueError("social_ingest_queue_schema_missing")
-    features = _scrape_jobs_features()
-    if not bool(features.get("has_run_id")):
-        raise ValueError("run_progress_requires_scrape_jobs_run_id")
+    if fast:
+        features = {"has_run_id": True, "has_queue_fields": True}
+    else:
+        if not _relation_exists("social.scrape_runs") or not _relation_exists("social.scrape_jobs"):
+            raise ValueError("social_ingest_queue_schema_missing")
+        features = _scrape_jobs_features()
+        if not bool(features.get("has_run_id")):
+            raise ValueError("run_progress_requires_scrape_jobs_run_id")
+    read_pool_name = SOCIAL_CATALOG_PROGRESS_POOL_NAME if fast else "default"
 
     try:
         run_row = _load_social_account_catalog_run_row(
             platform=normalized_platform,
             account_handle=normalized_account,
             run_id=run_id,
+            verify_account=not fast,
+            pool_name=read_pool_name,
         )
     except LookupError as exc:
         raise ValueError("run_not_found") from exc
@@ -40730,6 +41216,7 @@ def get_social_account_catalog_run_progress(
         platform=normalized_platform,
         account_handle=normalized_account,
         features=features,
+        pool_name=read_pool_name,
     )
     if not job_rows:
         recovery_result = recover_pending_social_account_catalog_launch(
@@ -40743,6 +41230,8 @@ def get_social_account_catalog_run_progress(
                     platform=normalized_platform,
                     account_handle=normalized_account,
                     run_id=run_id,
+                    verify_account=not fast,
+                    pool_name=read_pool_name,
                 )
             except LookupError as exc:
                 raise ValueError("run_not_found") from exc
@@ -40752,6 +41241,7 @@ def get_social_account_catalog_run_progress(
                 platform=normalized_platform,
                 account_handle=normalized_account,
                 features=features,
+                pool_name=read_pool_name,
             )
         if not job_rows:
             run_config = _metadata_dict(run_row.get("config"))
@@ -40773,6 +41263,17 @@ def get_social_account_catalog_run_progress(
                     recent_log_limit=safe_recent_log_limit,
                 )
             raise ValueError("run_not_found")
+
+    if fast:
+        return _build_terminal_catalog_run_progress_payload(
+            run_row=run_row,
+            job_rows=job_rows,
+            run_id=run_id,
+            run_config=run_config,
+            platform=normalized_platform,
+            account_handle=normalized_account,
+            recent_log_limit=safe_recent_log_limit,
+        )
 
     repaired_run_config = _repair_finalizing_catalog_launch_after_jobs(
         run_row=run_row,
@@ -40956,6 +41457,15 @@ def get_social_account_catalog_run_progress(
         _normalize_non_negative_int(post_progress.get("matched_posts")),
         _normalize_non_negative_int(frontier_progress.get("posts_saved")),
     )
+    if progress_total_posts > 0:
+        post_progress["completed_posts"] = min(
+            _normalize_non_negative_int(post_progress.get("completed_posts")),
+            progress_total_posts,
+        )
+        post_progress["matched_posts"] = min(
+            _normalize_non_negative_int(post_progress.get("matched_posts")),
+            progress_total_posts,
+        )
     payload["post_progress"] = post_progress
     payload["expected_total_posts"] = expected_total_posts or None
     payload["source_total_posts_current"] = source_total_posts_current or None
@@ -52997,7 +53507,19 @@ def _social_account_profile_title_text(platform: str, row: Mapping[str, Any]) ->
 def _social_account_profile_content_text(platform: str, row: Mapping[str, Any]) -> str:
     normalized_platform = _normalize_social_account_profile_platform(platform)
     if normalized_platform == "instagram":
-        return str(_first_non_empty_str(row.get("caption"), row.get("text")) or "")
+        raw_data = _metadata_dict(row.get("raw_data"))
+        raw_caption = raw_data.get("caption")
+        raw_caption_text = raw_caption.get("text") if isinstance(raw_caption, Mapping) else raw_caption
+        return str(
+            _first_non_empty_str(
+                row.get("caption"),
+                row.get("text"),
+                raw_caption_text,
+                raw_data.get("caption_text"),
+                raw_data.get("text"),
+            )
+            or ""
+        )
     if normalized_platform == "tiktok":
         raw_data = _metadata_dict(row.get("raw_data"))
         return str(
@@ -54114,12 +54636,45 @@ def _instagram_social_account_profile_dataset_rows(
     return dataset_rows
 
 
+def _normalize_social_account_profile_comment_filter(value: str | None) -> str | None:
+    normalized = str(value or "").strip().lower()
+    if not normalized or normalized == "all":
+        return None
+    if normalized not in SOCIAL_ACCOUNT_PROFILE_COMMENT_FILTERS:
+        allowed = ", ".join(sorted(SOCIAL_ACCOUNT_PROFILE_COMMENT_FILTERS))
+        raise ValueError(f"Unsupported comments post filter: {value}. Expected one of: {allowed}")
+    return normalized
+
+
+def _comments_only_profile_filter_where_sql(
+    *,
+    comment_filter: str | None,
+    reported_comments_sql: str,
+    saved_comments_sql: str,
+    reported_comments_is_normalized: bool = False,
+) -> str:
+    reported_comments = (
+        str(reported_comments_sql)
+        if reported_comments_is_normalized
+        else f"greatest(coalesce({reported_comments_sql}, 0), 0)"
+    )
+    saved_comments = f"greatest(coalesce({saved_comments_sql}, 0), 0)"
+    if comment_filter == "commentable":
+        return f"{reported_comments} > 0"
+    if comment_filter == "not_commentable":
+        return f"{reported_comments} = 0"
+    if comment_filter == "incomplete":
+        return f"{reported_comments} > 0 and {saved_comments} <> {reported_comments}"
+    return f"greatest({reported_comments}, {saved_comments}) > 0"
+
+
 def _fetch_materialized_comments_only_profile_rows_page(
     platform: str,
     account_handle: str,
     *,
     page: int,
     page_size: int,
+    comment_filter: str | None = None,
     conn: Any | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     normalized_platform = _normalize_social_account_profile_platform(platform)
@@ -54130,6 +54685,7 @@ def _fetch_materialized_comments_only_profile_rows_page(
             account_handle,
             page=page,
             page_size=page_size,
+            comment_filter=comment_filter,
             conn=conn,
         )
     table, source_id_column, posted_at_column = _social_account_profile_base_query_parts(normalized_platform)
@@ -54282,9 +54838,11 @@ def _fetch_instagram_owner_comments_only_profile_rows_page(
     *,
     page: int,
     page_size: int,
+    comment_filter: str | None = None,
     conn: Any | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
     normalized_account = _normalize_social_account_profile_handle(account_handle)
+    normalized_comment_filter = _normalize_social_account_profile_comment_filter(comment_filter)
     safe_page = max(1, int(page))
     safe_page_size = max(1, min(int(page_size), _SOCIAL_ACCOUNT_PROFILE_MAX_PAGE_SIZE))
     safe_offset = (safe_page - 1) * safe_page_size
@@ -54292,18 +54850,15 @@ def _fetch_instagram_owner_comments_only_profile_rows_page(
     active_filter = (
         "and c.is_missing is not true" if _comment_lifecycle_supported("instagram_comments", conn=conn) else ""
     )
-    eligible_posts_where_sql = f"""
-          {owner_match_clause}
-          and nullif(p.shortcode, '') is not null
-          and greatest(coalesce(p.comments_count, 0), 0) > 0
-    """
-    total_sql = f"""
-        select count(*)::int as total
-        from social.instagram_posts p
-        where {eligible_posts_where_sql}
-    """
-    page_sql = f"""
-        with page_rows as materialized (
+    reported_comments_expr = _instagram_reported_comments_sql("p")
+    filter_where_sql = _comments_only_profile_filter_where_sql(
+        comment_filter=normalized_comment_filter,
+        reported_comments_sql=_instagram_reported_comments_sql("candidate_rows"),
+        saved_comments_sql="saved_comment_counts.saved_comments",
+        reported_comments_is_normalized=True,
+    )
+    candidate_rows_sql = f"""
+        with candidate_rows as materialized (
           select
             p.id::text as id,
             p.id::text as profile_row_id,
@@ -54328,7 +54883,7 @@ def _fetch_instagram_owner_comments_only_profile_rows_page(
             coalesce(p.collaborators, '[]'::jsonb) as collaborators,
             coalesce(p.profile_tags, '[]'::jsonb) as profile_tags,
             coalesce(p.likes, 0)::bigint as likes,
-            coalesce(p.comments_count, 0)::bigint as comments_count,
+            {reported_comments_expr}::bigint as comments_count,
             coalesce(p.views, 0)::bigint as views,
             0::bigint as shares,
             0::bigint as retweets,
@@ -54341,26 +54896,42 @@ def _fetch_instagram_owner_comments_only_profile_rows_page(
           from social.instagram_posts p
           left join core.seasons s on s.id = p.season_id
           left join core.shows sh on sh.id = coalesce(p.show_id, s.show_id)
-          where {eligible_posts_where_sql}
-          order by p.posted_at desc nulls last, p.id desc
-          limit %s offset %s
+          where {owner_match_clause}
+            and nullif(p.shortcode, '') is not null
         ),
-        saved_comment_counts as (
+        saved_comment_counts as materialized (
           select
             c.post_id::text as profile_row_id,
             count(*)::int as saved_comments
           from social.instagram_comments c
-          where c.post_id in (select profile_row_id::uuid from page_rows)
+          join candidate_rows
+            on c.post_id = candidate_rows.profile_row_id::uuid
+          where 1 = 1
             {active_filter}
           group by c.post_id
+        ),
+        filtered_rows as materialized (
+          select
+            candidate_rows.*,
+            coalesce(saved_comment_counts.saved_comments, 0)::int as saved_comments
+          from candidate_rows
+          left join saved_comment_counts
+            on saved_comment_counts.profile_row_id = candidate_rows.profile_row_id
+          where {filter_where_sql}
         )
+    """
+    total_sql = f"""
+        {candidate_rows_sql}
+        select count(*)::int as total
+        from filtered_rows
+    """
+    page_sql = f"""
+        {candidate_rows_sql}
         select
-          page_rows.*,
-          coalesce(saved_comment_counts.saved_comments, 0)::int as saved_comments
-        from page_rows
-        left join saved_comment_counts
-          on saved_comment_counts.profile_row_id = page_rows.profile_row_id
+          *
+        from filtered_rows
         order by posted_at desc nulls last, id desc
+        limit %s offset %s
     """
     if conn is None:
         total_row = pg.fetch_one(total_sql, [normalized_account]) or {}
@@ -54379,13 +54950,16 @@ def _fetch_instagram_comments_only_profile_rows_page(
     *,
     page: int,
     page_size: int,
+    comment_filter: str | None = None,
     conn: Any | None = None,
 ) -> tuple[list[dict[str, Any]], int]:
+    normalized_comment_filter = _normalize_social_account_profile_comment_filter(comment_filter)
     if not _instagram_catalog_collaborator_membership_available(conn=conn):
         return _fetch_instagram_owner_comments_only_profile_rows_page(
             account_handle,
             page=page,
             page_size=page_size,
+            comment_filter=normalized_comment_filter,
             conn=conn,
         )
 
@@ -54396,6 +54970,13 @@ def _fetch_instagram_comments_only_profile_rows_page(
     owner_match_clause = _social_account_profile_owner_match_sql("instagram", alias="p")
     active_filter = (
         "and c.is_missing is not true" if _comment_lifecycle_supported("instagram_comments", conn=conn) else ""
+    )
+    reported_comments_expr = _instagram_reported_comments_sql("p")
+    filter_where_sql = _comments_only_profile_filter_where_sql(
+        comment_filter=normalized_comment_filter,
+        reported_comments_sql=_instagram_reported_comments_sql("d"),
+        saved_comments_sql="saved_comment_counts.saved_comments",
+        reported_comments_is_normalized=True,
     )
     candidate_rows_sql = f"""
         with owner_rows as materialized (
@@ -54429,7 +55010,7 @@ def _fetch_instagram_comments_only_profile_rows_page(
             coalesce(to_jsonb(p) -> 'collaborators_detail', '[]'::jsonb) as collaborators_detail,
             coalesce(p.profile_tags, '[]'::jsonb) as profile_tags,
             coalesce(p.likes, 0)::bigint as likes,
-            coalesce(p.comments_count, 0)::bigint as comments_count,
+            {reported_comments_expr}::bigint as comments_count,
             coalesce(p.views, 0)::bigint as views,
             0::bigint as shares,
             0::bigint as retweets,
@@ -54478,7 +55059,7 @@ def _fetch_instagram_comments_only_profile_rows_page(
               as collaborators_detail,
             coalesce(p.profile_tags, '[]'::jsonb) as profile_tags,
             coalesce(p.likes, 0)::bigint as likes,
-            coalesce(p.comments_count, 0)::bigint as comments_count,
+            {reported_comments_expr}::bigint as comments_count,
             coalesce(p.views, 0)::bigint as views,
             coalesce(p.shares, 0)::bigint as shares,
             coalesce(p.retweets, 0)::bigint as retweets,
@@ -54533,10 +55114,7 @@ def _fetch_instagram_comments_only_profile_rows_page(
           from deduped_rows d
           left join saved_comment_counts
             on saved_comment_counts.profile_row_id = d.profile_row_id
-          where greatest(
-            coalesce(d.comments_count, 0),
-            coalesce(saved_comment_counts.saved_comments, 0)
-          ) > 0
+          where {filter_where_sql}
         )
     """
     params = [normalized_account, normalized_account, normalized_account]
@@ -56018,7 +56596,7 @@ def get_social_account_profile_summary(
                     ),
                     fallback=lambda _exc: None,
                 )
-            if normalized_platform == "instagram" and normalized_detail == "full":
+            if normalized_platform == "instagram" and normalized_detail in {"full", "lite"}:
                 query_loaders["comments_coverage"] = lambda: _timed_social_account_profile_summary_query(
                     platform=normalized_platform,
                     account_handle=normalized_account,
@@ -56345,12 +56923,14 @@ def get_social_account_profile_posts(
     page_size: int = _SOCIAL_ACCOUNT_PROFILE_DEFAULT_PAGE_SIZE,
     search: str | None = None,
     comments_only: bool = False,
+    comment_filter: str | None = None,
 ) -> dict[str, Any]:
     normalized_platform = _normalize_social_account_profile_platform(platform)
     normalized_account = _normalize_social_account_profile_handle(account_handle)
     safe_page = max(1, int(page))
     safe_page_size = max(1, min(int(page_size), _SOCIAL_ACCOUNT_PROFILE_MAX_PAGE_SIZE))
     normalized_search = str(search or "").strip() or None
+    normalized_comment_filter = _normalize_social_account_profile_comment_filter(comment_filter)
     if normalized_platform == "instagram" and comments_only and normalized_search is None:
         with _social_account_profile_summary_connection("social-profile-posts-instagram-comments-only") as read_conn:
             _assert_social_account_profile_exists(normalized_platform, normalized_account, conn=read_conn)
@@ -56358,6 +56938,7 @@ def get_social_account_profile_posts(
                 normalized_account,
                 page=safe_page,
                 page_size=safe_page_size,
+                comment_filter=normalized_comment_filter,
                 conn=read_conn,
             )
     elif normalized_platform in {"tiktok", "twitter", "youtube"} and comments_only and normalized_search is None:
@@ -56439,18 +57020,19 @@ def _instagram_social_account_comments_target_counts(
         if _call_profile_summary_loader_with_conn(_comment_lifecycle_supported, "instagram_comments", conn=conn)
         else "count(c.id)::bigint"
     )
+    reported_comments_expr = _instagram_reported_comments_sql("p")
     sql = f"""
             with posts as (
               select
                 p.id,
-                greatest(0, coalesce(p.comments_count, 0))::bigint as reported_comments,
+                {reported_comments_expr}::bigint as reported_comments,
                 {active_count_expr} as saved_comments,
                 max(coalesce(c.last_seen_at, c.scraped_at)) as last_seen_at
               from social.instagram_posts p
               left join social.instagram_comments c on c.post_id = p.id
               where {owner_match_clause}
                 and nullif(p.shortcode, '') is not null
-              group by p.id
+              group by p.id, p.comments_count, p.raw_data
             )
             select
               count(*)::int as available_posts,
@@ -56503,6 +57085,301 @@ def _instagram_social_account_comments_target_counts(
     }
 
 
+def _instagram_comments_target_priority(refresh_policy: str) -> str:
+    normalized_refresh_policy = str(refresh_policy or "stale_or_missing").strip().lower() or "stale_or_missing"
+    if normalized_refresh_policy == "all_saved_posts":
+        target_priority = str(
+            os.getenv("SOCIAL_INSTAGRAM_COMMENTS_TARGET_PRIORITY", "gap_first") or "gap_first"
+        ).strip().lower()
+        return target_priority if target_priority in {"gap_first", "posted_at_desc"} else "gap_first"
+    return "missing_first_recent"
+
+
+def _normalize_instagram_comments_target_filter(value: str | None) -> str | None:
+    normalized = str(value or "").strip().lower()
+    if not normalized or normalized == "all":
+        return None
+    if normalized != "incomplete":
+        raise SocialIngestValidationError(
+            "SOCIAL_ACCOUNT_COMMENTS_INVALID_TARGET_FILTER",
+            "Profile comments scraping supports target_filter=incomplete.",
+        )
+    return normalized
+
+
+def _instagram_comments_target_preview_cache_ttl_seconds() -> int:
+    raw = str(os.getenv("SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS") or "").strip()
+    if not raw:
+        return SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS_DEFAULT
+    try:
+        return max(0, min(int(raw), 3600))
+    except ValueError:
+        return SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS_DEFAULT
+
+
+def _get_instagram_comments_target_preview_cache(
+    cache_key: tuple[Any, ...],
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    ttl_seconds = _instagram_comments_target_preview_cache_ttl_seconds()
+    cache_metadata = {
+        "enabled": ttl_seconds > 0,
+        "hit": False,
+        "age_seconds": None,
+        "ttl_seconds": ttl_seconds,
+    }
+    if ttl_seconds <= 0:
+        return None, cache_metadata
+    now_monotonic = time_module.monotonic()
+    with _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_LOCK:
+        cached = _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE.get(cache_key)
+        if not cached:
+            return None, cache_metadata
+        cached_at, cached_payload = cached
+        age_seconds = max(0.0, now_monotonic - cached_at)
+        if age_seconds > ttl_seconds:
+            _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE.pop(cache_key, None)
+            return None, cache_metadata
+        cache_metadata.update({"hit": True, "age_seconds": round(age_seconds, 3)})
+        return copy.deepcopy(cached_payload), cache_metadata
+
+
+def _set_instagram_comments_target_preview_cache(cache_key: tuple[Any, ...], payload: dict[str, Any]) -> None:
+    ttl_seconds = _instagram_comments_target_preview_cache_ttl_seconds()
+    if ttl_seconds <= 0:
+        return
+    with _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_LOCK:
+        if len(_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE) >= 128:
+            oldest_key = min(
+                _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE,
+                key=lambda key: _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE[key][0],
+            )
+            _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE.pop(oldest_key, None)
+        _INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE[cache_key] = (time_module.monotonic(), copy.deepcopy(payload))
+
+
+def _instagram_social_account_comment_target_preview(
+    account_handle: str,
+    *,
+    limit: int | None,
+    refresh_policy: str = "stale_or_missing",
+    target_filter: str | None = None,
+    sample_limit: int = 12,
+) -> dict[str, Any]:
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    normalized_refresh_policy = str(refresh_policy or "stale_or_missing").strip().lower() or "stale_or_missing"
+    normalized_target_filter = _normalize_instagram_comments_target_filter(target_filter)
+    if normalized_refresh_policy not in {"stale_or_missing", "all_saved_posts"}:
+        raise SocialIngestValidationError(
+            "SOCIAL_ACCOUNT_COMMENTS_INVALID_REFRESH_POLICY",
+            "Profile comments scraping supports stale_or_missing and all_saved_posts refreshes.",
+        )
+    safe_limit = None if limit is None else max(1, min(int(limit), 500))
+    safe_sample_limit = max(1, min(int(sample_limit or 12), 50))
+    if safe_limit is not None:
+        safe_sample_limit = min(safe_sample_limit, safe_limit)
+    target_priority = _instagram_comments_target_priority(normalized_refresh_policy)
+    cache_key = (
+        "instagram_comments_target_preview",
+        normalized_account,
+        normalized_refresh_policy,
+        normalized_target_filter,
+        target_priority,
+        safe_limit,
+        safe_sample_limit,
+    )
+    total_started_at = time_module.perf_counter()
+    cache_lookup_started_at = time_module.perf_counter()
+    cached_payload, cache_metadata = _get_instagram_comments_target_preview_cache(cache_key)
+    cache_lookup_ms = round((time_module.perf_counter() - cache_lookup_started_at) * 1000, 1)
+    if cached_payload is not None:
+        timing = _metadata_dict(cached_payload.get("timing"))
+        timing.update(
+            {
+                "cache_lookup_ms": cache_lookup_ms,
+                "total_ms": round((time_module.perf_counter() - total_started_at) * 1000, 1),
+            }
+        )
+        cached_payload["timing"] = timing
+        cached_payload["preview_cache"] = cache_metadata
+        cached_payload["cache"] = cache_metadata
+        return cached_payload
+
+    query_started_at = time_module.perf_counter()
+    owner_match_clause = _social_account_profile_owner_match_sql("instagram", alias="p")
+    if normalized_target_filter == "incomplete":
+        target_source_ids = _instagram_social_account_incomplete_comment_target_shortcodes(
+            normalized_account,
+            limit=safe_limit,
+        )
+        raw_target_count = len(target_source_ids)
+        target_count = raw_target_count
+        sample_target_source_ids = target_source_ids[:safe_sample_limit]
+        query_ms = round((time_module.perf_counter() - query_started_at) * 1000, 1)
+    elif normalized_refresh_policy == "all_saved_posts":
+        table, source_id_column, posted_at_column = _shared_catalog_base_query_parts("instagram")
+        reported_comments_expr = _instagram_reported_comments_sql("p")
+        active_count_expr = (
+            "count(c.id) filter (where c.is_missing is not true)::bigint"
+            if _comment_lifecycle_supported("instagram_comments")
+            else "count(c.id)::bigint"
+        )
+        order_clause = (
+            "missing_comments_gap desc, reported_comments desc nulls last, posted_at desc nulls last, shortcode desc"
+            if target_priority == "gap_first"
+            else "posted_at desc nulls last, shortcode desc"
+        )
+        sql = f"""
+        with saved_posts as (
+          select
+            p.id as post_id,
+            p.shortcode::text as shortcode,
+            p.posted_at,
+            {reported_comments_expr}::bigint as reported_comments
+          from social.instagram_posts p
+          where {owner_match_clause}
+            and nullif(p.shortcode, '') is not null
+          union all
+          select
+            null::uuid as post_id,
+            p.{source_id_column}::text as shortcode,
+            p.{posted_at_column} as posted_at,
+            {reported_comments_expr}::bigint as reported_comments
+          from social.{table} p
+          where lower(p.source_account) = lower(%s)
+            and nullif(p.{source_id_column}::text, '') is not null
+        ),
+        deduped_posts as (
+          select
+            max(post_id) filter (where post_id is not null) as post_id,
+            shortcode,
+            max(posted_at) as posted_at,
+            max(reported_comments) as reported_comments
+          from saved_posts
+          group by shortcode
+        ),
+        saved_comment_counts as (
+          select
+            dp.shortcode,
+            {active_count_expr} as saved_comments
+          from deduped_posts dp
+          left join social.instagram_comments c on c.post_id = dp.post_id
+          group by dp.shortcode
+        ),
+        targets as (
+          select
+            dp.shortcode,
+            greatest(coalesce(dp.reported_comments, 0) - coalesce(scc.saved_comments, 0), 0) as missing_comments_gap,
+            dp.reported_comments,
+            dp.posted_at
+          from deduped_posts dp
+          left join saved_comment_counts scc on scc.shortcode = dp.shortcode
+        )
+        select
+          (select count(*)::int from targets) as raw_target_source_ids_count,
+          array(
+            select shortcode
+            from targets
+            order by {order_clause}
+            limit %s
+          ) as sample_target_source_ids
+        """
+        params: list[Any] = [normalized_account, normalized_account, safe_sample_limit]
+        row = pg.fetch_one(sql, params) or {}
+        query_ms = round((time_module.perf_counter() - query_started_at) * 1000, 1)
+        raw_target_count = _normalize_non_negative_int(row.get("raw_target_source_ids_count"))
+        target_count = min(raw_target_count, safe_limit) if safe_limit is not None else raw_target_count
+        sample_target_source_ids = _as_text_list(row.get("sample_target_source_ids"))[:safe_sample_limit]
+    else:
+        reported_comments_expr = _instagram_reported_comments_sql("p")
+        active_count_expr = (
+            "(count(c.id) filter (where c.is_missing = false))::bigint"
+            if _comment_lifecycle_supported("instagram_comments")
+            else "count(c.id)::bigint"
+        )
+        sql = f"""
+        with posts as (
+          select
+            p.shortcode,
+            p.posted_at,
+            {reported_comments_expr}::bigint as reported_comments,
+            {active_count_expr} as saved_comments,
+            max(coalesce(c.last_seen_at, c.scraped_at)) as last_seen_at
+          from social.instagram_posts p
+          left join social.instagram_comments c on c.post_id = p.id
+          where {owner_match_clause}
+            and nullif(p.shortcode, '') is not null
+            and {reported_comments_expr} > 0
+          group by p.shortcode, p.posted_at, p.comments_count, p.raw_data
+        ),
+        targets as (
+          select
+            shortcode,
+            posted_at,
+            reported_comments,
+            saved_comments,
+            last_seen_at
+          from posts
+          where reported_comments > 0
+            and (
+              saved_comments = 0
+              or saved_comments < reported_comments
+              or coalesce(last_seen_at, to_timestamp(0)) < now() - make_interval(hours => %s)
+            )
+        )
+        select
+          (select count(*)::int from targets) as raw_target_source_ids_count,
+          array(
+            select shortcode
+            from targets
+            order by
+              case when saved_comments = 0 then 0 else 1 end asc,
+              posted_at desc nulls last,
+              shortcode desc
+            limit %s
+          ) as sample_target_source_ids
+        """
+        params = [normalized_account, _instagram_comments_stale_after_hours(), safe_sample_limit]
+        row = pg.fetch_one(sql, params) or {}
+        query_ms = round((time_module.perf_counter() - query_started_at) * 1000, 1)
+        raw_target_count = _normalize_non_negative_int(row.get("raw_target_source_ids_count"))
+        target_count = min(raw_target_count, safe_limit) if safe_limit is not None else raw_target_count
+        sample_target_source_ids = _as_text_list(row.get("sample_target_source_ids"))[:safe_sample_limit]
+    shard_count = _instagram_comments_profile_shard_count(target_count)
+    payload = {
+        "target_source_ids_count": target_count,
+        "raw_target_source_ids_count": raw_target_count,
+        "sample_target_source_ids": sample_target_source_ids,
+        "comments_shard_count": shard_count,
+        "comments_sharding_enabled": shard_count > 1,
+        "recommended_comments_shard_count": _instagram_comments_recommended_shard_count(target_count=target_count),
+        "refresh_policy": normalized_refresh_policy,
+        "target_filter": normalized_target_filter,
+        "incomplete_fill": normalized_target_filter == "incomplete",
+        "target_priority": target_priority,
+        "timing": {
+            "target_preview_ms": query_ms,
+            "target_count_ms": query_ms,
+            "sample_target_source_ids_ms": query_ms,
+            "cache_lookup_ms": cache_lookup_ms,
+            "total_ms": round((time_module.perf_counter() - total_started_at) * 1000, 1),
+        },
+        "preview_cache": cache_metadata,
+        "cache": cache_metadata,
+        "debug": {
+            "target_plan_strategy": "bounded_profile_preview",
+            "bounded": True,
+            "full_target_list_built": False,
+            "sample_limit": safe_sample_limit,
+            "max_posts": safe_limit,
+            "query_refresh_policy": normalized_refresh_policy,
+            "query_target_filter": normalized_target_filter,
+            "raw_target_source_ids_count": raw_target_count,
+        },
+    }
+    _set_instagram_comments_target_preview_cache(cache_key, payload)
+    return payload
+
+
 def _instagram_comment_columns(*, conn: Any | None = None) -> set[str]:
     try:
         return _relation_columns("social", "instagram_comments", conn=conn)
@@ -56536,13 +57413,14 @@ def _instagram_social_account_lite_header_stats(
         comment_columns
     )
     active_comment_filter = "and c.is_missing is not true" if lifecycle_supported else ""
+    reported_comments_expr = _instagram_reported_comments_sql("p")
     sql = f"""
             with filtered_posts as materialized (
               select
                 p.id,
                 p.posted_at,
                 coalesce(p.likes, 0)::bigint as likes,
-                greatest(0, coalesce(p.comments_count, 0))::int as reported_comments,
+                {reported_comments_expr}::int as reported_comments,
                 coalesce(p.views, 0)::bigint as views,
                 coalesce(p.media_urls, '[]'::jsonb) as media_urls,
                 coalesce(p.hosted_media_urls, '[]'::jsonb) as hosted_media_urls,
@@ -56657,11 +57535,12 @@ def _instagram_social_account_comments_saved_summary(
     hosted_comment_media_urls_expr = _instagram_comment_jsonb_expr("hosted_media_urls", comment_columns)
     comment_media_urls_expr = _instagram_comment_jsonb_expr("media_urls", comment_columns)
     active_comment_filter = "and c.is_missing is not true" if lifecycle_supported else ""
+    reported_comments_expr = _instagram_reported_comments_sql("p")
     sql = f"""
             with filtered_posts as (
               select
                 p.id,
-                greatest(0, coalesce(p.comments_count, 0))::int as reported_comments
+                {reported_comments_expr}::int as reported_comments
               from social.instagram_posts p
               where {owner_match_clause}
                 and nullif(p.shortcode, '') is not null
@@ -56745,6 +57624,7 @@ def _instagram_social_account_detail_rollup(
         comment_columns,
     )
     active_comment_filter = "and c.is_missing is not true" if lifecycle_supported else ""
+    reported_comments_expr = _instagram_reported_comments_sql("p")
     posts_sql = f"""
             select
               {post_format_expr} as post_format,
@@ -56762,7 +57642,7 @@ def _instagram_social_account_detail_rollup(
             with filtered_posts as materialized (
               select
                 p.id,
-                greatest(0, coalesce(p.comments_count, 0))::int as reported_comments
+                {reported_comments_expr}::int as reported_comments
               from social.instagram_posts p
               where {owner_match_clause}
                 and nullif(p.shortcode, '') is not null
@@ -57093,33 +57973,78 @@ def _instagram_social_account_comment_target_shortcodes(
     normalized_refresh_policy = str(refresh_policy or "stale_or_missing").strip().lower() or "stale_or_missing"
     safe_limit = None if limit is None else max(1, min(int(limit), 500))
     if normalized_refresh_policy == "all_saved_posts":
+        target_priority = _instagram_comments_target_priority(normalized_refresh_policy)
+        table, source_id_column, posted_at_column = _shared_catalog_base_query_parts("instagram")
+        reported_comments_expr = _instagram_reported_comments_sql("p")
+        active_count_expr = (
+            "count(c.id) filter (where c.is_missing is not true)::bigint"
+            if _comment_lifecycle_supported("instagram_comments")
+            else "count(c.id)::bigint"
+        )
+        order_sql = (
+            """
+            order by
+              missing_comments_gap desc,
+              reported_comments desc nulls last,
+              posted_at desc nulls last,
+              shortcode desc
+            """
+            if target_priority == "gap_first"
+            else "order by posted_at desc nulls last, shortcode desc"
+        )
         sql = f"""
-        select p.shortcode
-        from social.instagram_posts p
-        where {owner_match_clause}
-          and nullif(p.shortcode, '') is not null
-        order by p.posted_at desc nulls last, p.shortcode desc
+        with saved_posts as (
+          select
+            p.id as post_id,
+            p.shortcode::text as shortcode,
+            p.posted_at,
+            {reported_comments_expr}::bigint as reported_comments
+          from social.instagram_posts p
+          where {owner_match_clause}
+            and nullif(p.shortcode, '') is not null
+          union all
+          select
+            null::uuid as post_id,
+            p.{source_id_column}::text as shortcode,
+            p.{posted_at_column} as posted_at,
+            {reported_comments_expr}::bigint as reported_comments
+          from social.{table} p
+          where lower(p.source_account) = lower(%s)
+            and nullif(p.{source_id_column}::text, '') is not null
+        ),
+        deduped_posts as (
+          select
+            max(post_id) filter (where post_id is not null) as post_id,
+            shortcode,
+            max(posted_at) as posted_at,
+            max(reported_comments) as reported_comments
+          from saved_posts
+          group by shortcode
+        ),
+        saved_comment_counts as (
+          select
+            dp.shortcode,
+            {active_count_expr} as saved_comments
+          from deduped_posts dp
+          left join social.instagram_comments c on c.post_id = dp.post_id
+          group by dp.shortcode
+        )
+        select
+          dp.shortcode,
+          greatest(coalesce(dp.reported_comments, 0) - coalesce(scc.saved_comments, 0), 0) as missing_comments_gap,
+          dp.reported_comments,
+          dp.posted_at
+        from deduped_posts dp
+        left join saved_comment_counts scc on scc.shortcode = dp.shortcode
+        {order_sql}
         """
-        params: list[Any] = [normalized_account]
+        params: list[Any] = [normalized_account, normalized_account]
         if safe_limit is not None:
             sql += " limit %s"
             params.append(safe_limit)
         rows = pg.fetch_all(sql, params)
-        if not rows:
-            table, source_id_column, posted_at_column = _shared_catalog_base_query_parts("instagram")
-            shared_sql = f"""
-            select p.{source_id_column}::text as shortcode
-            from social.{table} p
-            where lower(p.source_account) = %s
-              and nullif(p.{source_id_column}::text, '') is not null
-            order by p.{posted_at_column} desc nulls last, p.{source_id_column}::text desc
-            """
-            shared_params: list[Any] = [normalized_account]
-            if safe_limit is not None:
-                shared_sql += " limit %s"
-                shared_params.append(safe_limit)
-            rows = pg.fetch_all(shared_sql, shared_params)
     else:
+        reported_comments_expr = _instagram_reported_comments_sql("p")
         active_count_expr = (
             "(count(c.id) filter (where c.is_missing = false))::bigint"
             if _comment_lifecycle_supported("instagram_comments")
@@ -57130,15 +58055,15 @@ def _instagram_social_account_comment_target_shortcodes(
           select
             p.shortcode,
             p.posted_at,
-            greatest(0, coalesce(p.comments_count, 0))::bigint as reported_comments,
+            {reported_comments_expr}::bigint as reported_comments,
             {active_count_expr} as saved_comments,
             max(coalesce(c.last_seen_at, c.scraped_at)) as last_seen_at
           from social.instagram_posts p
           left join social.instagram_comments c on c.post_id = p.id
           where {owner_match_clause}
             and nullif(p.shortcode, '') is not null
-            and greatest(0, coalesce(p.comments_count, 0)) > 0
-          group by p.shortcode, p.posted_at, p.comments_count
+            and {reported_comments_expr} > 0
+          group by p.shortcode, p.posted_at, p.comments_count, p.raw_data
         )
         select shortcode
         from posts
@@ -57159,6 +58084,133 @@ def _instagram_social_account_comment_target_shortcodes(
             params.append(safe_limit)
         rows = pg.fetch_all(sql, params)
     return [str(row.get("shortcode") or "").strip() for row in rows if str(row.get("shortcode") or "").strip()]
+
+
+def _instagram_social_account_incomplete_comment_target_shortcodes(
+    account_handle: str,
+    *,
+    limit: int | None,
+) -> list[str]:
+    """Return comments-tab incomplete post shortcodes for the account.
+
+    This intentionally reuses the comments-only profile row path so Incomplete
+    Fill targets match the server-side `comment_filter=incomplete` list instead
+    of trusting a client page list.
+    """
+
+    safe_limit = None if limit is None else max(1, min(int(limit), 500))
+    page_size = _SOCIAL_ACCOUNT_PROFILE_MAX_PAGE_SIZE
+    targets: list[str] = []
+    seen: set[str] = set()
+    page = 1
+    while True:
+        rows, total = _fetch_instagram_comments_only_profile_rows_page(
+            account_handle,
+            page=page,
+            page_size=page_size,
+            comment_filter="incomplete",
+        )
+        if not rows:
+            break
+        for row in rows:
+            shortcode = str(row.get("shortcode") or row.get("source_id") or "").strip()
+            if not shortcode or shortcode in seen:
+                continue
+            seen.add(shortcode)
+            targets.append(shortcode)
+            if safe_limit is not None and len(targets) >= safe_limit:
+                return targets
+        if len(targets) >= total:
+            break
+        page += 1
+    return targets
+
+
+def _instagram_filter_incomplete_comment_targets(
+    account_handle: str,
+    target_source_ids: Sequence[Any],
+) -> list[str]:
+    """Return requested shortcodes that still need comment hydration.
+
+    Unknown shortcodes are preserved so a missing materialized post row does not
+    accidentally drop work. Known posts are kept only when saved comments are
+    below the best reported Instagram total.
+    """
+
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    requested = _normalize_unique_terms(
+        [str(item or "").strip() for item in target_source_ids if str(item or "").strip()]
+    )
+    if not normalized_account or not requested:
+        return requested
+
+    owner_match_clause = _social_account_profile_owner_match_sql("instagram", alias="p")
+    reported_comments_expr = _instagram_reported_comments_sql("p")
+    active_count_expr = (
+        "count(c.id) filter (where c.is_missing is not true)::bigint"
+        if _comment_lifecycle_supported("instagram_comments")
+        else "count(c.id)::bigint"
+    )
+    rows = pg.fetch_all(
+        f"""
+        with requested as (
+          select
+            nullif(shortcode, '')::text as shortcode,
+            ordinality::int as sort_order
+          from unnest(%s::text[]) with ordinality as request(shortcode, ordinality)
+          where nullif(shortcode, '') is not null
+        ),
+        owner_posts as (
+          select
+            p.id as post_id,
+            p.shortcode::text as shortcode,
+            {reported_comments_expr}::bigint as reported_comments,
+            row_number() over (
+              partition by p.shortcode
+              order by p.posted_at desc nulls last, p.id desc
+            ) as row_number
+          from social.instagram_posts p
+          join requested r on r.shortcode = p.shortcode
+          where {owner_match_clause}
+        ),
+        selected_posts as (
+          select post_id, shortcode, reported_comments
+          from owner_posts
+          where row_number = 1
+        ),
+        saved_comment_counts as (
+          select
+            sp.shortcode,
+            {active_count_expr} as saved_comments
+          from selected_posts sp
+          left join social.instagram_comments c on c.post_id = sp.post_id
+          group by sp.shortcode
+        )
+        select
+          r.shortcode,
+          sp.post_id is null as post_missing,
+          coalesce(sp.reported_comments, 0)::bigint as reported_comments,
+          coalesce(scc.saved_comments, 0)::bigint as saved_comments
+        from requested r
+        left join selected_posts sp on sp.shortcode = r.shortcode
+        left join saved_comment_counts scc on scc.shortcode = r.shortcode
+        order by r.sort_order
+        """,
+        [requested, normalized_account],
+    )
+    incomplete: list[str] = []
+    for row in rows:
+        shortcode = str(row.get("shortcode") or "").strip()
+        if not shortcode:
+            continue
+        if row.get("post_missing"):
+            incomplete.append(shortcode)
+            continue
+        reported = _normalize_non_negative_int(row.get("reported_comments"))
+        saved = _normalize_non_negative_int(row.get("saved_comments"))
+        if reported > saved:
+            incomplete.append(shortcode)
+    return incomplete
 
 
 def _social_account_comments_recent_runs(
@@ -57285,6 +58337,53 @@ def _social_account_comments_start_lock_key(platform: str, account_handle: str) 
     ) % (2**31)
 
 
+def _instagram_comments_profile_shard_count(target_count: int) -> int:
+    if target_count <= 1:
+        return 1
+    recommended = _instagram_comments_recommended_shard_count(target_count=target_count)
+    raw_value = str(os.getenv("SOCIAL_INSTAGRAM_COMMENTS_PROFILE_SHARD_COUNT") or "").strip()
+    if not raw_value:
+        return recommended
+    try:
+        requested = int(raw_value)
+    except ValueError:
+        return recommended
+    requested = max(1, min(requested, 24))
+    return min(requested, target_count)
+
+
+def _instagram_comments_recommended_shard_count(
+    *,
+    target_count: int,
+    modal_pending_jobs: int = 0,
+    db_pressure_high: bool = False,
+) -> int:
+    if target_count <= 1:
+        return 1
+    if db_pressure_high or modal_pending_jobs >= 25:
+        return min(4, target_count)
+    if target_count >= 300:
+        return min(8, target_count)
+    if target_count >= 100:
+        return min(4, target_count)
+    return min(2, target_count)
+
+
+def _chunk_instagram_comment_targets(target_source_ids: Sequence[str], shard_count: int) -> list[list[str]]:
+    targets = [str(item or "").strip() for item in target_source_ids if str(item or "").strip()]
+    if not targets:
+        return []
+    effective_shard_count = max(1, min(int(shard_count or 1), len(targets)))
+    base_size, remainder = divmod(len(targets), effective_shard_count)
+    chunks: list[list[str]] = []
+    start = 0
+    for index in range(effective_shard_count):
+        chunk_size = base_size + (1 if index < remainder else 0)
+        chunks.append(targets[start : start + chunk_size])
+        start += chunk_size
+    return chunks
+
+
 def start_social_account_comments_scrape(
     platform: str,
     account_handle: str,
@@ -57295,6 +58394,7 @@ def start_social_account_comments_scrape(
     max_posts: int | None = None,
     max_comments_per_post: int | None = None,
     refresh_policy: str = "stale_or_missing",
+    target_filter: str | None = None,
     initiated_by: str | None = None,
     inline_worker_id: str | None = None,
     allow_local_dev_inline_bypass: bool = False,
@@ -57306,6 +58406,7 @@ def start_social_account_comments_scrape(
     normalized_account = _normalize_social_account_profile_handle(account_handle)
     normalized_mode = str(mode or "").strip().lower()
     normalized_refresh_policy = str(refresh_policy or "stale_or_missing").strip().lower()
+    normalized_target_filter = _normalize_instagram_comments_target_filter(target_filter)
     if normalized_platform != "instagram":
         raise SocialIngestValidationError(
             "SOCIAL_ACCOUNT_COMMENTS_UNSUPPORTED_PLATFORM",
@@ -57317,6 +58418,11 @@ def start_social_account_comments_scrape(
         raise SocialIngestValidationError(
             "SOCIAL_ACCOUNT_COMMENTS_INVALID_REFRESH_POLICY",
             "Profile comments scraping supports stale_or_missing and all_saved_posts refreshes.",
+        )
+    if normalized_mode != "profile" and normalized_target_filter is not None:
+        raise SocialIngestValidationError(
+            "SOCIAL_ACCOUNT_COMMENTS_INVALID_TARGET_FILTER",
+            "target_filter is only supported for profile comment scrapes.",
         )
     _assert_social_account_profile_exists(normalized_platform, normalized_account)
     normalized_max_posts = None if max_posts is None else max(1, min(int(max_posts), 500))
@@ -57330,6 +58436,17 @@ def start_social_account_comments_scrape(
     modal_queue_dispatch = queue_enabled and not allow_local_dev_inline_bypass and is_modal_remote_executor_enabled()
     required_worker_lane = None if modal_queue_dispatch else INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE
     required_execution_backend = "modal" if modal_queue_dispatch else None
+    if queue_enabled and not allow_local_dev_inline_bypass:
+        if modal_queue_dispatch:
+            assert_worker_available_when_queue_enabled(
+                required_execution_backend="modal",
+                platform=normalized_platform,
+            )
+        else:
+            assert_worker_available_when_queue_enabled(
+                required_worker_lane=INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE,
+                platform=normalized_platform,
+            )
 
     lock_key = _social_account_comments_start_lock_key(normalized_platform, normalized_account)
     lock_label = f"comments-scrape-lock:{normalized_platform}:{normalized_account[:48]}"
@@ -57344,13 +58461,24 @@ def start_social_account_comments_scrape(
                 normalized_account,
                 conn=lock_conn,
             )
+            if not active_run:
+                raise SocialIngestConflictError(
+                    "SOCIAL_ACCOUNT_COMMENTS_LAUNCH_IN_PROGRESS",
+                    f"Comments sync is already starting for @{normalized_account}.",
+                    detail={
+                        "platform": normalized_platform,
+                        "account_handle": normalized_account,
+                        "status": "starting",
+                        "retryable": True,
+                    },
+                )
             raise SocialIngestConflictError(
                 "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE",
                 (
-                    f"Comments scrape run {(active_run or {}).get('run_id') or 'unknown'} "
+                    f"Comments scrape run {active_run.get('run_id') or 'unknown'} "
                     f"is already active for @{normalized_account}."
                 ),
-                detail=active_run or {"platform": normalized_platform, "account_handle": normalized_account},
+                detail=active_run,
             )
         try:
             active_run = get_active_social_account_comments_run(
@@ -57367,18 +58495,8 @@ def start_social_account_comments_scrape(
                     ),
                     detail=active_run,
                 )
-            if queue_enabled and not allow_local_dev_inline_bypass:
-                if modal_queue_dispatch:
-                    assert_worker_available_when_queue_enabled(
-                        required_execution_backend="modal",
-                        platform=normalized_platform,
-                    )
-                else:
-                    assert_worker_available_when_queue_enabled(
-                        required_worker_lane=INSTAGRAM_COMMENTS_SCRAPLING_WORKER_LANE,
-                        platform=normalized_platform,
-                    )
             target_source_ids: list[str]
+            target_enumeration_started_at = time_module.perf_counter()
             if normalized_mode == "single_post":
                 normalized_source_id = str(source_id or "").strip()
                 if not normalized_source_id:
@@ -57388,22 +58506,46 @@ def start_social_account_comments_scrape(
                     )
                 target_source_ids = [normalized_source_id]
             else:
-                target_source_ids = _instagram_social_account_comment_target_shortcodes(
-                    normalized_account,
-                    limit=normalized_max_posts,
-                    refresh_policy=normalized_refresh_policy,
-                )
+                if normalized_target_filter == "incomplete":
+                    target_source_ids = _instagram_social_account_incomplete_comment_target_shortcodes(
+                        normalized_account,
+                        limit=normalized_max_posts,
+                    )
+                else:
+                    target_source_ids = _instagram_social_account_comment_target_shortcodes(
+                        normalized_account,
+                        limit=normalized_max_posts,
+                        refresh_policy=normalized_refresh_policy,
+                    )
                 if not target_source_ids:
                     message = (
+                        f"No incomplete Instagram comments were found for @{normalized_account}."
+                        if normalized_target_filter == "incomplete"
+                        else (
                         f"No saved Instagram posts were found for @{normalized_account}."
                         if normalized_refresh_policy == "all_saved_posts"
                         else f"No stale or missing Instagram comments were found for @{normalized_account}."
+                        )
                     )
                     raise SocialIngestValidationError(
                         "SOCIAL_ACCOUNT_COMMENTS_NOTHING_TO_REFRESH",
                         message,
                     )
+            target_enumeration_ms = round((time_module.perf_counter() - target_enumeration_started_at) * 1000, 1)
 
+            target_source_ids_count = len(target_source_ids)
+            comments_shard_count = (
+                _instagram_comments_profile_shard_count(target_source_ids_count)
+                if normalized_mode == "profile"
+                else 1
+            )
+            target_source_id_shards = _chunk_instagram_comment_targets(target_source_ids, comments_shard_count)
+            if not target_source_id_shards:
+                target_source_id_shards = [target_source_ids]
+                comments_shard_count = 1
+            recommended_comments_shard_count = _instagram_comments_recommended_shard_count(
+                target_count=target_source_ids_count
+            )
             run_status = "queued" if queue_enabled else "pending"
             run_config = {
                 "platform": normalized_platform,
@@ -57412,6 +58554,8 @@ def start_social_account_comments_scrape(
                 "mode": normalized_mode,
                 "stage": INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
                 "refresh_policy": normalized_refresh_policy,
+                "target_filter": normalized_target_filter,
+                "incomplete_fill": normalized_target_filter == "incomplete",
                 "max_posts": normalized_max_posts if normalized_mode == "profile" else None,
                 "max_comments_per_post": (
                     effective_profile_max_comments_per_post
@@ -57424,6 +58568,18 @@ def start_social_account_comments_scrape(
                 "required_execution_backend": required_execution_backend,
                 "allow_local_dev_inline_bypass": bool(allow_local_dev_inline_bypass),
                 "ingest_mode": "comments_only",
+                "target_source_ids_count": target_source_ids_count,
+                "comments_shard_count": comments_shard_count,
+                "comments_sharding_enabled": comments_shard_count > 1,
+                "comments_proxy_shard_sessions": (
+                    str(os.getenv("SOCIAL_INSTAGRAM_COMMENTS_PROXY_SHARD_SESSIONS", "0")).strip().lower()
+                    in {"1", "true", "yes", "on"}
+                ),
+                "recommended_comments_shard_count": recommended_comments_shard_count,
+                "timing": {
+                    "target_enumeration_ms": target_enumeration_ms,
+                    "target_source_ids_count": target_source_ids_count,
+                },
             }
             creator_runtime_version = dict(_resolve_runtime_version_stamp())
             effective_runtime_version = _resolve_effective_runtime_version(
@@ -57441,28 +58597,57 @@ def start_social_account_comments_scrape(
                 initiated_by=initiated_by,
                 config=run_config,
                 status=run_status,
+                conn=lock_conn,
             )
-            _create_job(
-                None,
-                run_id=run_id,
-                platform=normalized_platform,
-                source_scope=source_scope,
-                job_type="comments",
-                stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
-                config={
-                    **run_config,
-                    "source_id": source_id if normalized_mode == "single_post" else None,
-                    "target_source_ids": target_source_ids,
-                    "account": normalized_account,
-                    "required_worker_lane": required_worker_lane,
-                    "required_execution_backend": required_execution_backend,
-                },
-                initiated_by=initiated_by,
-                status=run_status,
-                priority=105,
-                worker_id=inline_worker_id,
-                preclaim=bool(inline_worker_id),
-            )
+            job_ids: list[str] = []
+            for shard_index, target_source_id_shard in enumerate(target_source_id_shards, start=1):
+                job_ids.append(
+                    _create_job(
+                        None,
+                        run_id=run_id,
+                        platform=normalized_platform,
+                        source_scope=source_scope,
+                        job_type="comments",
+                        stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                        config={
+                            **run_config,
+                            "source_id": source_id if normalized_mode == "single_post" else None,
+                            "target_source_ids": target_source_id_shard,
+                            "target_source_ids_count": target_source_ids_count,
+                            "comments_shard_index": shard_index,
+                            "comments_shard_count": comments_shard_count,
+                            "comments_shard_target_count": len(target_source_id_shard),
+                            "account": normalized_account,
+                            "required_worker_lane": required_worker_lane,
+                            "required_execution_backend": required_execution_backend,
+                        },
+                        initiated_by=initiated_by,
+                        status=run_status,
+                        priority=105,
+                        worker_id=inline_worker_id if comments_shard_count == 1 else None,
+                        preclaim=bool(inline_worker_id and comments_shard_count == 1),
+                        conn=lock_conn,
+                        track_run_counters=False,
+                    )
+                )
+            if _run_counter_columns_ready():
+                _persist_run_counters_and_summary(
+                    conn=lock_conn,
+                    run_id=run_id,
+                    total_jobs=len(job_ids),
+                    completed_jobs=0,
+                    failed_jobs=0,
+                    active_jobs=len(job_ids) if _status_is_active(run_status) else 0,
+                    items_found_total=0,
+                    stage_counts={
+                        INSTAGRAM_COMMENTS_SCRAPLING_STAGE: {
+                            "total": len(job_ids),
+                            "completed": 0,
+                            "failed": 0,
+                            "active": len(job_ids) if _status_is_active(run_status) else 0,
+                        },
+                    },
+                )
             payload = {
                 "run_id": run_id,
                 "status": run_status,
@@ -57470,6 +58655,16 @@ def start_social_account_comments_scrape(
                 "platform": normalized_platform,
                 "account_handle": normalized_account,
                 "target_source_ids": target_source_ids,
+                "target_source_ids_count": target_source_ids_count,
+                "target_filter": normalized_target_filter,
+                "incomplete_fill": normalized_target_filter == "incomplete",
+                "comments_shard_count": comments_shard_count,
+                "comments_sharding_enabled": comments_shard_count > 1,
+                "recommended_comments_shard_count": recommended_comments_shard_count,
+                "timing": {
+                    "target_enumeration_ms": target_enumeration_ms,
+                    "target_source_ids_count": target_source_ids_count,
+                },
                 "comments_enable_media_followups": bool(comments_enable_media_followups),
                 "launch_group_id": str(launch_group_id or "").strip() or None,
                 "required_worker_lane": required_worker_lane,
@@ -57491,6 +58686,289 @@ def start_social_account_comments_scrape(
     if queue_enabled and dispatch_immediately and run_id:
         dispatch_due_social_jobs(run_id=run_id)
     return payload or {}
+
+
+def preview_social_account_comments_scrape(
+    platform: str,
+    account_handle: str,
+    *,
+    mode: str,
+    source_id: str | None = None,
+    max_posts: int | None = None,
+    refresh_policy: str = "stale_or_missing",
+    target_filter: str | None = None,
+) -> dict[str, Any]:
+    started_at = time_module.perf_counter()
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    normalized_mode = str(mode or "").strip().lower()
+    normalized_target_filter = _normalize_instagram_comments_target_filter(target_filter)
+    if normalized_platform != "instagram":
+        raise SocialIngestValidationError(
+            "SOCIAL_ACCOUNT_COMMENTS_UNSUPPORTED_PLATFORM",
+            "Standalone comments scraping is currently only supported for Instagram.",
+        )
+    if normalized_mode not in {"profile", "single_post"}:
+        raise SocialIngestValidationError("SOCIAL_ACCOUNT_COMMENTS_INVALID_MODE", "Unsupported comments scrape mode.")
+    if normalized_mode == "single_post":
+        if normalized_target_filter is not None:
+            raise SocialIngestValidationError(
+                "SOCIAL_ACCOUNT_COMMENTS_INVALID_TARGET_FILTER",
+                "target_filter is only supported for profile comment scrapes.",
+            )
+        normalized_source_id = str(source_id or "").strip()
+        target_source_ids = [normalized_source_id] if normalized_source_id else []
+        target_count = len(target_source_ids)
+        return {
+            "dry_run": True,
+            "platform": normalized_platform,
+            "account_handle": normalized_account,
+            "mode": normalized_mode,
+            "refresh_policy": str(refresh_policy or "stale_or_missing").strip().lower() or "stale_or_missing",
+            "target_priority": "single_post",
+            "target_source_ids_count": target_count,
+            "comments_shard_count": 1,
+            "comments_sharding_enabled": False,
+            "recommended_comments_shard_count": 1,
+            "sample_target_source_ids": target_source_ids[:1],
+            "timing": {
+                "target_preview_ms": round((time_module.perf_counter() - started_at) * 1000, 1),
+                "target_count_ms": 0.0,
+                "sample_target_source_ids_ms": 0.0,
+                "cache_lookup_ms": 0.0,
+                "total_ms": round((time_module.perf_counter() - started_at) * 1000, 1),
+            },
+            "preview_cache": {
+                "enabled": False,
+                "hit": False,
+                "age_seconds": None,
+                "ttl_seconds": 0,
+            },
+            "cache": {
+                "enabled": False,
+                "hit": False,
+                "age_seconds": None,
+                "ttl_seconds": 0,
+            },
+            "debug": {
+                "target_plan_strategy": "single_post_preview",
+                "bounded": True,
+                "full_target_list_built": False,
+                "sample_limit": 1,
+                "max_posts": None,
+            },
+        }
+    else:
+        normalized_refresh_policy = str(refresh_policy or "stale_or_missing").strip().lower() or "stale_or_missing"
+        if normalized_refresh_policy not in {"stale_or_missing", "all_saved_posts"}:
+            raise SocialIngestValidationError(
+                "SOCIAL_ACCOUNT_COMMENTS_INVALID_REFRESH_POLICY",
+                "Profile comments scraping supports stale_or_missing and all_saved_posts refreshes.",
+            )
+        plan = _instagram_social_account_comment_target_preview(
+            normalized_account,
+            limit=None if max_posts is None else max(1, min(int(max_posts), 500)),
+            refresh_policy=normalized_refresh_policy,
+            target_filter=normalized_target_filter,
+        )
+    timing = _metadata_dict(plan.get("timing"))
+    timing["total_ms"] = round((time_module.perf_counter() - started_at) * 1000, 1)
+    return {
+        "dry_run": True,
+        "platform": normalized_platform,
+        "account_handle": normalized_account,
+        "mode": normalized_mode,
+        **plan,
+        "timing": timing,
+    }
+
+
+def rebalance_failed_instagram_comments_shard(
+    *,
+    failed_job_id: str,
+    max_retry_shard_size: int = 10,
+) -> dict[str, Any]:
+    row = pg.fetch_one(
+        """
+        select
+          j.id::text as job_id,
+          j.run_id::text as run_id,
+          j.platform,
+          j.source_scope,
+          j.config,
+          j.metadata,
+          j.initiated_by,
+          j.items_found
+        from social.scrape_jobs j
+        where j.id = %s::uuid
+          and j.status = 'failed'
+          and coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
+        """,
+        [failed_job_id, INSTAGRAM_COMMENTS_SCRAPLING_STAGE],
+    )
+    if not row:
+        return {"created_job_ids": [], "reason": "failed_job_not_found"}
+    config = _metadata_dict(row.get("config"))
+    metadata = _metadata_dict(row.get("metadata"))
+    retry_rebalance = _metadata_dict(metadata.get("retry_rebalance"))
+    remaining_targets = [
+        str(item or "").strip()
+        for item in retry_rebalance.get("remaining_target_source_ids") or []
+        if str(item or "").strip()
+    ]
+    if not remaining_targets:
+        original_targets = [
+            str(item or "").strip()
+            for item in (config.get("target_source_ids") or metadata.get("target_source_ids") or [])
+            if str(item or "").strip()
+        ]
+        processed_posts = max(
+            _normalize_non_negative_int(_metadata_dict(metadata.get("stage_counters")).get("posts")),
+            _normalize_non_negative_int(_metadata_dict(metadata.get("activity")).get("posts_checked")),
+        )
+        if _normalize_non_negative_int(row.get("items_found")) <= 0:
+            processed_posts = 0
+        remaining_targets = original_targets[processed_posts:]
+    if not remaining_targets:
+        return {"created_job_ids": [], "reason": "no_remaining_targets"}
+    safe_max_retry_shard_size = max(1, int(max_retry_shard_size or 10))
+    retry_shard_count = max(1, (len(remaining_targets) + safe_max_retry_shard_size - 1) // safe_max_retry_shard_size)
+    chunks = _chunk_instagram_comment_targets(remaining_targets, retry_shard_count)
+    created_job_ids: list[str] = []
+    retry_group_id = str(uuid4())
+    for index, chunk in enumerate(chunks, start=1):
+        retry_config = {
+            **config,
+            "target_source_ids": chunk,
+            "comments_retry_rebalance": True,
+            "comments_retry_rebalance_source_job_id": str(row.get("job_id") or ""),
+            "comments_retry_rebalance_group_id": retry_group_id,
+            "comments_retry_rebalance_index": index,
+            "comments_retry_rebalance_count": len(chunks),
+            "comments_shard_target_count": len(chunk),
+        }
+        created_job_ids.append(
+            _create_job(
+                None,
+                run_id=str(row.get("run_id") or ""),
+                platform="instagram",
+                source_scope=str(row.get("source_scope") or "bravo"),
+                job_type="comments",
+                stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                config=retry_config,
+                initiated_by=str(row.get("initiated_by") or "") or None,
+                status="queued",
+                priority=110,
+            )
+        )
+    return {"created_job_ids": created_job_ids, "retry_group_id": retry_group_id}
+
+
+def repair_instagram_comments_scrape_run_target_gaps(
+    *,
+    run_id: str,
+    max_retry_shard_size: int = 25,
+    dispatch_immediately: bool = True,
+) -> dict[str, Any]:
+    normalized_run_id = str(run_id or "").strip()
+    if not normalized_run_id:
+        return {"created_job_ids": [], "reason": "run_id_required"}
+    run_row = pg.fetch_one(
+        """
+        select
+          id::text as run_id,
+          source_scope,
+          initiated_by,
+          config
+        from social.scrape_runs
+        where id = %s::uuid
+          and coalesce(config->>'stage', '') = %s
+        """,
+        [normalized_run_id, INSTAGRAM_COMMENTS_SCRAPLING_STAGE],
+    )
+    if not run_row:
+        return {"created_job_ids": [], "reason": "run_not_found"}
+    run_config = _metadata_dict(run_row.get("config"))
+    account_handle = _normalize_social_account_profile_handle(run_config.get("account"))
+    if not account_handle:
+        return {"created_job_ids": [], "reason": "account_missing"}
+    refresh_policy = str(run_config.get("refresh_policy") or "stale_or_missing").strip().lower() or "stale_or_missing"
+    max_posts = run_config.get("max_posts")
+    target_source_ids = _instagram_social_account_comment_target_shortcodes(
+        account_handle,
+        limit=None if max_posts is None else max(1, min(int(max_posts), 500)),
+        refresh_policy=refresh_policy,
+    )
+    job_rows = pg.fetch_all(
+        """
+        select status, config
+        from social.scrape_jobs
+        where run_id = %s::uuid
+          and coalesce(config->>'stage', metadata->>'stage', job_type) = %s
+        """,
+        [normalized_run_id, INSTAGRAM_COMMENTS_SCRAPLING_STAGE],
+    )
+    active_assigned_targets: set[str] = set()
+    for row in job_rows:
+        status = str(row.get("status") or "").strip().lower()
+        if status not in {"queued", "pending", "retrying", "running"}:
+            continue
+        config = _metadata_dict(row.get("config"))
+        for target in config.get("target_source_ids") or []:
+            normalized_target = str(target or "").strip()
+            if normalized_target:
+                active_assigned_targets.add(normalized_target)
+    missing_targets = [target for target in target_source_ids if target not in active_assigned_targets]
+    if not missing_targets:
+        return {
+            "created_job_ids": [],
+            "reason": "no_missing_targets",
+            "target_source_ids_count": len(target_source_ids),
+            "assigned_target_source_ids_count": len(active_assigned_targets),
+        }
+    safe_max_retry_shard_size = max(1, int(max_retry_shard_size or 25))
+    retry_shard_count = max(1, (len(missing_targets) + safe_max_retry_shard_size - 1) // safe_max_retry_shard_size)
+    chunks = _chunk_instagram_comment_targets(missing_targets, retry_shard_count)
+    created_job_ids: list[str] = []
+    repair_group_id = str(uuid4())
+    original_shard_count = _normalize_non_negative_int(run_config.get("comments_shard_count")) or len(job_rows) or 1
+    effective_shard_count = original_shard_count + len(chunks)
+    for index, chunk in enumerate(chunks, start=1):
+        repair_config = {
+            **run_config,
+            "target_source_ids": chunk,
+            "comments_target_gap_repair": True,
+            "comments_target_gap_repair_group_id": repair_group_id,
+            "comments_target_gap_repair_index": index,
+            "comments_target_gap_repair_count": len(chunks),
+            "comments_shard_index": original_shard_count + index,
+            "comments_shard_count": effective_shard_count,
+            "comments_shard_target_count": len(chunk),
+            "account": account_handle,
+        }
+        created_job_ids.append(
+            _create_job(
+                None,
+                run_id=normalized_run_id,
+                platform="instagram",
+                source_scope=str(run_row.get("source_scope") or run_config.get("source_scope") or "bravo"),
+                job_type="comments",
+                stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                config=repair_config,
+                initiated_by=str(run_row.get("initiated_by") or "") or None,
+                status="queued",
+                priority=108,
+            )
+        )
+    if dispatch_immediately and created_job_ids:
+        dispatch_due_social_jobs(run_id=normalized_run_id)
+    return {
+        "created_job_ids": created_job_ids,
+        "repair_group_id": repair_group_id,
+        "missing_target_source_ids_count": len(missing_targets),
+        "target_source_ids_count": len(target_source_ids),
+        "assigned_target_source_ids_count": len(active_assigned_targets),
+    }
 
 
 def _social_account_posts_scrapling_start_lock_key(platform: str, account_handle: str) -> int:
@@ -57756,6 +59234,227 @@ def start_tiktok_posts_scrapling_scrape(
                 )
 
 
+def _build_comments_scrape_run_progress_payload(
+    *,
+    rows: Sequence[Mapping[str, Any]],
+    platform: str,
+    account_handle: str,
+) -> dict[str, Any]:
+    first = _metadata_dict(rows[0]) if rows else {}
+    run_config = _metadata_dict(first.get("run_config"))
+    raw_summary = _metadata_dict(first.get("summary"))
+    total_jobs = len(rows)
+    active_jobs = 0
+    queued_jobs = 0
+    completed_jobs = 0
+    failed_jobs = 0
+    cancelled_jobs = 0
+    failed_remaining_targets = 0
+    items_found_total = 0
+    completed_posts = 0
+    matched_posts = 0
+    target_source_ids: list[str] = []
+    latest_job_metadata: dict[str, Any] = {}
+    latest_job_status: str | None = None
+    latest_error: Any = None
+    queue_wait_seconds_values: list[int] = []
+    comment_shards: list[dict[str, Any]] = []
+
+    for row in rows:
+        config = _metadata_dict(row.get("config"))
+        metadata = _metadata_dict(row.get("metadata"))
+        activity = _metadata_dict(metadata.get("activity"))
+        stage_counters = _metadata_dict(metadata.get("stage_counters"))
+        persist_counters = _metadata_dict(metadata.get("persist_counters"))
+        status = str(row.get("job_status") or "").strip().lower()
+        row_items_found = _normalize_non_negative_int(row.get("items_found"))
+        items_found_total += row_items_found
+        latest_job_status = status
+        latest_job_metadata = metadata
+        latest_error = row.get("error_message") or latest_error
+
+        if status == "completed":
+            completed_jobs += 1
+        elif status == "cancelled":
+            cancelled_jobs += 1
+            failed_jobs += 1
+        elif status == "failed":
+            failed_jobs += 1
+        elif status in {"queued", "pending", "retrying", "cancelling", "running"}:
+            if status in {"queued", "pending", "retrying"}:
+                queued_jobs += 1
+            if status == "running":
+                active_jobs += 1
+
+        stage_posts = _normalize_non_negative_int(stage_counters.get("posts"))
+        activity_posts = _normalize_non_negative_int(activity.get("posts_checked"))
+        row_posts = stage_posts or activity_posts
+        row_matched_posts = max(
+            row_posts,
+            _normalize_non_negative_int(activity.get("matched_posts")),
+            _normalize_non_negative_int(persist_counters.get("posts_upserted")),
+        )
+        completed_posts += row_posts
+        matched_posts += row_matched_posts
+        retry_rebalance = _metadata_dict(metadata.get("retry_rebalance"))
+        failed_remaining_targets += len(retry_rebalance.get("remaining_target_source_ids") or [])
+        shard_target_source_ids = [
+            str(item or "").strip() for item in config.get("target_source_ids") or [] if str(item or "").strip()
+        ]
+        for source_id in config.get("target_source_ids") or []:
+            normalized_source_id = str(source_id or "").strip()
+            if normalized_source_id:
+                target_source_ids.append(normalized_source_id)
+
+        created_at = _coerce_dt(row.get("job_created_at") or row.get("created_at"))
+        started_at = _coerce_dt(row.get("job_started_at") or row.get("started_at"))
+        completed_at = _coerce_dt(row.get("job_completed_at") or row.get("completed_at"))
+        queue_wait_seconds: int | None = None
+        if created_at and started_at:
+            queue_wait_seconds = max(0, int((started_at - created_at).total_seconds()))
+            queue_wait_seconds_values.append(queue_wait_seconds)
+        shard_elapsed_seconds = (
+            max(1, int(((completed_at or _now_utc()) - started_at).total_seconds()))
+            if isinstance(started_at, datetime)
+            else 0
+        )
+        shard_target_count = _normalize_non_negative_int(config.get("comments_shard_target_count")) or len(
+            shard_target_source_ids
+        )
+        remaining_targets = retry_rebalance.get("remaining_target_source_ids") or []
+        remaining_target_count = len(remaining_targets)
+        if (
+            remaining_target_count <= 0
+            and shard_target_count > 0
+            and status in {"queued", "pending", "retrying", "running"}
+        ):
+            remaining_target_count = max(shard_target_count - row_posts, 0)
+        shard_error_message = row.get("error_message")
+        shard_error_code = str(row.get("last_error_code") or metadata.get("last_error_code") or "").strip().lower()
+        shard_has_current_progress = row_posts > 0 or row_items_found > 0
+        shard_error_text = str(shard_error_message or "").strip().lower()
+        stale_dispatch_error = shard_error_code == "stale_modal_dispatch_unclaimed" or (
+            "modal dispatch lease expired" in shard_error_text
+            and "before any worker claimed" in shard_error_text
+        )
+        if (
+            status in {"queued", "pending", "retrying", "running"}
+            and shard_has_current_progress
+            and stale_dispatch_error
+        ):
+            shard_error_message = None
+        latest_failure_reason = (
+            shard_error_message
+            or metadata.get("latest_failure_reason")
+            or metadata.get("failure_reason")
+            or _metadata_dict(metadata.get("activity")).get("failure_reason")
+        )
+        comment_shards.append(
+            {
+                "job_id": str(row.get("job_id") or "").strip() or None,
+                "shard_index": _normalize_non_negative_int(config.get("comments_shard_index")) or None,
+                "shard_count": _normalize_non_negative_int(config.get("comments_shard_count")) or None,
+                "status": status or None,
+                "target_count": shard_target_count,
+                "target_source_ids_count": shard_target_count,
+                "comments_shard_target_count": shard_target_count,
+                "processed_post_count": row_posts,
+                "completed_posts": row_posts,
+                "matched_posts": row_matched_posts,
+                "remaining_target_count": remaining_target_count,
+                "queue_wait_seconds": queue_wait_seconds,
+                "posts_per_minute": (
+                    round((row_posts * 60.0) / shard_elapsed_seconds, 2) if shard_elapsed_seconds else None
+                ),
+                "comments_per_minute": (
+                    round((row_items_found * 60.0) / shard_elapsed_seconds, 2) if shard_elapsed_seconds else None
+                ),
+                "items_found_total": row_items_found,
+                "error_message": shard_error_message,
+                "latest_failure_reason": latest_failure_reason,
+            }
+        )
+
+    started_at = _coerce_dt(first.get("started_at") or first.get("created_at"))
+    completed_at = _coerce_dt(first.get("completed_at"))
+    elapsed_until = completed_at or _now_utc()
+    elapsed_seconds = (
+        max(1, int((elapsed_until - started_at).total_seconds()))
+        if isinstance(started_at, datetime)
+        else 0
+    )
+    posts_per_minute = round((completed_posts * 60.0) / elapsed_seconds, 2) if elapsed_seconds else None
+    comments_per_minute = round((items_found_total * 60.0) / elapsed_seconds, 2) if elapsed_seconds else None
+    run_target_total = _normalize_non_negative_int(run_config.get("target_source_ids_count"))
+    target_source_ids_count = run_target_total or len(dict.fromkeys(target_source_ids))
+    shard_count = _normalize_non_negative_int(run_config.get("comments_shard_count")) or max(1, total_jobs)
+    del raw_summary
+    post_progress_total = target_source_ids_count or None
+    display_completed_posts = (
+        min(completed_posts, target_source_ids_count) if target_source_ids_count else completed_posts
+    )
+    display_matched_posts = min(matched_posts, target_source_ids_count) if target_source_ids_count else matched_posts
+    summary = {
+        "total_jobs": total_jobs,
+        "completed_jobs": completed_jobs,
+        "failed_jobs": failed_jobs,
+        "active_jobs": active_jobs + queued_jobs,
+        "items_found_total": items_found_total,
+    }
+    return {
+        "run_id": str(first.get("run_id") or "").strip(),
+        "platform": platform,
+        "account_handle": account_handle,
+        "run_status": str(first.get("run_status") or "").strip().lower() or None,
+        "created_at": first.get("created_at"),
+        "started_at": first.get("started_at"),
+        "completed_at": first.get("completed_at"),
+        "summary": summary,
+        "job_status": latest_job_status,
+        "job_metadata": latest_job_metadata,
+        "error_message": latest_error,
+        "target_source_ids": list(dict.fromkeys(target_source_ids)),
+        "target_source_ids_count": target_source_ids_count,
+        "comments_shard_count": shard_count,
+        "comments_sharding_enabled": shard_count > 1,
+        "recommended_comments_shard_count": _normalize_non_negative_int(
+            run_config.get("recommended_comments_shard_count")
+        )
+        or _instagram_comments_recommended_shard_count(target_count=target_source_ids_count),
+        "active_comment_jobs": active_jobs,
+        "queued_comment_jobs": queued_jobs,
+        "completed_comment_jobs": completed_jobs,
+        "failed_comment_jobs": failed_jobs,
+        "post_progress": {
+            "completed_posts": display_completed_posts,
+            "matched_posts": display_matched_posts,
+            "total_posts": post_progress_total,
+        },
+        "throughput": {
+            "elapsed_seconds": elapsed_seconds,
+            "posts_per_minute": posts_per_minute,
+            "comments_per_minute": comments_per_minute,
+        },
+        "cancellation_summary": {
+            "cancelled_jobs": cancelled_jobs,
+            "failed_jobs": failed_jobs,
+            "remaining_target_source_ids_count": failed_remaining_targets,
+            "resume_recommendation": "stale_or_missing" if cancelled_jobs or failed_remaining_targets else None,
+        },
+        "comment_shards": comment_shards,
+        "shards": comment_shards,
+        "shard_progress": comment_shards,
+        "timing": {
+            "queue_wait_seconds_max": max(queue_wait_seconds_values or [0]),
+            "queue_wait_seconds_avg": (
+                round(sum(queue_wait_seconds_values) / len(queue_wait_seconds_values), 2)
+                if queue_wait_seconds_values
+                else None
+            ),
+        },
+    }
+
+
 def get_social_account_comments_scrape_run_progress(
     platform: str,
     account_handle: str,
@@ -57771,11 +59470,17 @@ def get_social_account_comments_scrape_run_progress(
           r.created_at,
           r.started_at,
           r.completed_at,
+          r.config as run_config,
           r.summary,
           j.id::text as job_id,
           j.status as job_status,
           j.items_found,
+          j.created_at as job_created_at,
+          j.started_at as job_started_at,
+          j.completed_at as job_completed_at,
           j.error_message,
+          j.last_error_code,
+          j.last_error_class,
           j.metadata,
           j.config
         from social.scrape_runs r
@@ -57790,55 +59495,11 @@ def get_social_account_comments_scrape_run_progress(
     )
     if not rows:
         raise LookupError("Comments scrape run not found.")
-    raw_summary = dict((rows[0] or {}).get("summary") or {})
-    summary = {
-        "total_jobs": _normalize_non_negative_int(raw_summary.get("total_jobs")),
-        "completed_jobs": _normalize_non_negative_int(raw_summary.get("completed_jobs")),
-        "failed_jobs": _normalize_non_negative_int(raw_summary.get("failed_jobs")),
-        "active_jobs": _normalize_non_negative_int(raw_summary.get("active_jobs")),
-        "items_found_total": _normalize_non_negative_int(raw_summary.get("items_found_total")),
-    }
-    active_jobs = 0
-    completed_jobs = 0
-    failed_jobs = 0
-    items_found_total = 0
-    latest_job_metadata: dict[str, Any] = {}
-    latest_job_status = None
-    latest_error = None
-    for row in rows:
-        status = str(row.get("job_status") or "").strip().lower()
-        items_found_total += _normalize_non_negative_int(row.get("items_found"))
-        latest_job_status = status
-        latest_job_metadata = _metadata_dict(row.get("metadata"))
-        latest_error = row.get("error_message") or latest_error
-        if status in {"running", "queued", "pending", "retrying", "cancelling"}:
-            active_jobs += 1
-        elif status == "completed":
-            completed_jobs += 1
-        elif status in {"failed", "cancelled"}:
-            failed_jobs += 1
-    if not summary:
-        summary = {
-            "total_jobs": len(rows),
-            "completed_jobs": completed_jobs,
-            "failed_jobs": failed_jobs,
-            "active_jobs": active_jobs,
-            "items_found_total": items_found_total,
-        }
-    return {
-        "run_id": str((rows[0] or {}).get("run_id") or "").strip(),
-        "platform": normalized_platform,
-        "account_handle": normalized_account,
-        "run_status": str((rows[0] or {}).get("run_status") or "").strip().lower() or None,
-        "created_at": (rows[0] or {}).get("created_at"),
-        "started_at": (rows[0] or {}).get("started_at"),
-        "completed_at": (rows[0] or {}).get("completed_at"),
-        "summary": summary,
-        "job_status": latest_job_status,
-        "job_metadata": latest_job_metadata,
-        "error_message": latest_error,
-        "target_source_ids": list(_metadata_dict((rows[0] or {}).get("config")).get("target_source_ids") or []),
-    }
+    return _build_comments_scrape_run_progress_payload(
+        rows=rows,
+        platform=normalized_platform,
+        account_handle=normalized_account,
+    )
 
 
 def _format_instagram_profile_comment_row(row: Mapping[str, Any]) -> dict[str, Any]:
@@ -57856,6 +59517,8 @@ def _format_instagram_profile_comment_row(row: Mapping[str, Any]) -> dict[str, A
     created_at = row.get("created_at")
     parent_comment_id = str(row.get("parent_comment_id") or "").strip() or None
     parent_external_id = str(row.get("parent_comment_external_id") or "").strip() or None
+    media_urls = _as_text_list(row.get("media_urls"))
+    hosted_media_urls = _as_text_list(row.get("hosted_media_urls"))
     author = {
         "id": user_id,
         "username": username,
@@ -57895,6 +59558,8 @@ def _format_instagram_profile_comment_row(row: Mapping[str, Any]) -> dict[str, A
         "parent_comment_external_id": parent_external_id,
         "reply_depth": _normalize_non_negative_int(row.get("reply_depth")),
         "source_snapshot_type": row.get("source_snapshot_type"),
+        "media_urls": media_urls,
+        "hosted_media_urls": hosted_media_urls,
         "ownerUsername": username,
         "ownerProfilePicUrl": source_avatar_url or hosted_avatar_url,
         "owner": author,
@@ -58045,6 +59710,8 @@ def get_social_account_profile_comments(
                             c.text,
                             c.likes,
                             coalesce(c.reply_count, 0) as replies_count,
+                            coalesce(to_jsonb(c) -> 'media_urls', '[]'::jsonb) as media_urls,
+                            coalesce(to_jsonb(c) -> 'hosted_media_urls', '[]'::jsonb) as hosted_media_urls,
                             c.is_reply,
                             c.created_at,
                             c.parent_comment_id::text as parent_comment_id,
@@ -58080,6 +59747,8 @@ def get_social_account_profile_comments(
                           text,
                           likes,
                           replies_count,
+                          media_urls,
+                          hosted_media_urls,
                           is_reply,
                           created_at,
                           parent_comment_id,
@@ -58106,6 +59775,8 @@ def get_social_account_profile_comments(
                             null::text as text,
                             null::int as likes,
                             null::int as replies_count,
+                            '[]'::jsonb as media_urls,
+                            '[]'::jsonb as hosted_media_urls,
                             null::boolean as is_reply,
                             null::timestamptz as created_at,
                             null::text as parent_comment_id,
@@ -59694,6 +61365,7 @@ def _instagram_materialization_state(
     date_end: datetime | None = None,
 ) -> dict[str, Any]:
     normalized_account = _normalize_social_account_profile_handle(account_handle)
+    bounded_window = _catalog_backfill_has_bounded_window(date_start=date_start, date_end=date_end)
     catalog_posts = (
         _shared_catalog_total_posts_for_window(
             "instagram",
@@ -59701,7 +61373,7 @@ def _instagram_materialization_state(
             date_start=date_start,
             date_end=date_end,
         )
-        if _catalog_backfill_has_bounded_window(date_start=date_start, date_end=date_end)
+        if bounded_window
         else _shared_catalog_total_posts("instagram", normalized_account)
     )
     materialized_posts = _materialized_social_account_total_posts(
@@ -59716,13 +61388,43 @@ def _instagram_materialization_state(
         date_end=date_end,
     )
     posts_needing_detail_refresh = _normalize_non_negative_int(detail_gap_counts.get("posts_needing_detail_refresh"))
-    details_complete = catalog_posts > 0 and materialized_posts >= catalog_posts and posts_needing_detail_refresh == 0
-    bootstrap_required = catalog_posts == 0 or materialized_posts < catalog_posts
+    expected_total_posts = 0
+    if not bounded_window:
+        try:
+            expected_total_posts = _best_known_social_account_total_posts(
+                "instagram",
+                normalized_account,
+                materialized_total_posts=materialized_posts,
+                catalog_total_posts=catalog_posts,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "[instagram] Failed to resolve best-known total for materialization state account=%s",
+                normalized_account,
+            )
+            expected_total_posts = max(catalog_posts, materialized_posts)
+    completion_target_posts = max(catalog_posts, materialized_posts, expected_total_posts)
+    missing_catalog_posts = max(completion_target_posts - catalog_posts, 0) if completion_target_posts > 0 else 0
+    missing_materialized_posts = (
+        max(completion_target_posts - materialized_posts, 0) if completion_target_posts > 0 else 0
+    )
+    details_complete = (
+        catalog_posts > 0
+        and missing_catalog_posts <= 0
+        and missing_materialized_posts <= 0
+        and materialized_posts >= catalog_posts
+        and posts_needing_detail_refresh == 0
+    )
+    bootstrap_required = catalog_posts == 0 or materialized_posts < catalog_posts or missing_catalog_posts > 0
     return {
         "platform": "instagram",
         "account_handle": normalized_account,
         "catalog_posts": catalog_posts,
         "materialized_posts": materialized_posts,
+        "expected_total_posts": expected_total_posts,
+        "completion_target_posts": completion_target_posts,
+        "missing_catalog_posts": missing_catalog_posts,
+        "missing_materialized_posts": missing_materialized_posts,
         "detail_gap_counts": detail_gap_counts,
         "details_complete": details_complete,
         "bootstrap_required": bootstrap_required,
@@ -60259,7 +61961,7 @@ def _social_account_catalog_start_lock_key(platform: str, account_handle: str) -
 
 def _catalog_launch_initial_status(*, allow_local_dev_inline_bypass: bool) -> str:
     if allow_local_dev_inline_bypass or not is_queue_enabled():
-        return "pending"
+        return "running"
     return "queued"
 
 
@@ -61219,7 +62921,7 @@ def launch_social_account_catalog_backfill(
 
     if "comments" in effective_selected_tasks:
         comments_launch_started_at = time_module.perf_counter()
-        if requires_catalog_bootstrap and catalog_result is not None:
+        if catalog_result is not None:
             comments_deferred_until_catalog_complete = True
             catalog_run_id = str((catalog_result or {}).get("run_id") or "").strip()
             catalog_run_row = _load_catalog_run_row_by_id(catalog_run_id) if catalog_run_id else {}
@@ -61229,7 +62931,7 @@ def launch_social_account_catalog_backfill(
                 "platform": normalized_platform,
                 "account_handle": normalized_account,
                 "source_scope": source_scope,
-                "refresh_policy": "all_saved_posts",
+                "refresh_policy": "stale_or_missing",
                 "comments_enable_media_followups": "media" in effective_selected_tasks,
                 "allow_local_dev_inline_bypass": bool(allow_local_dev_inline_bypass),
                 "launch_group_id": launch_group_id,
@@ -61266,7 +62968,7 @@ def launch_social_account_catalog_backfill(
                     source_scope=source_scope,
                     max_posts=None,
                     max_comments_per_post=None,
-                    refresh_policy="all_saved_posts",
+                    refresh_policy="stale_or_missing",
                     initiated_by=initiated_by,
                     inline_worker_id=None if catalog_result else inline_worker_id,
                     allow_local_dev_inline_bypass=allow_local_dev_inline_bypass,
@@ -61297,15 +62999,33 @@ def launch_social_account_catalog_backfill(
                 )
                 catalog_run_id_for_media = str((catalog_result or {}).get("run_id") or "").strip() or None
                 if media_attachment_id and catalog_run_id_for_media:
-                    media_followup = _enqueue_instagram_account_media_repair_jobs(
-                        run_id=catalog_run_id_for_media,
-                        source_scope=source_scope,
-                        account_handle=normalized_account,
-                    )
+                    try:
+                        media_followup = _enqueue_instagram_account_media_repair_jobs(
+                            run_id=catalog_run_id_for_media,
+                            source_scope=source_scope,
+                            account_handle=normalized_account,
+                        )
+                        media_followup_status = "queued" if media_followup["enqueued_job_count"] > 0 else "completed"
+                    except Exception:
+                        logger.exception(
+                            (
+                                "[catalog-launch] media_followup_enqueue_failed platform=%s account=%s "
+                                "catalog_run_id=%s comments_run_id=%s"
+                            ),
+                            normalized_platform,
+                            normalized_account,
+                            catalog_run_id_for_media,
+                            active_comments_run_id,
+                        )
+                        media_followup = {
+                            "enqueued_job_ids": [],
+                            "enqueued_job_count": 0,
+                        }
+                        media_followup_status = "failed"
                     attached_followups["media"] = _build_attached_media_followup(
                         attachment_id=media_attachment_id,
                         source="catalog_media_mirror",
-                        status="queued" if media_followup["enqueued_job_count"] > 0 else "completed",
+                        status=media_followup_status,
                         enqueued_job_ids=media_followup["enqueued_job_ids"],
                         enqueued_job_count=media_followup["enqueued_job_count"],
                     )
@@ -61425,44 +63145,143 @@ def request_cancel_social_account_catalog_run(
         raise ValueError("Shared run not found")
 
     cancel_requested_at = _now_utc()
-    cancellation_metadata = {
+    cancel_result = cancel_shared_run(normalized_run_id, cancelled_by=cancelled_by)
+    _invalidate_queue_status_cache()
+    return {
+        "run_id": normalized_run_id,
+        "status": str(cancel_result.get("status") or "cancelled"),
+        "accepted": True,
         "cancel_requested_at": _iso(cancel_requested_at),
-        "cancel_requested_by": cancelled_by,
+        "cancelled_jobs": _normalize_non_negative_int(cancel_result.get("cancelled_jobs")),
     }
+
+
+def _load_social_account_comments_run_row(
+    *,
+    platform: str,
+    account_handle: str,
+    run_id: str,
+    conn: Any | None = None,
+) -> dict[str, Any]:
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    _assert_social_account_profile_exists(normalized_platform, normalized_account)
+    run_row = pg.fetch_one(
+        """
+        select
+          id::text as id,
+          id::text as run_id,
+          season_id::text as season_id,
+          status,
+          source_scope,
+          config,
+          summary,
+          created_at,
+          started_at,
+          completed_at
+        from social.scrape_runs
+        where id = %s::uuid
+          and lower(coalesce(config->>'stage', '')) = %s
+          and lower(coalesce(config->>'platform', '')) = %s
+          and lower(coalesce(config->>'account', '')) = %s
+        limit 1
+        """,
+        [run_id, INSTAGRAM_COMMENTS_SCRAPLING_STAGE, normalized_platform, normalized_account],
+        conn=conn,
+    )
+    if not run_row:
+        raise LookupError("Comments run not found.")
+    return {
+        "id": str(run_row.get("id") or "").strip(),
+        "run_id": str(run_row.get("run_id") or run_row.get("id") or "").strip(),
+        "season_id": str(run_row.get("season_id") or "").strip() or None,
+        "status": str(run_row.get("status") or "").strip().lower(),
+        "source_scope": str(run_row.get("source_scope") or "").strip() or None,
+        "config": _metadata_dict(run_row.get("config")),
+        "summary": _metadata_dict(run_row.get("summary")),
+        "created_at": run_row.get("created_at"),
+        "started_at": run_row.get("started_at"),
+        "completed_at": run_row.get("completed_at"),
+        "platform": normalized_platform,
+        "account_handle": normalized_account,
+    }
+
+
+def cancel_social_account_comments_run(
+    *,
+    platform: str,
+    account_handle: str,
+    run_id: str,
+    cancelled_by: str | None = None,
+    conn: Any | None = None,
+) -> dict[str, Any]:
+    run_row = _load_social_account_comments_run_row(
+        platform=platform,
+        account_handle=account_handle,
+        run_id=run_id,
+        conn=conn,
+    )
+    normalized_run_id = str(run_row.get("id") or "").strip()
+    if not normalized_run_id:
+        raise LookupError("Comments run not found.")
+    cancel_requested_at = _now_utc()
     pg.fetch_one(
         """
         update social.scrape_runs
         set
-          status = case
-            when status in ('queued', 'pending', 'retrying', 'running', 'cancelling') then 'cancelling'
-            else status
-          end,
-          summary = coalesce(summary, '{}'::jsonb) || %s::jsonb
+          status = 'cancelled',
+          cancelled_at = now(),
+          completed_at = now(),
+          summary = coalesce(summary, '{}'::jsonb) || jsonb_build_object(
+            'cancelled_by', %s,
+            'cancel_requested_at', %s
+          )
         where id = %s::uuid
-        returning id::text as id, status
+        returning id::text
         """,
-        [_json_dumps(cancellation_metadata), normalized_run_id],
+        [cancelled_by, _iso(cancel_requested_at), normalized_run_id],
+        conn=conn,
     )
-    pg.execute(
+    cancelled_jobs = pg.execute_returning(
         """
         update social.scrape_jobs
         set
-          status = case
-            when status in ('queued', 'pending', 'retrying', 'running') then 'cancelling'
-            else status
-          end,
-          metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
+          status = 'cancelled',
+          completed_at = now(),
+          error_message = coalesce(error_message, 'Cancelled by user request'),
+          metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+            'cancel_reason', 'comments_run_cancelled_by_admin',
+            'cancelled_by', %s,
+            'cancelled_at', %s
+          )
         where run_id = %s::uuid
-          and status in ('queued', 'pending', 'retrying', 'running')
+          and status in ('queued', 'pending', 'retrying', 'running', 'cancelling')
+        returning id::text as id
         """,
-        [_json_dumps(cancellation_metadata), normalized_run_id],
+        [cancelled_by, _iso(cancel_requested_at), normalized_run_id],
+        conn=conn,
     )
+    cancelled_job_ids = [
+        str(row.get("id") or "").strip()
+        for row in cancelled_jobs
+        if str(row.get("id") or "").strip()
+    ]
+    for job_id in cancelled_job_ids:
+        _clear_worker_heartbeat_for_job(
+            job_id=job_id,
+            status="idle",
+            metadata={"source": "cancel_social_account_comments_run", "job_status": "cancelled"},
+        )
+    summary = _update_run_summary(normalized_run_id, force_recompute=True, conn=conn)
     _invalidate_queue_status_cache()
     return {
         "run_id": normalized_run_id,
-        "status": "cancelling",
+        "status": "cancelled",
         "accepted": True,
         "cancel_requested_at": _iso(cancel_requested_at),
+        "cancelled_jobs": len(cancelled_job_ids),
+        "cancelled_job_ids": cancelled_job_ids,
+        "summary": summary,
     }
 
 

--- a/trr_backend/socials/control_plane/run_lifecycle.py
+++ b/trr_backend/socials/control_plane/run_lifecycle.py
@@ -33,6 +33,7 @@ def _create_run(
     initiated_by: str | None,
     config: dict[str, Any],
     status: str,
+    conn: Any | None = None,
 ) -> str:
     initial_summary = _build_run_summary_payload(
         total_jobs=0,
@@ -42,7 +43,8 @@ def _create_run(
         items_found_total=0,
         stage_counts={},
     )
-    row = legacy.pg.fetch_one(
+    row = _call_with_optional_conn(
+        legacy.pg.fetch_one,
         """
         insert into social.scrape_runs (
           season_id,
@@ -76,6 +78,7 @@ def _create_run(
             legacy.json.dumps(initial_summary),
             status,
         ],
+        conn=conn,
     )
     if not row:
         raise RuntimeError("Failed to create social scrape run")
@@ -86,7 +89,8 @@ def _create_run(
         pass_attempt = legacy._normalize_non_negative_int(config.get("pass_attempt")) or None
         pass_sequence = legacy._normalize_non_negative_int(config.get("pass_sequence")) or None
         if sync_session_id or pass_kind or pass_attempt is not None or pass_sequence is not None:
-            legacy.pg.fetch_one(
+            _call_with_optional_conn(
+                legacy.pg.fetch_one,
                 """
                 update social.scrape_runs
                 set
@@ -98,6 +102,7 @@ def _create_run(
                 returning id::text
                 """,
                 [sync_session_id, pass_kind, pass_attempt, pass_sequence, run_id],
+                conn=conn,
             )
     return run_id
 
@@ -114,17 +119,19 @@ def _set_run_status(run_id: str, status: str, *, conn: Any | None = None) -> Non
             else started_at
           end,
           completed_at = case
+            when %s in ('queued', 'pending', 'retrying', 'running') then null
             when %s in ('completed', 'failed', 'cancelled') then coalesce(completed_at, now())
             else completed_at
           end,
           cancelled_at = case
+            when %s in ('queued', 'pending', 'retrying', 'running') then null
             when %s = 'cancelled' then coalesce(cancelled_at, now())
             else cancelled_at
           end
         where id = %s
         returning id::text
         """,
-        [status, status, status, status, run_id],
+        [status, status, status, status, status, status, run_id],
         conn=conn,
     )
     legacy._invalidate_queue_status_cache()
@@ -166,7 +173,7 @@ def _maybe_start_deferred_comments_followup(
 ) -> None:
     if str(run_status or "").strip().lower() != "completed":
         return
-    if not legacy._shared_account_catalog_scrape_complete(run_config=run_config, summary=summary):
+    if not legacy._shared_account_catalog_scrape_complete(run_config=run_config, summary=summary, conn=conn):
         return
     followup = legacy._metadata_dict(run_config.get("deferred_comments_followup"))
     if str(followup.get("state") or "").strip().lower() != "pending":
@@ -177,19 +184,29 @@ def _maybe_start_deferred_comments_followup(
     attached_followups = legacy._normalize_attached_followups(run_config.get("attached_followups"))
     now_iso = legacy._iso(legacy._now_utc())
     try:
-        comments_result = legacy.start_social_account_comments_scrape(
-            str(followup.get("platform") or "").strip(),
-            str(followup.get("account_handle") or "").strip(),
-            mode="profile",
-            source_scope=str(followup.get("source_scope") or "bravo"),
-            max_posts=None,
-            max_comments_per_post=None,
-            refresh_policy=str(followup.get("refresh_policy") or "all_saved_posts"),
-            initiated_by="catalog_completion_followup",
-            allow_local_dev_inline_bypass=bool(followup.get("allow_local_dev_inline_bypass")),
-            comments_enable_media_followups=bool(followup.get("comments_enable_media_followups")),
-            launch_group_id=str(followup.get("launch_group_id") or "").strip() or None,
-        )
+        comments_source = "deferred_after_catalog"
+        try:
+            comments_result = legacy.start_social_account_comments_scrape(
+                str(followup.get("platform") or "").strip(),
+                str(followup.get("account_handle") or "").strip(),
+                mode="profile",
+                source_scope=str(followup.get("source_scope") or "bravo"),
+                max_posts=None,
+                max_comments_per_post=None,
+                refresh_policy=str(followup.get("refresh_policy") or "all_saved_posts"),
+                initiated_by="catalog_completion_followup",
+                allow_local_dev_inline_bypass=bool(followup.get("allow_local_dev_inline_bypass")),
+                comments_enable_media_followups=bool(followup.get("comments_enable_media_followups")),
+                launch_group_id=str(followup.get("launch_group_id") or "").strip() or None,
+            )
+        except legacy.SocialIngestConflictError as exc:
+            if exc.code != "SOCIAL_ACCOUNT_COMMENTS_RUN_ALREADY_ACTIVE":
+                raise
+            comments_result = {
+                "run_id": str(exc.detail.get("run_id") or "").strip() or None,
+                "status": str(exc.detail.get("status") or "running").strip().lower() or "running",
+            }
+            comments_source = "reused_run"
         _merge_run_config(
             run_id,
             config_updates={
@@ -198,7 +215,7 @@ def _maybe_start_deferred_comments_followup(
                     "comments": legacy._build_attached_comments_followup(
                         run_id=str((comments_result or {}).get("run_id") or "").strip() or None,
                         status=str((comments_result or {}).get("status") or "").strip().lower() or "pending",
-                        source="deferred_after_catalog",
+                        source=comments_source,
                     ),
                 },
                 "deferred_comments_followup": {
@@ -357,11 +374,17 @@ def _increment_stage_counter(
     return stage_counts
 
 
-def _increment_run_counters_on_job_create(*, run_id: str, stage: str, status: str) -> None:
+def _increment_run_counters_on_job_create(
+    *,
+    run_id: str,
+    stage: str,
+    status: str,
+    conn: Any | None = None,
+) -> None:
     if not run_id or not legacy._run_counter_columns_ready():
         return
     stage_key = str(stage or "unknown").strip() or "unknown"
-    with legacy.pg.db_connection() as conn:
+    if conn is not None:
         with legacy.pg.db_cursor(conn=conn) as cur:
             row = (
                 legacy.pg.fetch_one_with_cursor(
@@ -382,29 +405,75 @@ def _increment_run_counters_on_job_create(*, run_id: str, stage: str, status: st
                 )
                 or {}
             )
-            if not row:
-                return
-            total_jobs = legacy._normalize_non_negative_int(row.get("total_jobs")) + 1
-            completed_jobs = legacy._normalize_non_negative_int(row.get("completed_jobs"))
-            failed_jobs = legacy._normalize_non_negative_int(row.get("failed_jobs"))
-            active_jobs = legacy._normalize_non_negative_int(row.get("active_jobs")) + (
-                1 if _status_is_active(status) else 0
-            )
-            items_found_total = legacy._normalize_non_negative_int(row.get("items_found_total"))
-            stage_counts = _normalize_stage_counts(row.get("stage_counts"))
-            stage_counts = _increment_stage_counter(stage_counts, stage=stage_key, key="total", delta=1)
-            if _status_is_active(status):
-                stage_counts = _increment_stage_counter(stage_counts, stage=stage_key, key="active", delta=1)
-            _persist_run_counters_and_summary(
+            _persist_incremented_run_create_counters(
                 conn=conn,
                 run_id=run_id,
-                total_jobs=total_jobs,
-                completed_jobs=completed_jobs,
-                failed_jobs=failed_jobs,
-                active_jobs=active_jobs,
-                items_found_total=items_found_total,
-                stage_counts=stage_counts,
+                row=row,
+                stage_key=stage_key,
+                status=status,
             )
+        return
+    with legacy.pg.db_connection() as write_conn:
+        with legacy.pg.db_cursor(conn=write_conn) as cur:
+            row = (
+                legacy.pg.fetch_one_with_cursor(
+                    cur,
+                    """
+                select
+                  total_jobs,
+                  completed_jobs,
+                  failed_jobs,
+                  active_jobs,
+                  items_found_total,
+                  stage_counts
+                from social.scrape_runs
+                where id = %s
+                for update
+                """,
+                    [run_id],
+                )
+                or {}
+            )
+            _persist_incremented_run_create_counters(
+                conn=write_conn,
+                run_id=run_id,
+                row=row,
+                stage_key=stage_key,
+                status=status,
+            )
+
+
+def _persist_incremented_run_create_counters(
+    *,
+    conn: Any,
+    run_id: str,
+    row: dict[str, Any],
+    stage_key: str,
+    status: str,
+) -> None:
+    if not row:
+        return
+    total_jobs = legacy._normalize_non_negative_int(row.get("total_jobs")) + 1
+    completed_jobs = legacy._normalize_non_negative_int(row.get("completed_jobs"))
+    failed_jobs = legacy._normalize_non_negative_int(row.get("failed_jobs"))
+    active_jobs = legacy._normalize_non_negative_int(row.get("active_jobs")) + (
+        1 if _status_is_active(status) else 0
+    )
+    items_found_total = legacy._normalize_non_negative_int(row.get("items_found_total"))
+    stage_counts = _normalize_stage_counts(row.get("stage_counts"))
+    stage_counts = _increment_stage_counter(stage_counts, stage=stage_key, key="total", delta=1)
+    if _status_is_active(status):
+        stage_counts = _increment_stage_counter(stage_counts, stage=stage_key, key="active", delta=1)
+    _persist_run_counters_and_summary(
+        conn=conn,
+        run_id=run_id,
+        total_jobs=total_jobs,
+        completed_jobs=completed_jobs,
+        failed_jobs=failed_jobs,
+        active_jobs=active_jobs,
+        items_found_total=items_found_total,
+        stage_counts=stage_counts,
+    )
 
 
 def _increment_run_counters_on_job_finish(

--- a/trr_backend/socials/instagram/auth_resolver.py
+++ b/trr_backend/socials/instagram/auth_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import fcntl
 import hashlib
@@ -92,6 +93,9 @@ def _default_session_account_id() -> str | None:
     validation_username = (os.getenv("SOCIAL_INSTAGRAM_COOKIE_VALIDATION_USERNAME") or "").strip().lstrip("@")
     if validation_username:
         return validation_username.lower()
+    auth_username, _ = _auth_credentials()
+    if auth_username:
+        return auth_username.strip().lstrip("@").lower()
     return None
 
 
@@ -117,6 +121,14 @@ def _is_local_environment() -> bool:
     return not (os.getenv("MODAL_TASK_ID") or os.getenv("MODAL_ENVIRONMENT"))
 
 
+def _running_event_loop_active() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
 def _auth_credentials() -> tuple[str | None, str | None]:
     username = (
         (os.getenv("SOCIAL_AUTH_INSTAGRAM_USERNAME") or "").strip()
@@ -132,6 +144,8 @@ def _auth_credentials() -> tuple[str | None, str | None]:
 
 
 def _auto_refresh_enabled() -> bool:
+    if _running_event_loop_active():
+        return False
     raw = (os.getenv("SOCIAL_INSTAGRAM_COOKIE_AUTO_REFRESH") or "").strip().lower()
     if raw:
         return raw not in {"0", "false", "off", "no"}
@@ -142,6 +156,8 @@ def _auto_refresh_enabled() -> bool:
 def _interactive_login_enabled() -> bool:
     raw = (os.getenv("SOCIAL_INSTAGRAM_INTERACTIVE_LOGIN") or "").strip().lower()
     if raw in {"0", "false", "off", "no"}:
+        return False
+    if _running_event_loop_active():
         return False
     return _is_local_environment()
 
@@ -154,14 +170,21 @@ def _looks_like_shortcode(value: str) -> bool:
     return bool(_SHORTCODE_RE.fullmatch(value) and any(ch.isupper() for ch in value))
 
 
+def _looks_like_handle(value: str) -> bool:
+    normalized = str(value or "").strip().lstrip("@")
+    return bool(_HANDLE_RE.fullmatch(normalized.lower()) and not _looks_like_shortcode(normalized))
+
+
 def _normalize_session_account_id(browser_account_id: str | None) -> tuple[str | None, str | None]:
     normalized = str(browser_account_id or "").strip().lstrip("@")
-    if not normalized:
-        return _default_session_account_id(), None
-    lower = normalized.lower()
-    if _HANDLE_RE.fullmatch(lower) and not _looks_like_shortcode(normalized):
-        return lower, None
     default_account_id = _default_session_account_id()
+    if not normalized:
+        return default_account_id, None
+    lower = normalized.lower()
+    if default_account_id and default_account_id != lower:
+        return default_account_id, normalized
+    if _looks_like_handle(normalized):
+        return lower, None
     if default_account_id:
         return default_account_id, normalized
     return None, normalized
@@ -388,15 +411,21 @@ def _cache_evict(fingerprint: str | None) -> None:
     _VALIDATION_CACHE.pop(fingerprint, None)
 
 
-def _validation_username(session_account_id: str | None) -> str:
+def _validation_username(session_account_id: str | None, *, caller_context: str | None = None) -> str:
     fallback = (os.getenv("SOCIAL_INSTAGRAM_COOKIE_VALIDATION_USERNAME") or "").strip().lstrip("@")
-    return (session_account_id or fallback or "bravotv").lower()
+    if fallback:
+        return fallback.lower()
+    normalized_context = str(caller_context or "").strip().lstrip("@")
+    if _looks_like_handle(normalized_context):
+        return normalized_context.lower()
+    return (session_account_id or "bravotv").lower()
 
 
 def _validate_cookies_via_graphql(
     cookies: dict[str, str],
     *,
     session_account_id: str | None,
+    caller_context: str | None = None,
     require_validation: bool,
 ) -> tuple[bool, str | None, str, bool]:
     structurally_valid, structural_reason = _structural_validation(cookies)
@@ -421,7 +450,7 @@ def _validate_cookies_via_graphql(
 
     from trr_backend.socials.instagram.scraper import InstagramScraper
 
-    validation_username = _validation_username(session_account_id)
+    validation_username = _validation_username(session_account_id, caller_context=caller_context)
     scraper = InstagramScraper(cookies=dict(cookies), browser_account_id=session_account_id or validation_username)
     payload = scraper.fetch_posts_graphql(
         validation_username,
@@ -478,6 +507,7 @@ def _promote_browser_session_to_canonical_file(
     cookie_file_path: Path,
     browser_candidate: _CookieCandidate | None,
     observed_mtime: float | None,
+    caller_context: str | None = None,
 ) -> bool:
     if browser_candidate is None:
         return False
@@ -491,6 +521,7 @@ def _promote_browser_session_to_canonical_file(
         current_valid, _, _, _ = _validate_cookies_via_graphql(
             current_cookies,
             session_account_id=None,
+            caller_context=caller_context,
             require_validation=True,
         )
         if current_valid:
@@ -502,6 +533,7 @@ def _promote_browser_session_to_canonical_file(
 def _refresh_with_credentials(
     *,
     session_account_id: str | None,
+    caller_context: str | None = None,
     cookie_file_path: Path,
 ) -> tuple[dict[str, str], str | None]:
     if not _auto_refresh_enabled():
@@ -517,7 +549,7 @@ def _refresh_with_credentials(
         headless=(os.getenv("SOCIAL_INSTAGRAM_COOKIE_REFRESH_HEADLESS") or "true").strip().lower()
         not in {"0", "false", "off", "no"},
         timeout_seconds=max(30, int(os.getenv("SOCIAL_INSTAGRAM_COOKIE_REFRESH_TIMEOUT_SECONDS") or "120")),
-        validation_username=_validation_username(session_account_id),
+        validation_username=_validation_username(session_account_id, caller_context=caller_context),
     )
     return cookies, "credential_refresh"
 
@@ -525,6 +557,7 @@ def _refresh_with_credentials(
 def _refresh_interactively(
     *,
     session_account_id: str | None,
+    caller_context: str | None = None,
     cookie_file_path: Path,
 ) -> tuple[dict[str, str], str | None]:
     if not _interactive_login_enabled():
@@ -534,7 +567,8 @@ def _refresh_interactively(
         or "entertainmentdatagroup@gmail.com",
         cookie_file=str(cookie_file_path),
         timeout_seconds=max(60, int(os.getenv("SOCIAL_INSTAGRAM_INTERACTIVE_TIMEOUT_SECONDS") or "300")),
-        validation_username=_validation_username(session_account_id),
+        validation_username=_validation_username(session_account_id, caller_context=caller_context),
+        account_id=session_account_id,
         headless=(os.getenv("SOCIAL_INSTAGRAM_BROWSER_MODE") or "").strip().lower() == "headless",
     )
     return cookies, "interactive_login"
@@ -606,6 +640,9 @@ def resolve_instagram_auth_session(
 ) -> InstagramAuthSession:
     session_account_id, normalized_caller_context = _normalize_session_account_id(browser_account_id)
     caller_context = str(caller_context or normalized_caller_context or "").strip() or None
+    validation_context = caller_context if _looks_like_handle(caller_context or "") else normalized_caller_context
+    if not _looks_like_handle(validation_context or ""):
+        validation_context = None
     if session_account_id is None and require_validation:
         raise RuntimeError("instagram_auth_session_account_unresolved")
 
@@ -667,6 +704,7 @@ def resolve_instagram_auth_session(
         validated, validation_reason, validation_category, stale_ok = _validate_cookies_via_graphql(
             cookies,
             session_account_id=session_account_id,
+            caller_context=validation_context,
             require_validation=require_validation,
         )
         refreshed = False
@@ -683,6 +721,7 @@ def resolve_instagram_auth_session(
                 validated, validation_reason, validation_category, stale_ok = _validate_cookies_via_graphql(
                     cookies,
                     session_account_id=session_account_id,
+                    caller_context=validation_context,
                     require_validation=require_validation,
                 )
 
@@ -695,6 +734,7 @@ def resolve_instagram_auth_session(
                 validated_browser, reason_browser, category_browser, stale_ok_browser = _validate_cookies_via_graphql(
                     browser_candidate.cookies,
                     session_account_id=session_account_id,
+                    caller_context=validation_context,
                     require_validation=True,
                 )
                 if validated_browser:
@@ -708,6 +748,7 @@ def resolve_instagram_auth_session(
             if not validated and validation_category not in {"checkpoint_required", "unauthorized", "redirect_login"}:
                 refreshed_cookies, refresh_method = _refresh_with_credentials(
                     session_account_id=session_account_id,
+                    caller_context=validation_context,
                     cookie_file_path=cookie_file_path,
                 )
                 if refreshed_cookies:
@@ -718,12 +759,14 @@ def resolve_instagram_auth_session(
                     validated, validation_reason, validation_category, stale_ok = _validate_cookies_via_graphql(
                         cookies,
                         session_account_id=session_account_id,
+                        caller_context=validation_context,
                         require_validation=True,
                     )
 
             if not validated and validation_category in {"graphql_validation_failed", "unauthorized", "redirect_login"}:
                 interactive_cookies, interactive_method = _refresh_interactively(
                     session_account_id=session_account_id,
+                    caller_context=validation_context,
                     cookie_file_path=cookie_file_path,
                 )
                 if interactive_cookies:
@@ -735,6 +778,7 @@ def resolve_instagram_auth_session(
                     validated, validation_reason, validation_category, stale_ok = _validate_cookies_via_graphql(
                         cookies,
                         session_account_id=session_account_id,
+                        caller_context=validation_context,
                         require_validation=True,
                     )
 
@@ -745,6 +789,7 @@ def resolve_instagram_auth_session(
                 cookie_file_path=cookie_file_path,
                 browser_candidate=browser_candidate,
                 observed_mtime=observed_cookie_file_mtime,
+                caller_context=validation_context,
             )
 
         auth_session = _build_auth_session(

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -11,11 +11,19 @@ API calls go through httpx with the cookies bridged from warmup.
 from __future__ import annotations
 
 import asyncio
+import fcntl
+import hashlib
+import html as html_lib
 import json
 import logging
+import os
+import re
+import tempfile
 import time
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlencode
 
 import httpx
 
@@ -53,11 +61,17 @@ from trr_backend.socials.instagram.scraper import InstagramComment, InstagramScr
 
 logger = logging.getLogger("socials.instagram.comments_scrapling.fetcher")
 
-_COMMENT_PAGINATION_MAX_PAGES_DEFAULT = 25
-_REPLY_PAGINATION_MAX_PAGES_DEFAULT = 10
-_COMMENT_PAGINATION_MAX_SECONDS_DEFAULT = 30.0
-_REPLY_PAGINATION_MAX_SECONDS_DEFAULT = 20.0
+_COMMENT_PAGINATION_MAX_PAGES_DEFAULT = 250
+_REPLY_PAGINATION_MAX_PAGES_DEFAULT = 100
+_COMMENT_PAGINATION_MAX_SECONDS_DEFAULT = 600.0
+_REPLY_PAGINATION_MAX_SECONDS_DEFAULT = 180.0
 _COMMENT_REQUEST_DELAY_DEFAULT = 0.25
+_REPLY_CHECKPOINT_MAX_ITEMS_DEFAULT = 25
+_REPLY_CHECKPOINT_STRING_MAX_LENGTH = 256
+_BROWSER_API_FALLBACK_ENV = "SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK"
+_REVEAL_HIDDEN_COMMENTS_ENV = "SOCIAL_INSTAGRAM_COMMENTS_REVEAL_HIDDEN"
+_REVEAL_HIDDEN_COMMENTS_WITHOUT_EXPECTED_ENV = "SOCIAL_INSTAGRAM_COMMENTS_REVEAL_HIDDEN_WITHOUT_EXPECTED"
+_HIDDEN_COMMENTS_CLICK_LIMIT_DEFAULT = 4
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,10 +87,235 @@ _API_HEADER_KEYS_TO_STRIP = frozenset(
     }
 )
 
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_SPAN_TEXT_RE = re.compile(r"<span\b[^>]*\bdir=[\"']auto[\"'][^>]*>(.*?)</span>", re.IGNORECASE | re.DOTALL)
+_TIME_DATETIME_RE = re.compile(r"<time\b[^>]*\bdatetime=[\"']([^\"']+)[\"']", re.IGNORECASE)
+_PROFILE_HREF_RE = re.compile(r"href=[\"']/([^/\"?#]+)/[\"']", re.IGNORECASE)
+_LIKE_COUNT_RE = re.compile(r"\b(\d[\d,]*)\s+likes?\b", re.IGNORECASE)
+
+
+def _safe_non_negative_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _clean_html_text(fragment: str) -> str:
+    cleaned = _HTML_TAG_RE.sub(" ", str(fragment or ""))
+    cleaned = html_lib.unescape(cleaned).replace("\xa0", " ")
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _rendered_text_is_comment_body(value: str, *, username: str | None = None) -> bool:
+    text = str(value or "").strip()
+    if not text:
+        return False
+    normalized = text.casefold()
+    if username and normalized == username.casefold():
+        return False
+    if normalized in {"reply", "like", "view hidden comments", "view replies", "hide replies"}:
+        return False
+    if re.fullmatch(r"\d+\s*(?:s|m|h|d|w|y)", normalized):
+        return False
+    if re.fullmatch(r"\d[\d,]*\s+likes?", normalized):
+        return False
+    if normalized.startswith("view ") and "comment" in normalized:
+        return False
+    return True
+
+
+def _extract_rendered_comment_username(before_permalink_html: str) -> str:
+    ignored = {
+        "accounts",
+        "explore",
+        "p",
+        "reel",
+        "reels",
+        "stories",
+        "thetraitorsus",
+    }
+    for match in reversed(list(_PROFILE_HREF_RE.finditer(str(before_permalink_html or "")))):
+        username = html_lib.unescape(match.group(1)).strip().strip("/")
+        if username and username.lower() not in ignored:
+            return username
+    return ""
+
+
+def _extract_rendered_comment_text(after_permalink_html: str, *, username: str) -> str:
+    for match in _SPAN_TEXT_RE.finditer(str(after_permalink_html or "")):
+        candidate = _clean_html_text(match.group(1))
+        if _rendered_text_is_comment_body(candidate, username=username):
+            return candidate
+    return ""
+
+
+def _extract_rendered_comment_created_at(after_permalink_html: str) -> int:
+    match = _TIME_DATETIME_RE.search(str(after_permalink_html or ""))
+    if not match:
+        return 0
+    raw_value = html_lib.unescape(match.group(1)).strip()
+    if not raw_value:
+        return 0
+    try:
+        parsed = datetime.fromisoformat(raw_value.replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return max(0, int(parsed.timestamp()))
+
+
+def _extract_rendered_comment_like_count(after_permalink_html: str) -> int:
+    match = _LIKE_COUNT_RE.search(_clean_html_text(after_permalink_html[:2500]))
+    if not match:
+        return 0
+    return int(match.group(1).replace(",", "") or 0)
+
+
+def _extract_rendered_permalink_comments(
+    html_text: str,
+    *,
+    shortcode: str,
+    post_url: str,
+) -> list[InstagramComment]:
+    """Extract comments visible in the rendered post DOM.
+
+    Instagram's JSON comments endpoint can omit comments hidden behind the
+    rendered "View hidden comments" control. Once the browser clicks that
+    control, those comments still expose stable `/p/{shortcode}/c/{id}/`
+    permalinks, which gives us a deterministic anchor for parsing.
+    """
+
+    normalized_shortcode = str(shortcode or "").strip()
+    if not normalized_shortcode:
+        return []
+    permalink_pattern = re.compile(
+        rf"href=[\"'](?P<href>/p/{re.escape(normalized_shortcode)}/c/(?P<comment_id>\d+)/?[^\"']*)[\"']",
+        re.IGNORECASE,
+    )
+    comments: list[InstagramComment] = []
+    seen_comment_ids: set[str] = set()
+    text = str(html_text or "")
+    for match in permalink_pattern.finditer(text):
+        comment_id = str(match.group("comment_id") or "").strip()
+        if not comment_id or comment_id in seen_comment_ids:
+            continue
+        context_start = max(0, match.start() - 3000)
+        context_end = min(len(text), match.end() + 5000)
+        before_permalink = text[context_start : match.start()]
+        after_permalink = text[match.end() : context_end]
+        username = _extract_rendered_comment_username(before_permalink)
+        comment_text = _extract_rendered_comment_text(after_permalink, username=username)
+        if not username or not comment_text:
+            continue
+        created_at = _extract_rendered_comment_created_at(after_permalink)
+        seen_comment_ids.add(comment_id)
+        comments.append(
+            InstagramComment(
+                comment_id=comment_id,
+                text=comment_text,
+                username=username,
+                user_id="",
+                created_at=created_at,
+                date_time=datetime.fromtimestamp(created_at, tz=UTC).strftime("%Y-%m-%d %H:%M:%S")
+                if created_at
+                else "",
+                likes=_extract_rendered_comment_like_count(after_permalink),
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+                post_shortcode=normalized_shortcode,
+                post_url=post_url,
+            )
+        )
+    return comments
+
+
+def _merge_unique_comments(
+    comments: list[InstagramComment],
+    extra_comments: list[InstagramComment],
+    *,
+    max_comments: int,
+) -> int:
+    seen = {str(comment.comment_id or "").strip() for comment in comments if str(comment.comment_id or "").strip()}
+    appended = 0
+    for comment in extra_comments:
+        comment_id = str(comment.comment_id or "").strip()
+        if not comment_id or comment_id in seen:
+            continue
+        comments.append(comment)
+        seen.add(comment_id)
+        appended += 1
+        if max_comments > 0 and len(comments) >= max_comments:
+            break
+    return appended
+
 
 def _auth_failure_text(text: str) -> bool:
     normalized = str(text or "").strip().lower()
     return any(token in normalized for token in ("login", "checkpoint", "challenge", "accounts/login"))
+
+
+def _global_rate_limit_key(browser_account_id: str | None, proxy_fingerprint: str | None) -> str:
+    account = str(browser_account_id or "").strip().lower().lstrip("@") or "instagram"
+    proxy = str(proxy_fingerprint or "").strip().lower() or "no-proxy"
+    digest = hashlib.sha256(f"{account}:{proxy}".encode()).hexdigest()[:24]
+    return f"{account}-{digest}"
+
+
+def _global_rate_limit_path(key: str) -> str:
+    safe_key = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in str(key or "instagram"))
+    directory = os.path.join(tempfile.gettempdir(), "trr-instagram-comments-rate")
+    os.makedirs(directory, exist_ok=True)
+    return os.path.join(directory, f"{safe_key}.lock")
+
+
+def _pace_global_api_request(*, key: str, delay_seconds: float) -> None:
+    delay = max(0.0, float(delay_seconds or 0))
+    if delay <= 0:
+        return
+    path = _global_rate_limit_path(key)
+    with open(path, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            handle.seek(0)
+            raw_last_started_at = handle.read().strip()
+            try:
+                last_started_at = float(raw_last_started_at)
+            except (TypeError, ValueError):
+                last_started_at = 0.0
+            now = time.time()
+            remaining = (last_started_at + delay) - now
+            if remaining > 0:
+                time.sleep(remaining)
+                now = time.time()
+            handle.seek(0)
+            handle.truncate()
+            handle.write(f"{now:.6f}")
+            handle.flush()
+            os.fsync(handle.fileno())
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _cookies_to_scrapling(cookies: dict[str, str]) -> list[dict[str, Any]]:
+    payload: list[dict[str, Any]] = []
+    for name, value in (cookies or {}).items():
+        cookie_name = str(name or "").strip()
+        cookie_value = str(value or "").strip()
+        if not (cookie_name and cookie_value):
+            continue
+        payload.append(
+            {
+                "name": cookie_name,
+                "value": cookie_value,
+                "domain": ".instagram.com",
+                "path": "/",
+            }
+        )
+    return payload
 
 
 def _document_auth_failure_text(text: str) -> bool:
@@ -94,6 +333,42 @@ def _document_auth_failure_text(text: str) -> bool:
             "checkpoint_required",
         )
     )
+
+
+_TRANSPORT_FAILURE_MARKERS = (
+    "wrong_version_number",
+    "wrong version number",
+    "ssl:",
+    "ssl connection",
+    "closed unexpectedly",
+    "proxy error",
+    "proxyerror",
+    "net::err_http_response_code_failure",
+    "http_response_code_failure",
+    "connecterror",
+    "readerror",
+    "connection reset",
+    "server disconnected",
+    "network is unreachable",
+    "temporarily unavailable",
+)
+
+
+def _transport_failure_message(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    return any(marker in message for marker in _TRANSPORT_FAILURE_MARKERS)
+
+
+def _warmup_transport_failure(exc: BaseException) -> bool:
+    if isinstance(exc, TimeoutError | httpx.TimeoutException | httpx.TransportError | OSError):
+        return True
+    return _transport_failure_message(exc)
+
+
+def _api_transport_failure(exc: BaseException) -> bool:
+    if isinstance(exc, TimeoutError | httpx.TimeoutException | httpx.TransportError):
+        return True
+    return isinstance(exc, OSError) and _transport_failure_message(exc)
 
 
 class InstagramCommentsWarmupError(RuntimeError):
@@ -117,8 +392,10 @@ class InstagramCommentsFetchResult:
     fetch_failed: bool = False
     auth_failed: bool = False
     fetch_reason: str | None = None
+    reported_comment_count: int | None = None
     request_count: int = 0
     retryable: bool = False
+    reply_checkpoints: list[dict[str, Any]] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +407,7 @@ class InstagramCommentsScraplingFetcher:
     """Hybrid fetcher: Patchright for warmup, httpx for API calls."""
 
     # Retry policy for transient errors (429 / 5xx / transport timeout).
-    _MAX_TRANSIENT_RETRIES: int = 3
+    _MAX_TRANSIENT_RETRIES: int = 5
     _BASE_BACKOFF_SECONDS: float = 1.0
 
     def __init__(
@@ -162,8 +439,46 @@ class InstagramCommentsScraplingFetcher:
             minimum=0.0,
             maximum=30.0,
         )
+        self._global_api_delay_seconds = (
+            _resolve_positive_float_env(
+                "SOCIAL_INSTAGRAM_COMMENT_GLOBAL_DELAY_SEC",
+                self._api_delay_seconds,
+                minimum=0.0,
+                maximum=60.0,
+            )
+            if _env_truthy("SOCIAL_INSTAGRAM_COMMENT_GLOBAL_THROTTLE", True)
+            else 0.0
+        )
+        self._global_rate_limit_key = _global_rate_limit_key(
+            self._browser_account_id,
+            self._selected_proxy_fingerprint,
+        )
+        self._max_transient_retries = _resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_COMMENT_TRANSIENT_RETRIES",
+            self._MAX_TRANSIENT_RETRIES,
+            minimum=0,
+            maximum=20,
+        )
+        self._reply_max_transient_retries = _resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_COMMENT_REPLY_TRANSIENT_RETRIES",
+            min(self._max_transient_retries, 3),
+            minimum=0,
+            maximum=20,
+        )
         self._last_api_request_started_at = 0.0
         self._retry_reason_counts: dict[str, int] = {}
+        self._reply_checkpoints: list[dict[str, Any]] = []
+        self._reply_checkpoint_total_count = 0
+        self._reply_checkpoint_dropped_count = 0
+        self._hidden_comments_render_attempts = 0
+        self._hidden_comments_rendered_comments = 0
+        self._hidden_comments_merged = 0
+        self._reply_checkpoint_max_items = _resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_REPLY_CHECKPOINT_MAX_ITEMS",
+            _REPLY_CHECKPOINT_MAX_ITEMS_DEFAULT,
+            minimum=0,
+            maximum=500,
+        )
 
         # Browser fetcher (for warmup only).
         try:
@@ -189,9 +504,25 @@ class InstagramCommentsScraplingFetcher:
             "selected_proxy_fingerprint": self._selected_proxy_fingerprint,
             "proxy_session_mode": self._proxy_session_mode,
             "api_delay_seconds": self._api_delay_seconds,
+            "global_api_delay_seconds": self._global_api_delay_seconds,
+            "global_rate_limit_key": self._global_rate_limit_key,
+            "max_transient_retries": self._max_transient_retries,
+            "reply_max_transient_retries": self._reply_max_transient_retries,
             "transport": "httpx_after_browser_warmup",
             "request_count": self._request_count,
             "retry_reason_counts": dict(sorted(self._retry_reason_counts.items())),
+            "hidden_comments": {
+                "render_attempts": self._hidden_comments_render_attempts,
+                "rendered_comments": self._hidden_comments_rendered_comments,
+                "merged_comments": self._hidden_comments_merged,
+            },
+            "reply_checkpoint_metadata": {
+                "items": list(self._reply_checkpoints),
+                "total_count": self._reply_checkpoint_total_count,
+                "max_items": self._reply_checkpoint_max_items,
+                "dropped_count": self._reply_checkpoint_dropped_count,
+                "truncated": self._reply_checkpoint_dropped_count > 0,
+            },
         }
 
     async def warmup(self) -> None:
@@ -199,10 +530,20 @@ class InstagramCommentsScraplingFetcher:
         solve challenges, and bridge cookies into the httpx client."""
         warmup_account = str(self._browser_account_id or "").strip().lower().lstrip("@")
         warmup_url = f"https://www.instagram.com/{warmup_account}/" if warmup_account else "https://www.instagram.com/"
-        response = await self._fetch_page(
-            warmup_url,
-            referer=warmup_url,
-        )
+        try:
+            response = await self._fetch_page(
+                warmup_url,
+                referer=warmup_url,
+            )
+        except Exception as exc:  # noqa: BLE001
+            if not _warmup_transport_failure(exc):
+                raise
+            self._record_retry_reason("warmup_transport_error")
+            raise InstagramCommentsWarmupError(
+                f"Instagram comments warmup failed on transport/proxy setup: {exc}",
+                error_code="instagram_comments_warmup_transport_error",
+                retryable=True,
+            ) from exc
         text = _response_text(response)
         if _status_code(response) in {401, 403} or _document_auth_failure_text(text):
             raise InstagramCommentsWarmupError(
@@ -225,6 +566,7 @@ class InstagramCommentsScraplingFetcher:
         *,
         max_comments: int,
         fetch_replies: bool,
+        expected_comment_count: int | None = None,
     ) -> InstagramCommentsFetchResult:
         try:
             media_id = _shortcode_to_media_id(shortcode)
@@ -234,9 +576,11 @@ class InstagramCommentsScraplingFetcher:
                 fetch_failed=True,
                 auth_failed=False,
                 fetch_reason=f"invalid_shortcode:{exc.__class__.__name__}",
+                reported_comment_count=_safe_non_negative_int(expected_comment_count),
                 request_count=self._request_count,
             )
 
+        expected_comments = _safe_non_negative_int(expected_comment_count)
         post_url = f"https://www.instagram.com/p/{shortcode}/"
         comments: list[InstagramComment] = []
         cursor: str | None = None
@@ -245,13 +589,15 @@ class InstagramCommentsScraplingFetcher:
         auth_failed = False
         fetch_reason: str | None = None
         retryable = False
+        reply_checkpoints: list[dict[str, Any]] = []
         pages_seen = 0
         seen_cursors: set[str] = set()
+        reply_fetch_disabled_for_post = False
         deadline = time.monotonic() + _resolve_positive_float_env(
             "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_SECONDS",
             _COMMENT_PAGINATION_MAX_SECONDS_DEFAULT,
             minimum=1.0,
-            maximum=300.0,
+            maximum=1_800.0,
         )
         page_cap = _resolve_positive_int_env(
             "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_PAGES",
@@ -295,19 +641,34 @@ class InstagramCommentsScraplingFetcher:
                 if not isinstance(comment_data, dict):
                     continue
                 comment = self._parser._parse_comment(comment_data, shortcode, post_url)
-                if fetch_replies and comment.reply_count > 0 and not comment.replies:
+                if (
+                    fetch_replies
+                    and not reply_fetch_disabled_for_post
+                    and comment.reply_count > 0
+                    and not comment.replies
+                ):
                     replies_result = await self._fetch_comment_replies(
                         media_id=media_id,
                         comment_id=comment.comment_id,
                         shortcode=shortcode,
                         post_url=post_url,
+                        expected_reply_count=comment.reply_count,
                     )
                     comment.replies = replies_result.comments
+                    reply_checkpoints.extend(replies_result.reply_checkpoints)
                     fetch_failed = fetch_failed or replies_result.fetch_failed
                     auth_failed = auth_failed or replies_result.auth_failed
                     retryable = retryable or replies_result.retryable
                     if replies_result.fetch_reason and not fetch_reason:
                         fetch_reason = replies_result.fetch_reason
+                    if replies_result.fetch_failed and replies_result.retryable:
+                        reply_fetch_disabled_for_post = True
+                        self._record_retry_reason("reply_fetch_circuit_open")
+                        logger.warning(
+                            "Instagram comments reply fetch circuit opened for shortcode=%s reason=%s",
+                            shortcode,
+                            replies_result.fetch_reason,
+                        )
                 comments.append(comment)
                 comments_fetched += 1
                 if max_comments > 0 and comments_fetched >= max_comments:
@@ -325,6 +686,7 @@ class InstagramCommentsScraplingFetcher:
             if next_cursor == cursor or next_cursor in seen_cursors:
                 fetch_failed = True
                 fetch_reason = "pagination_repeated_cursor"
+                retryable = True
                 logger.warning(
                     "Instagram comments pagination repeated cursor for shortcode=%s cursor=%s",
                     shortcode,
@@ -334,6 +696,7 @@ class InstagramCommentsScraplingFetcher:
             if pages_seen >= page_cap:
                 fetch_failed = True
                 fetch_reason = "pagination_page_cap_reached"
+                retryable = True
                 logger.warning(
                     "Instagram comments pagination page cap reached for shortcode=%s page_cap=%d",
                     shortcode,
@@ -343,14 +706,148 @@ class InstagramCommentsScraplingFetcher:
             seen_cursors.add(next_cursor)
             cursor = next_cursor
 
+        if self._should_reveal_hidden_comments(
+            expected_comment_count=expected_comments,
+            current_comment_count=len(comments),
+            max_comments=max_comments,
+            auth_failed=auth_failed,
+        ):
+            hidden_comments = await self._fetch_rendered_comments_after_revealing_hidden(shortcode, post_url)
+            merged_count = _merge_unique_comments(comments, hidden_comments, max_comments=max_comments)
+            self._hidden_comments_merged += merged_count
+            if merged_count:
+                logger.info(
+                    "Merged %d rendered hidden Instagram comment(s) for shortcode=%s",
+                    merged_count,
+                    shortcode,
+                )
+
+        if expected_comments is not None and (max_comments <= 0 or expected_comments <= max_comments):
+            if not auth_failed and len(comments) < expected_comments:
+                fetch_failed = True
+                retryable = True
+                if not fetch_reason:
+                    fetch_reason = "hidden_comments_unresolved"
+
         return InstagramCommentsFetchResult(
             comments=comments,
             fetch_failed=fetch_failed,
             auth_failed=auth_failed,
             fetch_reason=fetch_reason,
+            reported_comment_count=expected_comments,
             request_count=self._request_count,
             retryable=retryable,
+            reply_checkpoints=reply_checkpoints,
         )
+
+    def _should_reveal_hidden_comments(
+        self,
+        *,
+        expected_comment_count: int | None,
+        current_comment_count: int,
+        max_comments: int,
+        auth_failed: bool,
+    ) -> bool:
+        if auth_failed or not _env_truthy(_REVEAL_HIDDEN_COMMENTS_ENV, True):
+            return False
+        if max_comments > 0 and current_comment_count >= max_comments:
+            return False
+        if expected_comment_count is not None:
+            target_count = min(expected_comment_count, max_comments) if max_comments > 0 else expected_comment_count
+            return current_comment_count < target_count
+        return _env_truthy(_REVEAL_HIDDEN_COMMENTS_WITHOUT_EXPECTED_ENV, False)
+
+    async def _fetch_rendered_comments_after_revealing_hidden(
+        self,
+        shortcode: str,
+        post_url: str,
+    ) -> list[InstagramComment]:
+        click_limit = _resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_COMMENTS_HIDDEN_CLICK_LIMIT",
+            _HIDDEN_COMMENTS_CLICK_LIMIT_DEFAULT,
+            minimum=0,
+            maximum=25,
+        )
+        if click_limit <= 0:
+            return []
+
+        async def reveal_hidden_comments(page: Any) -> None:
+            await page.evaluate(
+                """
+                async ({ maxClicks }) => {
+                  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+                  const textFor = (element) => {
+                    if (!element) return "";
+                    return [
+                      element.innerText || "",
+                      element.textContent || "",
+                      element.getAttribute?.("aria-label") || "",
+                      element.querySelector?.("title")?.textContent || "",
+                    ].join(" ").replace(/\\s+/g, " ").trim();
+                  };
+                  for (let index = 0; index < maxClicks; index += 1) {
+                    const candidates = Array.from(
+                      document.querySelectorAll('[role="button"], button, a, [tabindex="0"], svg, span, div')
+                    );
+                    const exactControl = candidates.find((element) => {
+                      const text = textFor(element).toLowerCase();
+                      return text === "view hidden comments";
+                    });
+                    const control = exactControl || candidates.find((element) => {
+                      const text = textFor(element).toLowerCase();
+                      return text.includes("view hidden comments") && text.length < 80;
+                    });
+                    if (!control) break;
+                    const clickable = control.closest?.('[role="button"], button, a, [tabindex="0"]') || control;
+                    clickable.click?.();
+                    clickable.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, view: window }));
+                    await sleep(700);
+                  }
+                }
+                """,
+                {"maxClicks": click_limit},
+            )
+
+        self._hidden_comments_render_attempts += 1
+        self._request_count += 1
+        all_headers = self._parser._get_headers(post_url)
+        nav_headers = {k: v for k, v in all_headers.items() if k.lower() not in _API_HEADER_KEYS_TO_STRIP}
+        try:
+            response = await self._fetcher.async_fetch(
+                post_url,
+                headless=self._headless,
+                network_idle=True,
+                load_dom=True,
+                cookies=_cookies_to_scrapling(self._raw_cookies),
+                proxy_rotator=self._proxy_rotator,
+                extra_headers=nav_headers,
+                timeout=self._timeout_ms,
+                retries=1,
+                retry_delay=1.0,
+                wait=1_000,
+                page_action=reveal_hidden_comments,
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._record_retry_reason("hidden_comments_render_fetch_failed")
+            logger.warning(
+                "Rendered hidden comments fetch failed for shortcode=%s: %s",
+                shortcode,
+                exc,
+                exc_info=True,
+            )
+            return []
+
+        self._sync_response_cookies(response)
+        html_text = _response_text(response)
+        comments = _extract_rendered_permalink_comments(html_text, shortcode=shortcode, post_url=post_url)
+        self._hidden_comments_rendered_comments += len(comments)
+        if comments:
+            logger.info(
+                "Rendered Instagram post yielded %d permalink comment(s) after hidden-comment reveal for shortcode=%s",
+                len(comments),
+                shortcode,
+            )
+        return comments
 
     async def aclose(self) -> None:
         """Close the httpx client. Called by job_runner in finally."""
@@ -372,6 +869,7 @@ class InstagramCommentsScraplingFetcher:
         comment_id: str,
         shortcode: str,
         post_url: str,
+        expected_reply_count: int | None = None,
     ) -> InstagramCommentsFetchResult:
         replies: list[InstagramComment] = []
         cursor: str | None = None
@@ -381,11 +879,14 @@ class InstagramCommentsScraplingFetcher:
         retryable = False
         pages_seen = 0
         seen_cursors: set[str] = set()
+        last_attempt_count = 0
+        last_reply_cursor: str | None = None
+        next_reply_cursor: str | None = None
         deadline = time.monotonic() + _resolve_positive_float_env(
             "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_SECONDS",
             _REPLY_PAGINATION_MAX_SECONDS_DEFAULT,
             minimum=1.0,
-            maximum=300.0,
+            maximum=1_800.0,
         )
         page_cap = _resolve_positive_int_env(
             "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES",
@@ -405,7 +906,10 @@ class InstagramCommentsScraplingFetcher:
                 COMMENT_REPLIES_URL.format(media_id=media_id, comment_id=comment_id),
                 referer=post_url,
                 params={"min_id": cursor} if cursor else None,
+                max_retries=self._reply_max_transient_retries,
             )
+            last_attempt_count = int(response.get("attempt_count") or 0)
+            last_reply_cursor = cursor
             payload = response.get("payload")
             fetch_reason = response.get("reason")
             fetch_failed = bool(response.get("failed"))
@@ -440,9 +944,11 @@ class InstagramCommentsScraplingFetcher:
             if not next_cursor:
                 break
             next_cursor = str(next_cursor)
+            next_reply_cursor = next_cursor
             if next_cursor == cursor or next_cursor in seen_cursors:
                 fetch_failed = True
                 fetch_reason = "pagination_repeated_cursor"
+                retryable = True
                 logger.warning(
                     "Instagram reply pagination repeated cursor for comment_id=%s cursor=%s",
                     comment_id,
@@ -452,6 +958,7 @@ class InstagramCommentsScraplingFetcher:
             if pages_seen >= page_cap:
                 fetch_failed = True
                 fetch_reason = "pagination_page_cap_reached"
+                retryable = True
                 logger.warning(
                     "Instagram reply pagination page cap reached for comment_id=%s page_cap=%d",
                     comment_id,
@@ -461,6 +968,24 @@ class InstagramCommentsScraplingFetcher:
             seen_cursors.add(next_cursor)
             cursor = next_cursor
 
+        reply_checkpoints: list[dict[str, Any]] = []
+        if fetch_failed and retryable:
+            checkpoint = self._record_reply_checkpoint(
+                shortcode=shortcode,
+                media_id=media_id,
+                parent_comment_id=comment_id,
+                stop_reason=fetch_reason or "reply_pagination_retryable_stop",
+                attempt_count=last_attempt_count,
+                last_error_code=fetch_reason,
+                last_reply_cursor=last_reply_cursor,
+                next_reply_cursor=next_reply_cursor,
+                saved_reply_count=len(replies),
+                expected_reply_count=expected_reply_count,
+                pages_seen=pages_seen,
+            )
+            if checkpoint:
+                reply_checkpoints.append(checkpoint)
+
         return InstagramCommentsFetchResult(
             comments=replies,
             fetch_failed=fetch_failed,
@@ -468,6 +993,7 @@ class InstagramCommentsScraplingFetcher:
             fetch_reason=fetch_reason,
             request_count=self._request_count,
             retryable=retryable,
+            reply_checkpoints=reply_checkpoints,
         )
 
     # -------------------------------------------------------------------
@@ -568,7 +1094,50 @@ class InstagramCommentsScraplingFetcher:
         self._sync_response_cookies(response)
         return response
 
+    async def _fetch_api_with_browser(
+        self,
+        url: str,
+        *,
+        referer: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Fetch a JSON API URL through the same browser transport as warmup.
+
+        Instagram sometimes redirects the lightweight httpx transport from the
+        comments API to `/` after a successful browser warmup. In that state the
+        session is not necessarily logged out; the API call is being rejected on
+        transport/browser-context signals. This fallback keeps the same cookie
+        jar and proxy plane but asks Patchright/Scrapling to make the request.
+        """
+        clean_params = {key: value for key, value in (params or {}).items() if value is not None}
+        request_url = url
+        if clean_params:
+            separator = "&" if "?" in request_url else "?"
+            request_url = f"{request_url}{separator}{urlencode(clean_params, doseq=True)}"
+        self._request_count += 1
+        response = await self._fetcher.async_fetch(
+            request_url,
+            headless=self._headless,
+            network_idle=False,
+            load_dom=False,
+            cookies=_cookies_to_scrapling(self._raw_cookies),
+            proxy_rotator=self._proxy_rotator,
+            extra_headers=self._parser._get_headers(referer),
+            timeout=self._timeout_ms,
+            retries=1,
+            retry_delay=1.0,
+        )
+        self._sync_response_cookies(response)
+        await self._rebuild_http_client()
+        return response
+
     async def _pace_api_requests(self) -> None:
+        if self._global_api_delay_seconds > 0:
+            await asyncio.to_thread(
+                _pace_global_api_request,
+                key=self._global_rate_limit_key,
+                delay_seconds=self._global_api_delay_seconds,
+            )
         if self._api_delay_seconds <= 0:
             return
         remaining = (self._last_api_request_started_at + self._api_delay_seconds) - time.monotonic()
@@ -597,6 +1166,162 @@ class InstagramCommentsScraplingFetcher:
         if not normalized:
             return
         self._retry_reason_counts[normalized] = self._retry_reason_counts.get(normalized, 0) + 1
+
+    def _decode_json_response_result(self, response: Any, *, attempt: int) -> dict[str, Any]:
+        status_code = _status_code(response)
+        text = _response_text(response)
+        auth_failed = status_code in {401, 403} or _auth_failure_text(text)
+
+        if 300 <= status_code < 400:
+            location = _safe_location(response)
+            reason = (
+                "redirect_to_login"
+                if "/accounts/login" in location
+                else "redirect_to_checkpoint"
+                if ("/challenge" in location or "/checkpoint" in location)
+                else "redirect_to_homepage"
+            )
+            auth_redirect = any(token in location for token in ("login", "challenge", "checkpoint"))
+            return {
+                "failed": True,
+                "auth_failed": auth_redirect or reason == "redirect_to_homepage",
+                "reason": reason,
+                "retryable": False,
+                "payload": None,
+                "attempt_count": attempt,
+            }
+
+        if self._is_transient_status(status_code):
+            return {
+                "failed": True,
+                "auth_failed": False,
+                "reason": f"http_{status_code}",
+                "retryable": True,
+                "payload": None,
+                "attempt_count": attempt,
+            }
+
+        if status_code >= 400:
+            return {
+                "failed": True,
+                "auth_failed": auth_failed,
+                "reason": f"http_{status_code}",
+                "retryable": False,
+                "payload": None,
+                "attempt_count": attempt,
+            }
+
+        if text and text.lstrip().startswith("<"):
+            return {
+                "failed": True,
+                "auth_failed": auth_failed or _auth_failure_text(text),
+                "reason": "html_challenge_or_auth_required",
+                "retryable": False,
+                "payload": None,
+                "attempt_count": attempt,
+            }
+
+        try:
+            payload = response.json()
+        except Exception:  # noqa: BLE001
+            try:
+                payload = json.loads(text)
+            except Exception:  # noqa: BLE001
+                return {
+                    "failed": True,
+                    "auth_failed": auth_failed,
+                    "reason": "non_json_response",
+                    "retryable": False,
+                    "payload": None,
+                    "attempt_count": attempt,
+                }
+
+        if isinstance(payload, dict):
+            status_value = str(payload.get("status") or "").strip().lower()
+            message = str(payload.get("message") or payload.get("error_message") or "").strip().lower()
+            if status_value and status_value != "ok":
+                return {
+                    "failed": True,
+                    "auth_failed": auth_failed
+                    or any(
+                        token in f"{status_value} {message}"
+                        for token in ("login", "checkpoint", "challenge", "unauthorized")
+                    ),
+                    "reason": status_value or "api_status_fail",
+                    "retryable": False,
+                    "payload": payload,
+                    "attempt_count": attempt,
+                }
+
+        return {
+            "failed": False,
+            "auth_failed": auth_failed,
+            "reason": None,
+            "retryable": False,
+            "payload": payload,
+            "attempt_count": attempt,
+        }
+
+    @staticmethod
+    def _compact_checkpoint_text(value: Any) -> str | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        if len(text) <= _REPLY_CHECKPOINT_STRING_MAX_LENGTH:
+            return text
+        return text[:_REPLY_CHECKPOINT_STRING_MAX_LENGTH]
+
+    @staticmethod
+    def _non_negative_int(value: Any) -> int | None:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed >= 0 else None
+
+    def _record_reply_checkpoint(
+        self,
+        *,
+        shortcode: str,
+        media_id: str,
+        parent_comment_id: str,
+        stop_reason: str,
+        attempt_count: int | None,
+        last_error_code: str | None,
+        last_reply_cursor: str | None,
+        next_reply_cursor: str | None,
+        saved_reply_count: int,
+        expected_reply_count: int | None,
+        pages_seen: int,
+    ) -> dict[str, Any] | None:
+        self._reply_checkpoint_total_count += 1
+        if self._reply_checkpoint_max_items <= 0:
+            self._reply_checkpoint_dropped_count += 1
+            return None
+
+        checkpoint = {
+            "platform": "instagram",
+            "target_shortcode": self._compact_checkpoint_text(shortcode),
+            "source_id": self._compact_checkpoint_text(shortcode),
+            "media_id": self._compact_checkpoint_text(media_id),
+            "parent_comment_id": self._compact_checkpoint_text(parent_comment_id),
+            "stop_reason": self._compact_checkpoint_text(stop_reason),
+            "attempt_count": self._non_negative_int(attempt_count),
+            "last_error_code": self._compact_checkpoint_text(last_error_code or stop_reason),
+            "last_reply_cursor": self._compact_checkpoint_text(last_reply_cursor),
+            "next_reply_cursor": self._compact_checkpoint_text(next_reply_cursor),
+            "saved_reply_count_observed": self._non_negative_int(saved_reply_count),
+            "expected_reply_count": self._non_negative_int(expected_reply_count),
+            "pages_seen": self._non_negative_int(pages_seen),
+            "retryable": True,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        compact_checkpoint = {key: value for key, value in checkpoint.items() if value is not None}
+        while len(self._reply_checkpoints) >= self._reply_checkpoint_max_items:
+            self._reply_checkpoints.pop(0)
+            self._reply_checkpoint_dropped_count += 1
+        self._reply_checkpoints.append(compact_checkpoint)
+        return compact_checkpoint
 
     # -------------------------------------------------------------------
     # JSON response handling with retry/backoff
@@ -627,34 +1352,45 @@ class InstagramCommentsScraplingFetcher:
         *,
         referer: str,
         params: dict[str, Any] | None = None,
+        max_retries: int | None = None,
     ) -> dict[str, Any]:
         """JSON fetch via httpx with bounded exponential backoff on transient
         failures (429 / 5xx / transport timeout).
         """
         attempt = 0
+        retry_limit = self._max_transient_retries if max_retries is None else max(0, int(max_retries))
         homepage_redirect_recovery_attempted = False
+        browser_api_fallback_attempted = False
         last_transient_reason: str | None = None
         while True:
             attempt += 1
             try:
                 response = await self._fetch_api(url, referer=referer, params=params)
-            except (TimeoutError, httpx.TimeoutException, httpx.TransportError) as exc:
+            except (TimeoutError, httpx.TimeoutException, httpx.TransportError, OSError) as exc:
+                if not _api_transport_failure(exc):
+                    raise
                 last_transient_reason = _transport_failure_reason(exc)
                 self._record_retry_reason(last_transient_reason)
-                if attempt > self._MAX_TRANSIENT_RETRIES:
+                if attempt > retry_limit:
                     return {
                         "failed": True,
                         "auth_failed": False,
                         "reason": last_transient_reason,
                         "retryable": True,
                         "payload": None,
+                        "attempt_count": attempt,
                     }
+                try:
+                    await self._rebuild_http_client()
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "Failed to rebuild Instagram comments HTTP client after transport error", exc_info=True
+                    )
                 await asyncio.sleep(_transient_backoff_seconds(attempt, self._BASE_BACKOFF_SECONDS))
                 continue
 
             status_code = _status_code(response)
             text = _response_text(response)
-            auth_failed = status_code in {401, 403} or _auth_failure_text(text)
 
             # 3xx: explicit redirect handling.
             if 300 <= status_code < 400:
@@ -678,6 +1414,37 @@ class InstagramCommentsScraplingFetcher:
                         homepage_redirect_recovery_attempted = True
                         if await self._recover_homepage_redirect(referer=referer):
                             continue
+                    if (
+                        not browser_api_fallback_attempted
+                        and _env_truthy(_BROWSER_API_FALLBACK_ENV, True)
+                    ):
+                        browser_api_fallback_attempted = True
+                        self._record_retry_reason("browser_api_fallback")
+                        try:
+                            browser_response = await self._fetch_api_with_browser(
+                                url,
+                                referer=referer,
+                                params=params,
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            if not _warmup_transport_failure(exc):
+                                raise
+                            reason = _transport_failure_reason(exc)
+                            self._record_retry_reason(reason)
+                            return {
+                                "failed": True,
+                                "auth_failed": False,
+                                "reason": reason,
+                                "retryable": True,
+                                "payload": None,
+                                "attempt_count": attempt,
+                            }
+                        browser_result = self._decode_json_response_result(browser_response, attempt=attempt)
+                        if not (
+                            browser_result.get("failed")
+                            and browser_result.get("reason") == "redirect_to_homepage"
+                        ):
+                            return browser_result
                     auth_redirect = True
                 return {
                     "failed": True,
@@ -685,19 +1452,21 @@ class InstagramCommentsScraplingFetcher:
                     "reason": reason,
                     "retryable": False,
                     "payload": None,
+                    "attempt_count": attempt,
                 }
 
             # Transient 429 / 5xx: retry with backoff.
             if self._is_transient_status(status_code):
                 last_transient_reason = f"http_{status_code}"
                 self._record_retry_reason(last_transient_reason)
-                if attempt > self._MAX_TRANSIENT_RETRIES:
+                if attempt > retry_limit:
                     return {
                         "failed": True,
                         "auth_failed": False,
                         "reason": last_transient_reason,
                         "retryable": True,
                         "payload": None,
+                        "attempt_count": attempt,
                     }
                 retry_after = self._retry_after_seconds(response)
                 sleep_seconds = _transient_backoff_seconds(
@@ -710,60 +1479,10 @@ class InstagramCommentsScraplingFetcher:
 
             # Permanent 4xx.
             if status_code >= 400:
-                return {
-                    "failed": True,
-                    "auth_failed": auth_failed,
-                    "reason": f"http_{status_code}",
-                    "retryable": False,
-                    "payload": None,
-                }
+                return self._decode_json_response_result(response, attempt=attempt)
 
             # HTML response (challenge page, not JSON).
             if text and text.lstrip().startswith("<"):
-                return {
-                    "failed": True,
-                    "auth_failed": auth_failed or _auth_failure_text(text),
-                    "reason": "html_challenge_or_auth_required",
-                    "retryable": False,
-                    "payload": None,
-                }
+                return self._decode_json_response_result(response, attempt=attempt)
 
-            # Parse JSON.
-            try:
-                payload = response.json()
-            except Exception:  # noqa: BLE001
-                try:
-                    payload = json.loads(text)
-                except Exception:  # noqa: BLE001
-                    return {
-                        "failed": True,
-                        "auth_failed": auth_failed,
-                        "reason": "non_json_response",
-                        "retryable": False,
-                        "payload": None,
-                    }
-
-            # Check IG API-level status.
-            if isinstance(payload, dict):
-                status_value = str(payload.get("status") or "").strip().lower()
-                message = str(payload.get("message") or payload.get("error_message") or "").strip().lower()
-                if status_value and status_value != "ok":
-                    return {
-                        "failed": True,
-                        "auth_failed": auth_failed
-                        or any(
-                            token in f"{status_value} {message}"
-                            for token in ("login", "checkpoint", "challenge", "unauthorized")
-                        ),
-                        "reason": status_value or "api_status_fail",
-                        "retryable": False,
-                        "payload": payload,
-                    }
-
-            return {
-                "failed": False,
-                "auth_failed": auth_failed,
-                "reason": None,
-                "retryable": False,
-                "payload": payload,
-            }
+            return self._decode_json_response_result(response, attempt=attempt)

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections import Counter
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
@@ -18,6 +19,12 @@ from trr_backend.socials.instagram.comments_scrapling.proxy import select_commen
 from trr_backend.socials.instagram.comments_scrapling.session import resolve_comments_scrapling_session
 
 logger = logging.getLogger("socials.instagram.comments_scrapling.job_runner")
+
+_RUN_FATAL_COMMENTS_ERROR_CODES = {
+    "instagram_comments_auth_failed",
+    "instagram_comments_warmup_auth_failed",
+    "instagram_comments_warmup_no_cookies",
+}
 
 
 @dataclass(slots=True)
@@ -113,14 +120,299 @@ def _comments_scrape_is_complete(
 ) -> bool:
     if result.fetch_failed or result.auth_failed:
         return False
+    reported_comment_count = _extract_reported_comment_count(result)
+    if reported_comment_count is not None and len(result.comments) < reported_comment_count:
+        if max_comments_per_post <= 0 or reported_comment_count <= max_comments_per_post:
+            return False
     if max_comments_per_post <= 0:
         return True
     return len(result.comments) < max_comments_per_post
 
 
+def _safe_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _config_truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_database_capacity_error(exc: BaseException) -> bool:
+    if isinstance(exc, pg.DatabaseServiceUnavailableError):
+        return True
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "emaxconnsession",
+            "max clients reached",
+            "pool exhausted",
+            "database pool",
+            "session_pool_capacity",
+        )
+    )
+
+
+def _is_comments_transport_error(exc: BaseException) -> bool:
+    message = str(exc).lower()
+    if not message:
+        return False
+    return any(
+        marker in message
+        for marker in (
+            "wrong_version_number",
+            "wrong version number",
+            "ssl:",
+            "ssl connection",
+            "closed unexpectedly",
+            "transport error",
+            "transporterror",
+            "proxy error",
+            "proxyerror",
+            "connecterror",
+            "readerror",
+            "connection reset",
+            "server disconnected",
+            "remote protocol error",
+            "network is unreachable",
+            "temporarily unavailable",
+        )
+    )
+
+
+def _extract_reported_comment_count(result: InstagramCommentsFetchResult) -> int | None:
+    reported = getattr(result, "reported_comment_count", None) or getattr(result, "comments_count", None)
+    if reported is not None:
+        return _safe_int(reported)
+    for attr_name in ("runtime_metadata", "raw_metadata"):
+        metadata = getattr(result, attr_name, None)
+        if not isinstance(metadata, dict):
+            continue
+        for key in ("reported_comment_count", "comments_count", "comment_count"):
+            parsed = _safe_int(metadata.get(key))
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def _load_expected_comment_counts(
+    *,
+    repo: Any,
+    account_handle: str,
+    target_source_ids: list[str],
+) -> dict[str, int]:
+    normalized_account = str(account_handle or "").strip().lower().lstrip("@")
+    requested = list(dict.fromkeys(str(item or "").strip() for item in target_source_ids if str(item or "").strip()))
+    if not normalized_account or not requested:
+        return {}
+    owner_match_clause = repo._social_account_profile_owner_match_sql("instagram", alias="p")
+    reported_comments_expr = repo._instagram_reported_comments_sql("p")
+    rows = pg.fetch_all(
+        f"""
+        with requested as (
+          select
+            nullif(shortcode, '')::text as shortcode,
+            ordinality::int as sort_order
+          from unnest(%s::text[]) with ordinality as request(shortcode, ordinality)
+          where nullif(shortcode, '') is not null
+        ),
+        owner_posts as (
+          select
+            p.shortcode::text as shortcode,
+            {reported_comments_expr}::bigint as reported_comments,
+            row_number() over (
+              partition by p.shortcode
+              order by p.posted_at desc nulls last, p.id desc
+            ) as row_number
+          from social.instagram_posts p
+          join requested r on r.shortcode = p.shortcode
+          where {owner_match_clause}
+        )
+        select
+          r.shortcode,
+          coalesce(op.reported_comments, 0)::bigint as reported_comments
+        from requested r
+        left join owner_posts op on op.shortcode = r.shortcode and op.row_number = 1
+        order by r.sort_order
+        """,
+        [requested, normalized_account],
+    )
+    counts: dict[str, int] = {}
+    for row in rows:
+        shortcode = str(row.get("shortcode") or "").strip()
+        reported = _safe_int(row.get("reported_comments"))
+        if shortcode and reported is not None:
+            counts[shortcode] = reported
+    return counts
+
+
+def _post_latency_metadata(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "samples": samples[-25:],
+        "slowest": sorted(
+            samples,
+            key=lambda sample: int(sample.get("total_elapsed_ms") or 0),
+            reverse=True,
+        )[:10],
+        "sample_count": len(samples),
+    }
+
+
+def _comment_completeness_metadata(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "complete_posts": sum(1 for sample in samples if sample.get("is_complete")),
+        "incomplete_posts": sum(1 for sample in samples if not sample.get("is_complete")),
+        "completion_reasons": dict(Counter(str(sample.get("completion_reason") or "unknown") for sample in samples)),
+    }
+
+
+def _retry_rebalance_metadata(
+    *,
+    comments_shard_count: int,
+    target_source_ids: list[str],
+    processed_posts: int,
+    incomplete_target_source_ids: list[str] | None = None,
+) -> dict[str, Any] | None:
+    retry_targets = [
+        str(item or "").strip()
+        for item in (incomplete_target_source_ids or [])
+        if str(item or "").strip()
+    ]
+    retry_targets.extend(target_source_ids[max(0, processed_posts) :])
+    remaining_targets = list(dict.fromkeys(retry_targets))
+    if comments_shard_count <= 1 and not remaining_targets:
+        return None
+    return {
+        "remaining_target_source_ids": remaining_targets,
+        "eligible": bool(remaining_targets),
+    }
+
+
+def _reply_checkpoint_summary(fetcher_metadata: dict[str, Any]) -> dict[str, Any]:
+    checkpoint_metadata = fetcher_metadata.get("reply_checkpoint_metadata")
+    if not isinstance(checkpoint_metadata, dict):
+        return {
+            "total_count": 0,
+            "retained_count": 0,
+            "dropped_count": 0,
+            "truncated": False,
+            "stop_reasons": {},
+            "latest": None,
+        }
+    items = [
+        item
+        for item in (checkpoint_metadata.get("items") or [])
+        if isinstance(item, dict)
+    ]
+    return {
+        "total_count": int(checkpoint_metadata.get("total_count") or len(items)),
+        "retained_count": len(items),
+        "dropped_count": int(checkpoint_metadata.get("dropped_count") or 0),
+        "truncated": bool(checkpoint_metadata.get("truncated")),
+        "stop_reasons": dict(Counter(str(item.get("stop_reason") or "unknown") for item in items)),
+        "latest": items[-1] if items else None,
+    }
+
+
+def _auth_context_metadata(auth_session: Any | None) -> dict[str, Any]:
+    if auth_session is None:
+        return {}
+    metadata = dict(getattr(auth_session, "metadata", {}) or {})
+    return {
+        "session_source": getattr(auth_session, "source", None),
+        "browser_account_id": getattr(auth_session, "browser_account_id", None),
+        "session_account_id": getattr(auth_session, "session_account_id", None),
+        "validation_category": getattr(auth_session, "validation_category", None),
+        "validation_reason": getattr(auth_session, "validation_reason", None),
+        "validated": bool(getattr(auth_session, "validated", False)),
+        "stale_ok": bool(getattr(auth_session, "stale_ok", False)),
+        "resolver_version": getattr(auth_session, "resolver_version", None),
+        "browser_session_used": bool(metadata.get("browser_session_used")),
+        "cookie_source_fingerprint": metadata.get("fingerprint"),
+    }
+
+
+def _abort_queued_sibling_shards_after_run_fatal_error(
+    *,
+    repo: Any,
+    run_id: str,
+    failed_job_id: str,
+    stage: str,
+    account_handle: str,
+    mode: str,
+    source_scope: str,
+    error_code: str,
+    error_class: str,
+    error_message: str,
+) -> int:
+    if not run_id or not failed_job_id:
+        return 0
+    normalized_error_code = str(error_code or "").strip().lower()
+    if normalized_error_code not in _RUN_FATAL_COMMENTS_ERROR_CODES:
+        return 0
+    sibling_rows = pg.fetch_all(
+        """
+        select id::text as id, coalesce(items_found, 0)::int as items_found
+        from social.scrape_jobs
+        where run_id = %s::uuid
+          and id <> %s::uuid
+          and status in ('queued', 'pending', 'retrying')
+          and coalesce(config->>'stage', metadata->>'stage', job_type, '') = %s
+        order by created_at asc
+        """,
+        [run_id, failed_job_id, stage],
+    )
+    aborted = 0
+    for sibling in sibling_rows:
+        sibling_id = str(sibling.get("id") or "").strip()
+        if not sibling_id:
+            continue
+        repo._finish_job(
+            sibling_id,
+            status="failed",
+            items_found=_safe_int(sibling.get("items_found")) or 0,
+            error_message=(
+                f"Aborted because sibling shard {failed_job_id} failed with run-level "
+                f"Instagram comments error {normalized_error_code}: {error_message}"
+            ),
+            metadata={
+                "stage": stage,
+                "platform": "instagram",
+                "account": account_handle,
+                "mode": mode,
+                "source_scope": source_scope,
+                "error_code": normalized_error_code,
+                "error_class": "SiblingShardAborted",
+                "aborted_by_sibling_job_id": failed_job_id,
+                "aborted_by_error_code": normalized_error_code,
+                "activity": {"phase": "aborted_by_run_fatal_error"},
+            },
+            last_error_code=normalized_error_code,
+            last_error_class=error_class or "SiblingShardAborted",
+        )
+        aborted += 1
+    if aborted:
+        logger.warning(
+            "Aborted %d queued Instagram comments sibling shard(s) after run-level failure: "
+            "run_id=%s job_id=%s error=%s",
+            aborted,
+            run_id,
+            failed_job_id,
+            normalized_error_code,
+        )
+    return aborted
+
+
 def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str | None = None) -> dict[str, Any]:
     from trr_backend.repositories import social_season_analytics as repo
 
+    job_runner_started_at = repo._now_utc()
     job_id = str(job.get("id") or "").strip()
     run_id = str(job.get("run_id") or "").strip()
     config = dict(job.get("config") or {})
@@ -135,6 +427,38 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         for item in (config.get("target_source_ids") or ([config.get("source_id")] if config.get("source_id") else []))
         if str(item or "").strip()
     ]
+    comments_shard_index = max(1, int(config.get("comments_shard_index") or 1))
+    comments_shard_count = max(1, int(config.get("comments_shard_count") or 1))
+    comments_shard_target_count = max(0, int(config.get("comments_shard_target_count") or len(target_source_ids)))
+    skipped_complete_target_source_ids: list[str] = []
+    skip_complete_retry_targets = any(
+        _config_truthy(config.get(flag))
+        for flag in (
+            "comments_retry_rebalance",
+            "comments_retry_incomplete",
+            "comments_target_gap_repair",
+            "comments_skip_complete_targets",
+        )
+    )
+    if skip_complete_retry_targets and target_source_ids:
+        try:
+            incomplete_targets = repo._instagram_filter_incomplete_comment_targets(account_handle, target_source_ids)
+            incomplete_target_set = set(incomplete_targets)
+            skipped_complete_target_source_ids = [
+                target for target in target_source_ids if target not in incomplete_target_set
+            ]
+        except pg.DatabaseServiceUnavailableError as exc:
+            logger.warning(
+                "Continuing comments retry without complete-target prefilter after database saturation: "
+                "job_id=%s error=%s",
+                job_id,
+                exc,
+            )
+    shard_metadata = {
+        "comments_shard_index": comments_shard_index,
+        "comments_shard_count": comments_shard_count,
+        "comments_shard_target_count": comments_shard_target_count,
+    }
     if not account_handle:
         raise CommentsScraplingRuntimeError(
             "Instagram comments Scrapling job is missing an account handle.",
@@ -147,6 +471,20 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             error_code="instagram_comments_targets_missing",
             retryable=False,
         )
+    try:
+        expected_comment_counts_by_shortcode = _load_expected_comment_counts(
+            repo=repo,
+            account_handle=account_handle,
+            target_source_ids=target_source_ids,
+        )
+    except Exception as exc:  # noqa: BLE001
+        expected_comment_counts_by_shortcode = {}
+        logger.warning(
+            "Continuing Instagram comments job without expected comment counts: job_id=%s error=%s",
+            job_id,
+            exc,
+            exc_info=True,
+        )
 
     progress_state = repo._new_job_progress_state()
     processed_posts = 0
@@ -157,14 +495,44 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
     mirror_job_enqueue_errors = 0
     activity: dict[str, Any] = {
         "phase": "comments_scrapling_start",
-        "posts_checked": len(target_source_ids),
+        "posts_checked": 0,
         "matched_posts": 0,
         "saved_posts": 0,
         "total_posts": len(target_source_ids),
+        **shard_metadata,
     }
     fetcher_metadata: dict[str, Any] = {}
+    post_latency_samples: list[dict[str, Any]] = []
+    incomplete_target_source_ids: list[str] = []
+    incomplete_fetch_reasons: dict[str, str] = {}
+    auth_failed_target_source_ids: list[str] = []
+    auth_failed_fetch_reasons: dict[str, str] = {}
+    consecutive_post_auth_failures = 0
+    successful_target_fetches = 0
+    post_auth_failure_circuit_limit = _safe_int(config.get("post_auth_failure_circuit_limit")) or 3
+    warmup_completed_at = None
+    first_post_persisted_at = None
+    auth_context: dict[str, Any] = {}
     terminal_status = str(job.get("status") or "").strip().lower() or None
     terminal_error_message: str | None = None
+
+    def terminal_metadata_common() -> dict[str, Any]:
+        return {
+            **shard_metadata,
+            "post_latency": _post_latency_metadata(post_latency_samples),
+            "comment_completeness": _comment_completeness_metadata(post_latency_samples),
+            "post_auth_failures": {
+                "target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
+                "fetch_reasons": dict(auth_failed_fetch_reasons),
+                "circuit_limit": post_auth_failure_circuit_limit,
+            },
+            "reply_checkpoint_summary": _reply_checkpoint_summary(fetcher_metadata),
+            "timing": {
+                "job_runner_started_at": repo._iso(job_runner_started_at),
+                "warmup_completed_at": repo._iso(warmup_completed_at),
+                "first_post_persisted_at": repo._iso(first_post_persisted_at),
+            },
+        }
 
     # Single event loop: fetcher is created, warmed up, used for all
     # shortcodes, and closed within one asyncio.run(). The httpx client
@@ -173,12 +541,20 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         nonlocal processed_posts, comments_upserted, comments_fetched
         nonlocal comments_marked_missing, mirror_jobs_enqueued, mirror_job_enqueue_errors
         nonlocal activity, fetcher_metadata
+        nonlocal consecutive_post_auth_failures, successful_target_fetches
+        nonlocal warmup_completed_at, first_post_persisted_at, auth_context
 
         session = resolve_comments_scrapling_session(
             browser_account_id=account_handle,
             caller_context=f"comments_scrapling:{mode}:{account_handle}",
         )
-        proxy_session_key = str(session.browser_account_id or account_handle).strip().lower().lstrip("@")
+        auth_context = _auth_context_metadata(session.auth_session)
+        use_shard_proxy_session = _config_truthy(config.get("comments_proxy_shard_sessions"))
+        proxy_session_key = (
+            f"{account_handle}:comments:{comments_shard_index}"
+            if use_shard_proxy_session and comments_shard_count > 1
+            else str(session.browser_account_id or account_handle).strip().lower().lstrip("@")
+        )
         proxy_config = select_comments_proxy(session_key=proxy_session_key or account_handle)
         fetcher = InstagramCommentsScraplingFetcher(
             cookies=session.cookies,
@@ -190,6 +566,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         try:
             try:
                 await fetcher.warmup()
+                warmup_completed_at = repo._now_utc()
             except InstagramCommentsWarmupError as exc:
                 raise CommentsScraplingRuntimeError(
                     str(exc),
@@ -203,75 +580,54 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 run_id=run_id,
                 runtime_metadata=dict(fetcher.runtime_metadata),
             )
-            with pg.db_connection(label="instagram-comments-scrapling-persist") as persist_conn:
-                repo._touch_job_heartbeat(job_id, worker_id=worker_id)
-                repo._emit_job_progress(
-                    job_id=job_id,
-                    stage=stage,
-                    platform="instagram",
-                    account=account_handle,
-                    scraped_posts=0,
-                    scraped_comments=0,
-                    posts_upserted=0,
-                    comments_upserted=0,
-                    activity=activity,
-                    progress_state=progress_state,
-                    force=True,
-                )
+            repo._touch_job_heartbeat(job_id, worker_id=worker_id)
+            repo._emit_job_progress(
+                job_id=job_id,
+                stage=stage,
+                platform="instagram",
+                account=account_handle,
+                scraped_posts=0,
+                scraped_comments=0,
+                posts_upserted=0,
+                comments_upserted=0,
+                activity=activity,
+                progress_state=progress_state,
+                force=True,
+            )
 
-                for index, shortcode in enumerate(target_source_ids, start=1):
-                    repo._touch_job_heartbeat(job_id, worker_id=worker_id)
-                    _raise_if_cancelled(
-                        job_id=job_id,
-                        run_id=run_id,
-                        runtime_metadata=dict(fetcher.runtime_metadata),
-                        conn=persist_conn,
+            for index, shortcode in enumerate(target_source_ids, start=1):
+                post_started_at = time.monotonic()
+                repo._touch_job_heartbeat(job_id, worker_id=worker_id)
+                _raise_if_cancelled(
+                    job_id=job_id,
+                    run_id=run_id,
+                    runtime_metadata=dict(fetcher.runtime_metadata),
+                )
+                if shortcode in skipped_complete_target_source_ids:
+                    total_elapsed_ms = int((time.monotonic() - post_started_at) * 1000)
+                    post_latency_samples.append(
+                        {
+                            "shortcode": shortcode,
+                            "fetch_elapsed_ms": 0,
+                            "persist_elapsed_ms": 0,
+                            "total_elapsed_ms": total_elapsed_ms,
+                            "comments_fetched": 0,
+                            "comments_upserted": 0,
+                            "comments_marked_missing": 0,
+                            "fetch_reason": "already_complete",
+                            "is_complete": True,
+                            "completion_reason": "already_complete",
+                            "reported_comment_count": None,
+                        }
                     )
-                    result = await fetcher.fetch_comments_for_shortcode(
-                        shortcode,
-                        max_comments=max_comments_per_post,
-                        fetch_replies=fetch_replies,
-                    )
-                    if result.auth_failed and not result.comments:
-                        raise CommentsScraplingRuntimeError(
-                            f"Instagram auth failed while fetching comments for {shortcode}.",
-                            error_code="instagram_comments_auth_failed",
-                            retryable=False,
-                            runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
-                        )
-                    if result.fetch_failed and not result.comments:
-                        raise CommentsScraplingRuntimeError(
-                            f"Instagram comments fetch failed for {shortcode}.",
-                            error_code=str(result.fetch_reason or "instagram_comments_fetch_failed"),
-                            retryable=bool(result.retryable),
-                            runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
-                        )
-                    persisted = persist_instagram_comments_for_post(
-                        account_handle=account_handle,
-                        shortcode=shortcode,
-                        comments=result.comments,
-                        run_id=run_id or None,
-                        job_id=job_id,
-                        is_complete=_comments_scrape_is_complete(
-                            result=result,
-                            max_comments_per_post=max_comments_per_post,
-                        ),
-                        source_scope=source_scope,
-                        conn=persist_conn,
-                    )
-                    persist_conn.commit()
                     processed_posts += 1
-                    comments_fetched += len(result.comments)
-                    comments_upserted += persisted.comments_upserted
-                    comments_marked_missing += persisted.comments_marked_missing
-                    mirror_jobs_enqueued += persisted.comment_media_mirror_jobs_enqueued
-                    mirror_job_enqueue_errors += persisted.comment_media_mirror_job_enqueue_errors
                     activity = {
                         "phase": "comments_scrapling_running",
-                        "posts_checked": len(target_source_ids),
-                        "matched_posts": index,
+                        "posts_checked": processed_posts,
+                        "matched_posts": processed_posts,
                         "saved_posts": processed_posts,
                         "total_posts": len(target_source_ids),
+                        **shard_metadata,
                     }
                     repo._emit_job_progress(
                         job_id=job_id,
@@ -286,6 +642,186 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         progress_state=progress_state,
                         force=index == len(target_source_ids),
                     )
+                    continue
+                fetch_started_at = time.monotonic()
+                result = await fetcher.fetch_comments_for_shortcode(
+                    shortcode,
+                    max_comments=max_comments_per_post,
+                    fetch_replies=fetch_replies,
+                    expected_comment_count=expected_comment_counts_by_shortcode.get(shortcode),
+                )
+                fetch_elapsed_ms = int((time.monotonic() - fetch_started_at) * 1000)
+                if result.auth_failed and not result.comments:
+                    normalized_auth_failed_shortcode = str(shortcode or "").strip()
+                    if normalized_auth_failed_shortcode:
+                        auth_failed_target_source_ids.append(normalized_auth_failed_shortcode)
+                        auth_failed_fetch_reasons[normalized_auth_failed_shortcode] = str(
+                            result.fetch_reason or "auth_failed"
+                        )
+                    consecutive_post_auth_failures += 1
+                    should_skip_post_auth_failure = (
+                        successful_target_fetches > 0
+                        or consecutive_post_auth_failures < post_auth_failure_circuit_limit
+                    )
+                    if should_skip_post_auth_failure:
+                        total_elapsed_ms = int((time.monotonic() - post_started_at) * 1000)
+                        post_latency_samples.append(
+                            {
+                                "shortcode": shortcode,
+                                "fetch_elapsed_ms": fetch_elapsed_ms,
+                                "persist_elapsed_ms": 0,
+                                "total_elapsed_ms": total_elapsed_ms,
+                                "comments_fetched": 0,
+                                "comments_upserted": 0,
+                                "comments_marked_missing": 0,
+                                "fetch_reason": result.fetch_reason,
+                                "is_complete": False,
+                                "completion_reason": "post_auth_failed_skipped",
+                                "reported_comment_count": _extract_reported_comment_count(result),
+                            }
+                        )
+                        processed_posts += 1
+                        activity = {
+                            "phase": "comments_scrapling_running",
+                            "posts_checked": processed_posts,
+                            "matched_posts": processed_posts,
+                            "saved_posts": processed_posts,
+                            "total_posts": len(target_source_ids),
+                            **shard_metadata,
+                        }
+                        repo._emit_job_progress(
+                            job_id=job_id,
+                            stage=stage,
+                            platform="instagram",
+                            account=account_handle,
+                            scraped_posts=processed_posts,
+                            scraped_comments=comments_fetched,
+                            posts_upserted=processed_posts,
+                            comments_upserted=comments_upserted,
+                            activity=activity,
+                            progress_state=progress_state,
+                            force=index == len(target_source_ids),
+                        )
+                        continue
+                    raise CommentsScraplingRuntimeError(
+                        f"Instagram auth failed while fetching comments for {shortcode}.",
+                        error_code="instagram_comments_auth_failed",
+                        retryable=successful_target_fetches > 0,
+                        runtime_metadata={
+                            "shortcode": shortcode,
+                            "fetch_reason": result.fetch_reason,
+                            "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
+                            "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
+                            "post_auth_failure_circuit_limit": post_auth_failure_circuit_limit,
+                        },
+                    )
+                consecutive_post_auth_failures = 0
+                if result.fetch_failed and not result.comments:
+                    raise CommentsScraplingRuntimeError(
+                        f"Instagram comments fetch failed for {shortcode}.",
+                        error_code=str(result.fetch_reason or "instagram_comments_fetch_failed"),
+                        retryable=bool(result.retryable),
+                        runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
+                    )
+                is_complete = _comments_scrape_is_complete(
+                    result=result,
+                    max_comments_per_post=max_comments_per_post,
+                )
+                completion_reason = (
+                    "max_comments_cap"
+                    if max_comments_per_post and len(result.comments) >= max_comments_per_post
+                    else "pagination_exhausted"
+                    if is_complete
+                    else "incomplete_fetch"
+                )
+                persist_started_at = time.monotonic()
+                with pg.db_connection(label="instagram-comments-scrapling-persist") as persist_conn:
+                    _raise_if_cancelled(
+                        job_id=job_id,
+                        run_id=run_id,
+                        runtime_metadata=dict(fetcher.runtime_metadata),
+                        conn=persist_conn,
+                    )
+                    persisted = persist_instagram_comments_for_post(
+                        account_handle=account_handle,
+                        shortcode=shortcode,
+                        comments=result.comments,
+                        run_id=run_id or None,
+                        job_id=job_id,
+                        is_complete=is_complete,
+                        source_scope=source_scope,
+                        conn=persist_conn,
+                    )
+                    persist_conn.commit()
+                persist_elapsed_ms = int((time.monotonic() - persist_started_at) * 1000)
+                total_elapsed_ms = int((time.monotonic() - post_started_at) * 1000)
+                if first_post_persisted_at is None:
+                    first_post_persisted_at = repo._now_utc()
+                if result.fetch_failed and result.retryable:
+                    normalized_incomplete_shortcode = str(shortcode or "").strip()
+                    if normalized_incomplete_shortcode:
+                        incomplete_target_source_ids.append(normalized_incomplete_shortcode)
+                        incomplete_fetch_reasons[normalized_incomplete_shortcode] = str(
+                            result.fetch_reason or "retryable_incomplete_fetch"
+                        )
+                post_latency_samples.append(
+                    {
+                        "shortcode": shortcode,
+                        "fetch_elapsed_ms": fetch_elapsed_ms,
+                        "persist_elapsed_ms": persist_elapsed_ms,
+                        "total_elapsed_ms": total_elapsed_ms,
+                        "comments_fetched": len(result.comments),
+                        "comments_upserted": persisted.comments_upserted,
+                        "comments_marked_missing": persisted.comments_marked_missing,
+                        "fetch_reason": result.fetch_reason,
+                        "is_complete": is_complete,
+                        "completion_reason": completion_reason,
+                        "reported_comment_count": _extract_reported_comment_count(result),
+                    }
+                )
+                processed_posts += 1
+                comments_fetched += len(result.comments)
+                comments_upserted += persisted.comments_upserted
+                successful_target_fetches += 1
+                comments_marked_missing += persisted.comments_marked_missing
+                mirror_jobs_enqueued += persisted.comment_media_mirror_jobs_enqueued
+                mirror_job_enqueue_errors += persisted.comment_media_mirror_job_enqueue_errors
+                activity = {
+                    "phase": "comments_scrapling_running",
+                    "posts_checked": processed_posts,
+                    "matched_posts": processed_posts,
+                    "saved_posts": processed_posts,
+                    "total_posts": len(target_source_ids),
+                    **shard_metadata,
+                }
+                repo._emit_job_progress(
+                    job_id=job_id,
+                    stage=stage,
+                    platform="instagram",
+                    account=account_handle,
+                    scraped_posts=processed_posts,
+                    scraped_comments=comments_fetched,
+                    posts_upserted=processed_posts,
+                    comments_upserted=comments_upserted,
+                    activity=activity,
+                    progress_state=progress_state,
+                    force=index == len(target_source_ids),
+                )
+
+            retryable_incomplete_targets = list(dict.fromkeys(incomplete_target_source_ids))
+            if retryable_incomplete_targets:
+                raise CommentsScraplingRuntimeError(
+                    "Instagram comments Scrapling job had retryable incomplete posts.",
+                    error_code="instagram_comments_incomplete_retryable",
+                    retryable=True,
+                    runtime_metadata={
+                        "incomplete_target_source_ids": retryable_incomplete_targets,
+                        "incomplete_fetch_reasons": {
+                            shortcode: incomplete_fetch_reasons.get(shortcode)
+                            for shortcode in retryable_incomplete_targets
+                        },
+                    },
+                )
 
             return auth_metadata, dict(fetcher.runtime_metadata)
         finally:
@@ -301,7 +837,9 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             "mode": mode,
             "source_scope": source_scope,
             "target_source_ids": target_source_ids,
+            **terminal_metadata_common(),
             "stage_counters": {"posts": processed_posts, "comments": comments_fetched},
+            "skipped_complete_target_source_ids": skipped_complete_target_source_ids,
             "persist_counters": {
                 "posts_upserted": processed_posts,
                 "comments_upserted": comments_upserted,
@@ -315,9 +853,8 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 "target_posts": len(target_source_ids),
             },
             "auth_context": {
-                "session_source": auth_metadata.get("source"),
-                "browser_account_id": auth_metadata.get("browser_account_id"),
-                "validation_category": auth_metadata.get("validation_category"),
+                **auth_context,
+                "metadata_source": auth_metadata.get("source"),
             },
             "fetcher_runtime": fetcher_metadata,
         }
@@ -342,6 +879,10 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 "mode": mode,
                 "source_scope": source_scope,
                 "target_source_ids": target_source_ids,
+                "incomplete_target_source_ids": list(dict.fromkeys(incomplete_target_source_ids)),
+                "skipped_complete_target_source_ids": skipped_complete_target_source_ids,
+                "incomplete_fetch_reasons": dict(incomplete_fetch_reasons),
+                **terminal_metadata_common(),
                 "cancelled": True,
                 "cancel_scope": exc.cancel_scope,
                 "job_status_at_cancel": exc.job_status,
@@ -356,7 +897,14 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     "comment_media_mirror_job_enqueue_errors": mirror_job_enqueue_errors,
                 },
                 "runtime_metadata": exc.runtime_metadata,
+                "auth_context": auth_context,
                 "fetcher_runtime": fetcher_metadata,
+                "retry_rebalance": _retry_rebalance_metadata(
+                    comments_shard_count=comments_shard_count,
+                    target_source_ids=target_source_ids,
+                    processed_posts=processed_posts,
+                    incomplete_target_source_ids=incomplete_target_source_ids,
+                ),
             },
             last_error_code="instagram_comments_scrapling_cancelled",
             last_error_class=exc.__class__.__name__,
@@ -365,12 +913,56 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         terminal_error_message = str(exc)
     except Exception as exc:  # noqa: BLE001
         runtime_error_code = str(getattr(exc, "error_code", "") or "").strip().lower()
-        error_code = runtime_error_code or "instagram_comments_scrapling_failed"
+        runtime_metadata = repo._metadata_dict(getattr(exc, "runtime_metadata", None))
+        retry_incomplete_targets = [
+            str(item or "").strip()
+            for item in runtime_metadata.get("incomplete_target_source_ids") or []
+            if str(item or "").strip()
+        ]
+        retry_incomplete_targets = list(dict.fromkeys(retry_incomplete_targets))
+        database_capacity_error = _is_database_capacity_error(exc)
+        transport_error = _is_comments_transport_error(exc)
+        error_code = (
+            "instagram_comments_database_capacity"
+            if database_capacity_error
+            else "instagram_comments_transport_error"
+            if transport_error
+            else runtime_error_code or "instagram_comments_scrapling_failed"
+        )
         error_class = str(getattr(exc, "error_class", "") or exc.__class__.__name__).strip()
-        retryable = bool(getattr(exc, "retryable", False))
+        retryable = bool(getattr(exc, "retryable", False)) or database_capacity_error or transport_error
         attempt_count = int(job.get("attempt_count") or 1)
         max_attempts = int(job.get("max_attempts") or 1)
         can_retry = retryable and attempt_count < max_attempts
+        retry_rebalance = _retry_rebalance_metadata(
+            comments_shard_count=comments_shard_count,
+            target_source_ids=target_source_ids,
+            processed_posts=processed_posts,
+            incomplete_target_source_ids=retry_incomplete_targets or incomplete_target_source_ids,
+        )
+        retry_target_source_ids = retry_incomplete_targets or [
+            str(item or "").strip()
+            for item in ((retry_rebalance or {}).get("remaining_target_source_ids") or [])
+            if str(item or "").strip()
+        ]
+        retry_target_source_ids = list(dict.fromkeys(retry_target_source_ids))
+        if can_retry and retry_target_source_ids:
+            try:
+                repo._update_job_config(
+                    job_id,
+                    config_updates={
+                        "target_source_ids": retry_target_source_ids,
+                        "comments_shard_target_count": len(retry_target_source_ids),
+                        "comments_retry_incomplete": True,
+                        "comments_retry_incomplete_source_job_id": job_id,
+                    },
+                )
+            except pg.DatabaseServiceUnavailableError as update_exc:
+                logger.warning(
+                    "Deferred comments retry target narrowing after database saturation: job_id=%s error=%s",
+                    job_id,
+                    update_exc,
+                )
         next_available_at = (
             repo._now_utc() + timedelta(seconds=repo._retry_backoff_seconds(attempt_count)) if can_retry else None
         )
@@ -386,6 +978,10 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 "mode": mode,
                 "source_scope": source_scope,
                 "target_source_ids": target_source_ids,
+                "incomplete_target_source_ids": list(dict.fromkeys(incomplete_target_source_ids)),
+                "skipped_complete_target_source_ids": skipped_complete_target_source_ids,
+                "incomplete_fetch_reasons": dict(incomplete_fetch_reasons),
+                **terminal_metadata_common(),
                 "error_code": error_code,
                 "error_class": error_class,
                 "activity": {"phase": "failed", "last_progress_at": repo._iso(repo._now_utc())},
@@ -393,8 +989,10 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     "posts_upserted": processed_posts,
                     "comments_upserted": comments_upserted,
                 },
-                "runtime_metadata": getattr(exc, "runtime_metadata", None),
+                "runtime_metadata": runtime_metadata or getattr(exc, "runtime_metadata", None),
+                "auth_context": auth_context,
                 "fetcher_runtime": fetcher_metadata,
+                "retry_rebalance": retry_rebalance,
             },
             last_error_code=error_code,
             last_error_class=error_class,
@@ -402,6 +1000,27 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         )
         terminal_status = "retrying" if can_retry else "failed"
         terminal_error_message = str(exc)
+        if terminal_status == "failed":
+            try:
+                _abort_queued_sibling_shards_after_run_fatal_error(
+                    repo=repo,
+                    run_id=run_id,
+                    failed_job_id=job_id,
+                    stage=stage,
+                    account_handle=account_handle,
+                    mode=mode,
+                    source_scope=source_scope,
+                    error_code=error_code,
+                    error_class=error_class,
+                    error_message=str(exc),
+                )
+            except pg.DatabaseServiceUnavailableError as abort_exc:
+                logger.warning(
+                    "Deferred sibling comments shard abort after database saturation: run_id=%s job_id=%s error=%s",
+                    run_id,
+                    job_id,
+                    abort_exc,
+                )
     finally:
         if run_id:
             try:
@@ -450,5 +1069,6 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             "metadata": {
                 "degraded_summary": True,
                 "database_service_unavailable": True,
+                **terminal_metadata_common(),
             },
         }

--- a/trr_backend/socials/instagram/cookie_refresh.py
+++ b/trr_backend/socials/instagram/cookie_refresh.py
@@ -294,6 +294,7 @@ def interactive_chrome_login(
     cookie_file: str | Path = "data/instagram_cookies.json",
     timeout_seconds: int = 300,
     validation_username: str | None = None,
+    account_id: str | None = None,
     headless: bool = False,
 ) -> dict[str, str]:
     """Open Chrome with the user's real profile for Instagram login.
@@ -306,9 +307,11 @@ def interactive_chrome_login(
     if not target_file.is_absolute():
         target_file = Path(__file__).resolve().parent.parent.parent.parent / cookie_file
     normalized_validation_username = str(validation_username or "").strip().lstrip("@")
+    normalized_account_id = str(account_id or "").strip().lstrip("@")
+    session_account_id = normalized_account_id or normalized_validation_username or chrome_profile_name
     session_paths = _INSTAGRAM_BROWSER_SESSIONS.session_paths(
-        normalized_validation_username or chrome_profile_name,
-        fallback_account_id=normalized_validation_username or chrome_profile_name,
+        session_account_id,
+        fallback_account_id=session_account_id,
     )
     saved_cookies = _read_cookie_file(session_paths.cookie_file_path)
     if saved_cookies.get("sessionid"):
@@ -461,9 +464,9 @@ def interactive_chrome_login(
                 raise RuntimeError("Timed out waiting for Instagram login — no session cookie detected")
 
             _INSTAGRAM_BROWSER_SESSIONS.import_bootstrapped_session(
-                normalized_validation_username or chrome_profile_name,
+                session_account_id,
                 context.storage_state(),
-                fallback_account_id=normalized_validation_username or chrome_profile_name,
+                fallback_account_id=session_account_id,
             )
             _write_cookie_file(target_file, cookies)
             logger.info("Interactive login succeeded — cookies written to %s", target_file)

--- a/trr_backend/socials/instagram/post_normalizer.py
+++ b/trr_backend/socials/instagram/post_normalizer.py
@@ -173,8 +173,7 @@ def normalize_instagram_post(payload: dict[str, Any], *, account_handle: str | N
     caption = _extract_caption(node)
     media_variants = _extract_media_variants(node)
     child_posts = _extract_child_posts(node)
-    child_urls = [variant.url for child in child_posts for variant in child.media_variants]
-    media_urls = _dedupe([variant.url for variant in media_variants] + child_urls)
+    media_urls = _extract_primary_media_urls(node, media_variants, child_posts)
     width, height = _extract_dimensions(node, media_variants)
     thumbnail_url = _extract_thumbnail_url(node, media_variants)
     shortcode = _extract_shortcode(node)
@@ -593,6 +592,45 @@ def _extract_media_variants(node: dict[str, Any]) -> list[InstagramMediaVariant]
     return variants
 
 
+def _select_primary_variant_url(
+    media_variants: list[InstagramMediaVariant],
+    *,
+    media_type: str | None,
+) -> str | None:
+    normalized_media_type = str(media_type or "").strip().lower()
+    expects_video = normalized_media_type in {"video", "reel"}
+    if expects_video:
+        for variant in media_variants:
+            if variant.media_type == "video":
+                return variant.url
+    for variant in media_variants:
+        if variant.media_type == "image":
+            return variant.url
+    for variant in media_variants:
+        if variant.media_type == "video":
+            return variant.url
+    return media_variants[0].url if media_variants else None
+
+
+def _extract_primary_media_urls(
+    node: dict[str, Any],
+    media_variants: list[InstagramMediaVariant],
+    child_posts: list[InstagramChildPost],
+) -> list[str]:
+    media_type = _determine_media_type(node)
+    if media_type == "carousel" and child_posts:
+        return _dedupe(
+            [
+                selected
+                for child in child_posts
+                for selected in [_select_primary_variant_url(child.media_variants, media_type=child.media_type)]
+                if selected
+            ]
+        )
+    selected = _select_primary_variant_url(media_variants, media_type=media_type)
+    return [selected] if selected else []
+
+
 def _extract_child_posts(node: dict[str, Any]) -> list[InstagramChildPost]:
     children: list[InstagramChildPost] = []
 
@@ -701,6 +739,8 @@ def _determine_media_type(node: dict[str, Any]) -> str | None:
     if media_type == 8 or node.get("carousel_media") or node.get("carousel_media_count") or node.get("childPosts"):
         return "carousel"
     if media_type == 2 or node.get("is_video") is True or _first_value(node, "videoUrl", "video_url"):
+        return "video"
+    if _as_list(node.get("video_versions")):
         return "video"
     if media_type == 1:
         return "image"

--- a/trr_backend/socials/instagram/posts_scrapling/persistence.py
+++ b/trr_backend/socials/instagram/posts_scrapling/persistence.py
@@ -254,42 +254,70 @@ def _collect_video_versions_urls(video_versions: Any) -> list[str]:
     return urls
 
 
-def _extract_media_urls(node: dict[str, Any]) -> tuple[list[str], str | None]:
-    """Return (media_urls, thumbnail_url) handling both legacy and XDTMediaDict shapes.
+def _is_video_media_node(node: dict[str, Any]) -> bool:
+    typename = str(node.get("__typename") or "").strip()
+    if typename in {"GraphVideo", "XDTGraphVideo"}:
+        return True
+    media_type_int = node.get("media_type")
+    if media_type_int == 2:
+        return True
+    return bool(node.get("is_video") or node.get("video_url") or node.get("video_versions"))
 
-    Dedupes. Returns the first image_versions url as the thumbnail hint.
+
+def _select_primary_media_url_for_node(
+    node: dict[str, Any],
+    *,
+    image_urls: list[str],
+    video_urls: list[str],
+) -> str | None:
+    if _is_video_media_node(node) and video_urls:
+        return video_urls[0]
+    if image_urls:
+        return image_urls[0]
+    if video_urls:
+        return video_urls[0]
+    return None
+
+
+def _extract_media_urls(node: dict[str, Any]) -> tuple[list[str], str | None]:
+    """Return canonical media_urls plus thumbnail_url for legacy/XDT shapes.
+
+    ``media_urls`` stores the post payloads to mirror. Cover images stay in
+    ``thumbnail_url`` so reels mirror one cover image and one video, not a
+    duplicate cover/video candidate set.
     """
     media_urls: list[str] = []
     thumbnail_url: str | None = None
 
     # Legacy top-level display_url + video_url
     display_url = str(node.get("display_url") or "").strip()
+    top_image_urls = [display_url] if display_url else []
     if display_url:
-        media_urls.append(display_url)
         thumbnail_url = display_url
     video_url = str(node.get("video_url") or "").strip()
-    if video_url and video_url not in media_urls:
-        media_urls.append(video_url)
+    top_video_urls = [video_url] if video_url else []
 
     # XDTMediaDict top-level image_versions2 / video_versions
     image_urls = _collect_image_versions_urls(node.get("image_versions2"))
     if image_urls and not thumbnail_url:
         thumbnail_url = image_urls[0]
-    for url in image_urls:
-        if url not in media_urls:
-            media_urls.append(url)
-    for url in _collect_video_versions_urls(node.get("video_versions")):
-        if url not in media_urls:
-            media_urls.append(url)
+    top_image_urls.extend(image_urls)
+    top_video_urls.extend(_collect_video_versions_urls(node.get("video_versions")))
 
     # Legacy carousel children
     sidecar_edges = (node.get("edge_sidecar_to_children") or {}).get("edges") or []
+    child_urls: list[str] = []
     for child_edge in sidecar_edges:
         child = child_edge.get("node") or {} if isinstance(child_edge, dict) else {}
-        for url_key in ("display_url", "video_url"):
-            child_url = str(child.get(url_key) or "").strip()
-            if child_url and child_url not in media_urls:
-                media_urls.append(child_url)
+        child_image_urls = [str(child.get("display_url") or "").strip()]
+        child_video_urls = [str(child.get("video_url") or "").strip()]
+        selected = _select_primary_media_url_for_node(
+            child,
+            image_urls=[url for url in child_image_urls if url],
+            video_urls=[url for url in child_video_urls if url],
+        )
+        if selected:
+            child_urls.append(selected)
 
     # XDTMediaDict carousel_media
     carousel_media = node.get("carousel_media") or []
@@ -297,12 +325,24 @@ def _extract_media_urls(node: dict[str, Any]) -> tuple[list[str], str | None]:
         for child in carousel_media:
             if not isinstance(child, dict):
                 continue
-            for url in _collect_image_versions_urls(child.get("image_versions2")):
-                if url not in media_urls:
-                    media_urls.append(url)
-            for url in _collect_video_versions_urls(child.get("video_versions")):
-                if url not in media_urls:
-                    media_urls.append(url)
+            selected = _select_primary_media_url_for_node(
+                child,
+                image_urls=_collect_image_versions_urls(child.get("image_versions2")),
+                video_urls=_collect_video_versions_urls(child.get("video_versions")),
+            )
+            if selected:
+                child_urls.append(selected)
+
+    if child_urls:
+        media_urls.extend(child_urls)
+    else:
+        selected = _select_primary_media_url_for_node(
+            node,
+            image_urls=top_image_urls,
+            video_urls=top_video_urls,
+        )
+        if selected:
+            media_urls.append(selected)
 
     return media_urls, thumbnail_url
 

--- a/trr_backend/socials/instagram/scraper.py
+++ b/trr_backend/socials/instagram/scraper.py
@@ -208,9 +208,13 @@ class InstagramComment:
     is_reply: bool
     parent_comment_id: str | None  # ID of parent comment if this is a reply
     reply_count: int
+    reply_depth: int = 0
     replies: list["InstagramComment"] = field(default_factory=list)
     media_urls: list[str] = field(default_factory=list)
+    hosted_media_urls: list[str] = field(default_factory=list)
+    owner_full_name: str | None = None
     owner_profile_pic_url: str | None = None
+    owner_profile_pic_url_hd: str | None = None
     owner_is_verified: bool | None = None
 
     # Post reference
@@ -3464,21 +3468,53 @@ class InstagramScraper:
         post_url: str,
         is_reply: bool = False,
         parent_id: str | None = None,
+        reply_depth: int | None = None,
     ) -> InstagramComment:
         """Parse comment data into InstagramComment object."""
         user = data.get("user", {}) if isinstance(data.get("user"), dict) else {}
         owner = data.get("owner", {}) if isinstance(data.get("owner"), dict) else {}
+        owner_hd_info = owner.get("hd_profile_pic_url_info")
+        if not isinstance(owner_hd_info, dict):
+            owner_hd_info = {}
+        user_hd_info = user.get("hd_profile_pic_url_info")
+        if not isinstance(user_hd_info, dict):
+            user_hd_info = {}
         created_at = self._coerce_timestamp(data.get("created_at") or data.get("timestamp"))
         username = data.get("ownerUsername") or owner.get("username") or user.get("username") or ""
-        user_id = data.get("ownerId") or owner.get("id") or user.get("pk") or user.get("id") or ""
+        user_id = data.get("ownerId") or owner.get("id") or owner.get("pk") or user.get("pk") or user.get("id") or ""
+        owner_full_name = (
+            data.get("ownerFullName")
+            or data.get("ownerDisplayName")
+            or owner.get("full_name")
+            or owner.get("fullName")
+            or user.get("full_name")
+            or user.get("fullName")
+        )
+        owner_profile_pic_url_hd = (
+            data.get("ownerProfilePicUrlHd")
+            or owner.get("profile_pic_url_hd")
+            or owner.get("profilePicUrlHd")
+            or user.get("profile_pic_url_hd")
+            or user.get("profilePicUrlHd")
+            or owner_hd_info.get("url")
+            or user_hd_info.get("url")
+        )
         likes = data.get("comment_like_count")
         if likes is None:
             likes = data.get("likesCount")
         if likes is None:
             likes = data.get("like_count")
+        if likes is None:
+            likes = data.get("likes")
         reply_count = data.get("child_comment_count")
         if reply_count is None:
             reply_count = data.get("repliesCount")
+        if reply_count is None:
+            reply_count = data.get("reply_count")
+        if reply_count is None:
+            reply_count = data.get("replies_count")
+        fallback_reply_depth = 1 if is_reply or parent_id else 0
+        normalized_reply_depth = max(0, int(reply_depth if reply_depth is not None else fallback_reply_depth))
 
         comment = InstagramComment(
             comment_id=str(data.get("pk") or data.get("id") or ""),
@@ -3491,15 +3527,19 @@ class InstagramScraper:
             is_reply=is_reply,
             parent_comment_id=parent_id,
             reply_count=self._coerce_int(reply_count, 0),
+            reply_depth=normalized_reply_depth,
             media_urls=self._extract_comment_media_urls(data),
+            hosted_media_urls=self._extract_hosted_comment_media_urls(data),
+            owner_full_name=str(owner_full_name or "").strip() or None,
             owner_profile_pic_url=self._pick_best_profile_pic_url(
-                data.get("ownerProfilePicUrlHd"),
+                owner_profile_pic_url_hd,
                 data.get("ownerProfilePicUrl"),
-                owner.get("profile_pic_url_hd") or owner.get("profilePicUrlHd"),
                 owner.get("profile_pic_url"),
-                user.get("profile_pic_url_hd") or user.get("profilePicUrlHd"),
+                owner.get("profilePicUrl"),
                 user.get("profile_pic_url"),
+                user.get("profilePicUrl"),
             ),
+            owner_profile_pic_url_hd=str(owner_profile_pic_url_hd or "").strip() or None,
             owner_is_verified=(
                 bool(owner.get("is_verified"))
                 if "is_verified" in owner
@@ -3511,15 +3551,37 @@ class InstagramScraper:
             post_url=post_url,
         )
         nested_replies = data.get("replies")
+        if not isinstance(nested_replies, list):
+            nested_replies = data.get("child_comments")
         if isinstance(nested_replies, list):
             comment.replies = [
-                self._parse_comment(reply, shortcode, post_url, is_reply=True, parent_id=comment.comment_id)
+                self._parse_comment(
+                    reply,
+                    shortcode,
+                    post_url,
+                    is_reply=True,
+                    parent_id=comment.comment_id,
+                    reply_depth=comment.reply_depth + 1,
+                )
                 for reply in nested_replies
                 if isinstance(reply, dict)
             ]
             if comment.reply_count <= 0:
                 comment.reply_count = len(comment.replies)
         return comment
+
+    @staticmethod
+    def _extract_hosted_comment_media_urls(data: dict[str, Any]) -> list[str]:
+        urls: list[str] = []
+        for key in ("hosted_media_urls", "hostedMediaUrls"):
+            candidates = data.get(key)
+            if not isinstance(candidates, list):
+                continue
+            for candidate in candidates:
+                value = str(candidate or "").strip()
+                if value.startswith(("http://", "https://")) and value not in urls:
+                    urls.append(value)
+        return urls
 
     def _extract_comment_media_urls(self, data: dict[str, Any]) -> list[str]:
         """Extract media URLs from Instagram comment payloads when present."""
@@ -3534,6 +3596,12 @@ class InstagramScraper:
         if isinstance(explicit_media_urls, list):
             for candidate in explicit_media_urls:
                 _append(candidate)
+        explicit_media_urls = data.get("mediaUrls")
+        if isinstance(explicit_media_urls, list):
+            for candidate in explicit_media_urls:
+                _append(candidate)
+        for key in ("media_url", "mediaUrl"):
+            _append(data.get(key))
 
         def _collect_media_node(node: Any) -> None:
             if isinstance(node, list):
@@ -3556,25 +3624,46 @@ class InstagramScraper:
                 "imageUrl",
                 "thumbnail_url",
                 "thumbnailUrl",
+                "media_url",
+                "mediaUrl",
+                "src",
             ):
                 _append(node.get(key))
 
             for nested_key in (
                 "media",
+                "comment_media",
+                "commentMedia",
                 "media_versions",
                 "attachment",
                 "attachments",
                 "content",
                 "preview",
+                "image",
                 "image_versions2",
                 "video_versions",
                 "carousel_media",
+                "giphy_media_info",
+                "giphyMediaInfo",
+                "animated_media",
+                "animatedMedia",
             ):
                 nested = node.get(nested_key)
                 if isinstance(nested, (dict, list)):
                     _collect_media_node(nested)
 
-        for key in ("media", "attachment", "attachments", "content", "preview", "clip"):
+        for key in (
+            "media",
+            "comment_media",
+            "commentMedia",
+            "attachment",
+            "attachments",
+            "content",
+            "preview",
+            "clip",
+            "giphy_media_info",
+            "giphyMediaInfo",
+        ):
             nested = data.get(key)
             if isinstance(nested, (dict, list)):
                 _collect_media_node(nested)

--- a/trr_backend/socials/profile_dashboard.py
+++ b/trr_backend/socials/profile_dashboard.py
@@ -58,6 +58,7 @@ def build_social_account_profile_dashboard(
             account_handle,
             progress_run_id,
             recent_log_limit=recent_log_limit,
+            fast=True,
         )
 
     payload = {


### PR DESCRIPTION
## Summary
- Expand Instagram comments workflow coverage across run lifecycle, cancellation/progress, sharding, auth resolution, retry behavior, and profile dashboard paths.
- Update backend social routes, repositories, worker/fetcher/job-runner behavior, and targeted tests for the current comments/admin contracts.

## Validation
- Passed: `pytest tests/api/routers/test_socials_season_analytics.py -k "comments_run_cancel or catalog_run_cancel or comments_scrape" -q` (9 passed, 216 deselected).
- Passed: `pytest tests/repositories/test_social_season_analytics.py -k "comments_scrape or comments_run_cancel or profile_dashboard or comments_rows or target_preview or large_target" -q` (16 passed, 711 deselected).
- Passed: `pytest tests/socials/test_instagram_comments_scrapling_retry.py tests/socials/test_instagram_comments_scrapling.py tests/socials/test_comment_scraper_fixes.py -q` (187 passed).
- GitHub: Secret Scan passed; CI still in progress when last checked.

Part of the 2026-04-30 workspace PR orchestrator publish-and-sync pass across trr-backend, trr-app, and trr-workspace.