### PR TITLE
Instagram comments coverage + field completeness (Phase 1-5)

### DIFF
--- a/scripts/socials/instagram/benchmark_comments_shards.py
+++ b/scripts/socials/instagram/benchmark_comments_shards.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Benchmark Instagram comments shard runtime without launching a scrape.
+
+Fixture mode is the default. Live mode is read-only and requires explicit
+confirmation plus an active-job preflight so this command cannot accidentally
+compete with an operator run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@dataclass(frozen=True, slots=True)
+class FixturePost:
+    shortcode: str
+    top_level_comments: int
+    replies: int
+    media_comments: int
+    hidden_reveal_attempted: bool = False
+    hidden_comments_merged: int = 0
+    hidden_reveal_skipped: bool = False
+    browser_fallback_ms: int = 0
+    transport_retries: int = 0
+    proxy_session: str = "fixture-session-a"
+    retryable_gaps: int = 0
+    terminal_unavailable: int = 0
+    stop_reason: str = "complete_fetchable"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="benchmark_comments_shards",
+        description="Benchmark Instagram comments shard metrics in fixture mode, or read-only live mode with guards.",
+    )
+    parser.add_argument(
+        "--fixture-profile",
+        choices=("tiny", "10", "50"),
+        default="tiny",
+        help="Fixture-backed profile to run. Fixture mode is the default.",
+    )
+    parser.add_argument("--output", help="Optional JSON output file.")
+    parser.add_argument("--live", action="store_true", help="Use read-only live DB rows instead of fixtures.")
+    parser.add_argument("--account", help="Instagram account handle for live mode.")
+    parser.add_argument(
+        "--confirm-live",
+        action="store_true",
+        help="Required with --live to acknowledge the command will query live DB state.",
+    )
+    parser.add_argument(
+        "--active-job-preflight",
+        action="store_true",
+        help="Required with --live; blocks when active comments_scrapling jobs exist for the account.",
+    )
+    parser.add_argument(
+        "--limit-posts",
+        type=int,
+        default=50,
+        help="Maximum recent live job rows to inspect in live mode.",
+    )
+    return parser.parse_args(argv)
+
+
+def _normalize_account(value: str | None) -> str:
+    return str(value or "").strip().lstrip("@").lower()
+
+
+def _require_live_guards(args: argparse.Namespace) -> list[str]:
+    missing: list[str] = []
+    if not _normalize_account(args.account):
+        missing.append("--account")
+    if not args.confirm_live:
+        missing.append("--confirm-live")
+    if not args.active_job_preflight:
+        missing.append("--active-job-preflight")
+    return missing
+
+
+def _build_fixture_profile(profile: str) -> list[FixturePost]:
+    if profile == "tiny":
+        return [
+            FixturePost(
+                shortcode="fixture_reply_tail",
+                top_level_comments=18,
+                replies=11,
+                media_comments=0,
+                transport_retries=1,
+                proxy_session="fixture-session-a",
+                stop_reason="complete_fetchable_with_replies",
+            ),
+            FixturePost(
+                shortcode="fixture_hidden_reveal",
+                top_level_comments=9,
+                replies=2,
+                media_comments=0,
+                hidden_reveal_attempted=True,
+                hidden_comments_merged=3,
+                browser_fallback_ms=420,
+                proxy_session="fixture-session-b",
+                stop_reason="complete_fetchable_hidden_merged",
+            ),
+            FixturePost(
+                shortcode="fixture_media_comment",
+                top_level_comments=7,
+                replies=4,
+                media_comments=2,
+                proxy_session="fixture-session-c",
+                stop_reason="complete_fetchable_media_comments",
+            ),
+        ]
+
+    post_count = 10 if profile == "10" else 50
+    posts: list[FixturePost] = []
+    for index in range(1, post_count + 1):
+        has_hidden_gap = index % 11 == 0
+        has_media = index % 7 == 0
+        retryable = 1 if index % 13 == 0 else 0
+        posts.append(
+            FixturePost(
+                shortcode=f"fixture_{profile}_{index:03d}",
+                top_level_comments=10 + (index % 5) * 3,
+                replies=(index % 4) * 4,
+                media_comments=1 if has_media else 0,
+                hidden_reveal_attempted=has_hidden_gap,
+                hidden_comments_merged=2 if has_hidden_gap and not retryable else 0,
+                hidden_reveal_skipped=bool(retryable),
+                browser_fallback_ms=360 if has_hidden_gap else 0,
+                transport_retries=1 if index % 9 == 0 else 0,
+                proxy_session=f"fixture-session-{(index % 4) + 1}",
+                retryable_gaps=retryable,
+                terminal_unavailable=1 if index % 29 == 0 else 0,
+                stop_reason="partial_retryable" if retryable else "complete_fetchable",
+            )
+        )
+    return posts
+
+
+def _estimated_post_runtime_ms(post: FixturePost) -> float:
+    comment_work_ms = (post.top_level_comments * 1.8) + (post.replies * 2.5)
+    media_work_ms = post.media_comments * 6.0
+    retry_work_ms = post.transport_retries * 45.0
+    retryable_gap_ms = post.retryable_gaps * 30.0
+    return round(
+        55.0 + comment_work_ms + media_work_ms + retry_work_ms + retryable_gap_ms + post.browser_fallback_ms,
+        2,
+    )
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(1, math.ceil((percentile / 100.0) * len(ordered)))
+    return round(ordered[min(rank - 1, len(ordered) - 1)], 2)
+
+
+def _summarize_fixture_profile(profile: str) -> dict[str, Any]:
+    started_at = datetime.now(UTC)
+    wall_start = time.perf_counter()
+    posts = _build_fixture_profile(profile)
+    post_runtime_ms = [_estimated_post_runtime_ms(post) for post in posts]
+    wall_seconds = time.perf_counter() - wall_start
+
+    stop_reasons: dict[str, int] = {}
+    proxy_sessions: dict[str, int] = {}
+    for post in posts:
+        stop_reasons[post.stop_reason] = stop_reasons.get(post.stop_reason, 0) + 1
+        proxy_sessions[post.proxy_session] = proxy_sessions.get(post.proxy_session, 0) + 1
+
+    top_level_comments = sum(post.top_level_comments for post in posts)
+    replies = sum(post.replies for post in posts)
+    hidden_merged = sum(post.hidden_comments_merged for post in posts)
+    media_comments = sum(post.media_comments for post in posts)
+
+    return {
+        "status": "ok",
+        "mode": "fixture",
+        "fixture_profile": profile,
+        "account": None,
+        "started_at": started_at.isoformat(),
+        "completed_at": datetime.now(UTC).isoformat(),
+        "safety": {
+            "fixture_mode_default": True,
+            "live_mode_requires_confirm_live": True,
+            "live_mode_requires_active_job_preflight": True,
+            "launched_scrape": False,
+        },
+        "totals": {
+            "posts_processed": len(posts),
+            "top_level_comments": top_level_comments,
+            "replies": replies,
+            "flattened_saved": top_level_comments + replies + hidden_merged,
+            "media_comments": media_comments,
+            "hidden_reveal_attempts": sum(1 for post in posts if post.hidden_reveal_attempted),
+            "hidden_comments_merged": hidden_merged,
+            "hidden_reveal_skipped": sum(1 for post in posts if post.hidden_reveal_skipped),
+            "transport_retries": sum(post.transport_retries for post in posts),
+            "retryable_gaps": sum(post.retryable_gaps for post in posts),
+            "terminal_unavailable": sum(post.terminal_unavailable for post in posts),
+        },
+        "timing": {
+            "wall_seconds": round(wall_seconds, 4),
+            "fixture_estimated_seconds": round(sum(post_runtime_ms) / 1000.0, 3),
+            "browser_fallback_seconds": round(sum(post.browser_fallback_ms for post in posts) / 1000.0, 3),
+            "per_post_median_ms": _percentile(post_runtime_ms, 50.0),
+            "per_post_p95_ms": _percentile(post_runtime_ms, 95.0),
+        },
+        "transport": {
+            "proxy_session_usage": proxy_sessions,
+            "session_count": len(proxy_sessions),
+            "redirect_refresh_count": 0,
+        },
+        "stop_reasons": stop_reasons,
+        "sample_posts": [
+            {
+                "shortcode": post.shortcode,
+                "top_level_comments": post.top_level_comments,
+                "replies": post.replies,
+                "media_comments": post.media_comments,
+                "hidden_reveal_attempted": post.hidden_reveal_attempted,
+                "stop_reason": post.stop_reason,
+                "estimated_runtime_ms": runtime_ms,
+            }
+            for post, runtime_ms in list(zip(posts, post_runtime_ms, strict=True))[:5]
+        ],
+    }
+
+
+def _load_db_helpers():
+    from trr_backend.db import pg
+    from trr_backend.utils.env import load_env
+
+    return pg, load_env
+
+
+def _active_live_comments_jobs(account: str) -> dict[str, Any]:
+    pg, load_env = _load_db_helpers()
+    load_env()
+    rows = pg.fetch_all(
+        """
+        select
+          count(*) as active_comment_jobs,
+          array_remove(array_agg(distinct run_id::text), null) as active_run_ids
+        from social.scrape_jobs
+        where platform = 'instagram'
+          and coalesce(config->>'stage', metadata->>'stage', job_type) = 'comments_scrapling'
+          and status in ('queued', 'pending', 'retrying', 'running')
+          and ltrim(lower(coalesce(
+            config->>'account',
+            metadata->>'account',
+            config->>'account_handle',
+            metadata->>'account_handle',
+            config->>'owner_username',
+            metadata->>'owner_username',
+            ''
+          )), '@') = %s
+        """,
+        [account],
+    )
+    row = rows[0] if rows else {}
+    return {
+        "active_comment_jobs": int(row.get("active_comment_jobs") or 0),
+        "active_run_ids": [str(value) for value in row.get("active_run_ids") or []],
+    }
+
+
+def _int_from_nested(mapping: dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, bool):
+            continue
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            continue
+        return max(0, parsed)
+    return 0
+
+
+def _sum_post_latency_samples(metadata: dict[str, Any], key: str) -> int:
+    post_latency = metadata.get("post_latency")
+    if not isinstance(post_latency, dict):
+        return 0
+    total = 0
+    for sample in post_latency.get("samples") or []:
+        if isinstance(sample, dict):
+            total += _int_from_nested(sample, key)
+    return total
+
+
+def _transport_retry_count(fetcher_runtime: dict[str, Any], retrieval_meta: dict[str, Any]) -> int:
+    explicit = _int_from_nested(retrieval_meta, "transport_retries", "retry_count")
+    if explicit:
+        return explicit
+    retry_reason_counts = fetcher_runtime.get("retry_reason_counts")
+    if not isinstance(retry_reason_counts, dict):
+        return 0
+    return sum(
+        max(0, int(value))
+        for value in retry_reason_counts.values()
+        if not isinstance(value, bool) and str(value).strip().isdigit()
+    )
+
+
+def _summarize_live_rows(account: str, *, limit_posts: int) -> dict[str, Any]:
+    pg, load_env = _load_db_helpers()
+    load_env()
+    rows = pg.fetch_all(
+        """
+        select
+          id::text as job_id,
+          status,
+          items_found,
+          last_error_code,
+          metadata
+        from social.scrape_jobs
+        where platform = 'instagram'
+          and coalesce(config->>'stage', metadata->>'stage', job_type) = 'comments_scrapling'
+          and ltrim(lower(coalesce(
+            config->>'account',
+            metadata->>'account',
+            config->>'account_handle',
+            metadata->>'account_handle',
+            config->>'owner_username',
+            metadata->>'owner_username',
+            ''
+          )), '@') = %s
+        order by created_at desc
+        limit %s
+        """,
+        [account, max(1, int(limit_posts))],
+    )
+
+    stop_reasons: dict[str, int] = {}
+    totals = {
+        "posts_processed": 0,
+        "top_level_comments": 0,
+        "replies": 0,
+        "flattened_saved": 0,
+        "media_comments": 0,
+        "hidden_reveal_attempts": 0,
+        "hidden_comments_merged": 0,
+        "hidden_reveal_skipped": 0,
+        "transport_retries": 0,
+        "retryable_gaps": 0,
+        "terminal_unavailable": 0,
+    }
+    for row in rows:
+        metadata = dict(row.get("metadata") or {})
+        activity = dict(metadata.get("activity") or {})
+        counters = dict(metadata.get("persist_counters") or {})
+        stage_counters = dict(metadata.get("stage_counters") or {})
+        fetcher_runtime = dict(metadata.get("fetcher_runtime") or {})
+        hidden_comments = dict(fetcher_runtime.get("hidden_comments") or {})
+        retrieval_meta = dict(metadata.get("retrieval_meta") or {})
+        sample_top_level_comments = _sum_post_latency_samples(metadata, "top_level_comment_count")
+        sample_flattened_comments = _sum_post_latency_samples(metadata, "observed_comment_count")
+        if not sample_flattened_comments:
+            sample_flattened_comments = _sum_post_latency_samples(metadata, "comments_fetched")
+        flattened_comments = (
+            sample_flattened_comments
+            or _int_from_nested(stage_counters, "comments")
+            or max(0, int(row.get("items_found") or 0) - _int_from_nested(stage_counters, "posts"))
+        )
+        top_level_comments = (
+            sample_top_level_comments
+            or _int_from_nested(counters, "top_level_comments", "top_level_comment_count")
+            or _int_from_nested(counters, "comments_upserted")
+        )
+        reply_comments = _int_from_nested(counters, "replies", "reply_comments", "saved_reply_comments")
+        if not reply_comments and flattened_comments and top_level_comments:
+            reply_comments = max(0, flattened_comments - top_level_comments)
+        stop_reason = str(
+            metadata.get("latest_retryable_stop_reason")
+            or metadata.get("stop_reason")
+            or row.get("last_error_code")
+            or row.get("status")
+            or "unknown"
+        )
+        stop_reasons[stop_reason] = stop_reasons.get(stop_reason, 0) + 1
+        totals["posts_processed"] += _int_from_nested(activity, "posts_checked", "completed_posts")
+        totals["top_level_comments"] += top_level_comments
+        totals["replies"] += reply_comments
+        totals["flattened_saved"] += flattened_comments
+        totals["media_comments"] += _int_from_nested(counters, "media_comments", "media_comment_rows")
+        totals["hidden_reveal_attempts"] += _int_from_nested(
+            activity,
+            "hidden_reveal_attempts",
+        ) or _int_from_nested(hidden_comments, "render_attempts")
+        totals["hidden_comments_merged"] += _int_from_nested(
+            counters,
+            "hidden_comments_merged",
+        ) or _int_from_nested(hidden_comments, "merged_comments")
+        totals["hidden_reveal_skipped"] += _int_from_nested(activity, "hidden_reveal_skipped_due_budget")
+        totals["transport_retries"] += _transport_retry_count(fetcher_runtime, retrieval_meta)
+        totals["retryable_gaps"] += _int_from_nested(
+            metadata,
+            "retryable_gaps",
+            "checkpoint_backed_repair_target_count",
+        )
+        totals["terminal_unavailable"] += _int_from_nested(metadata, "terminal_unavailable")
+    totals["flattened_saved"] = max(totals["flattened_saved"], totals["top_level_comments"] + totals["replies"])
+
+    return {
+        "status": "ok",
+        "mode": "live_read_only",
+        "fixture_profile": None,
+        "account": account,
+        "started_at": datetime.now(UTC).isoformat(),
+        "completed_at": datetime.now(UTC).isoformat(),
+        "safety": {
+            "fixture_mode_default": True,
+            "live_mode_requires_confirm_live": True,
+            "live_mode_requires_active_job_preflight": True,
+            "launched_scrape": False,
+        },
+        "totals": totals,
+        "timing": {
+            "wall_seconds": 0.0,
+            "fixture_estimated_seconds": None,
+            "browser_fallback_seconds": None,
+            "per_post_median_ms": None,
+            "per_post_p95_ms": None,
+        },
+        "transport": {"proxy_session_usage": {}, "session_count": None, "redirect_refresh_count": None},
+        "stop_reasons": stop_reasons,
+        "sample_jobs": [
+            {
+                "job_id": row.get("job_id"),
+                "status": row.get("status"),
+                "items_found": row.get("items_found"),
+                "last_error_code": row.get("last_error_code"),
+            }
+            for row in rows[:5]
+        ],
+    }
+
+
+def run_benchmark(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
+    if not args.live:
+        return 0, _summarize_fixture_profile(str(args.fixture_profile))
+
+    missing = _require_live_guards(args)
+    if missing:
+        return 2, {
+            "status": "refused",
+            "mode": "live_read_only",
+            "error": "live_mode_requires_explicit_flags",
+            "missing_flags": missing,
+            "safety": {"launched_scrape": False},
+        }
+
+    account = _normalize_account(args.account)
+    preflight = _active_live_comments_jobs(account)
+    if preflight["active_comment_jobs"] > 0:
+        return 2, {
+            "status": "blocked_active_jobs",
+            "mode": "live_read_only",
+            "account": account,
+            "active_job_preflight": preflight,
+            "safety": {"launched_scrape": False},
+        }
+
+    payload = _summarize_live_rows(account, limit_posts=args.limit_posts)
+    payload["active_job_preflight"] = preflight
+    return 0, payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    rc, payload = run_benchmark(args)
+    output = json.dumps(payload, indent=2, sort_keys=True, default=str)
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(output + "\n", encoding="utf-8")
+    print(output)
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -31,6 +31,17 @@ coalesce(
   end
 )
 """.strip()
+ACCOUNT_SQL = """
+ltrim(lower(coalesce(
+  config->>'account',
+  metadata->>'account',
+  config->>'account_handle',
+  metadata->>'account_handle',
+  config->>'owner_username',
+  metadata->>'owner_username',
+  ''
+)), '@')
+""".strip()
 
 
 @dataclass(slots=True)
@@ -46,8 +57,18 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--season-id", action="append", default=[], help="Optional season UUID filter.")
     parser.add_argument("--show-id", action="append", default=[], help="Optional show UUID filter.")
+    parser.add_argument("--account", action="append", default=[], help="Optional Instagram account handle filter.")
     parser.add_argument("--dry-run", action="store_true", help="Preview matching duplicate rows (default).")
     parser.add_argument("--apply", action="store_true", help="Retire duplicate rows by marking them cancelled.")
+    parser.add_argument(
+        "--confirm-destructive",
+        action="store_true",
+        help="Required with --apply; confirms duplicate jobs will be cancelled.",
+    )
+    parser.add_argument(
+        "--confirm-account",
+        help="Required with --apply; must match the single --account value.",
+    )
     parser.set_defaults(dry_run=True)
     return parser.parse_args(argv)
 
@@ -64,7 +85,32 @@ def _normalize_text_filters(values: list[str] | tuple[str, ...] | None) -> list[
     return normalized
 
 
-def _duplicate_comment_media_where_clause(*, season_ids: list[str], show_ids: list[str]) -> tuple[str, list[object]]:
+def _normalize_account_filters(values: list[str] | tuple[str, ...] | None) -> list[str]:
+    return _normalize_text_filters([str(value or "").strip().lstrip("@").lower() for value in values or []])
+
+
+def _destructive_refusal_reasons(args: argparse.Namespace, *, accounts: list[str]) -> list[str]:
+    if not bool(args.apply):
+        return []
+    reasons: list[str] = []
+    if not args.confirm_destructive:
+        reasons.append("missing --confirm-destructive")
+    if len(accounts) != 1:
+        reasons.append("destructive cleanup requires exactly one --account")
+    confirm_account = _normalize_account_filters([args.confirm_account] if args.confirm_account else [])
+    if not confirm_account:
+        reasons.append("missing --confirm-account")
+    elif len(accounts) == 1 and confirm_account[0] != accounts[0]:
+        reasons.append("--confirm-account must match --account")
+    return reasons
+
+
+def _duplicate_comment_media_where_clause(
+    *,
+    season_ids: list[str],
+    show_ids: list[str],
+    accounts: list[str],
+) -> tuple[str, list[object]]:
     filters = [
         "platform = 'instagram'",
         "status in ('queued', 'pending', 'retrying', 'running')",
@@ -78,11 +124,18 @@ def _duplicate_comment_media_where_clause(*, season_ids: list[str], show_ids: li
     if show_ids:
         filters.append("show_id::text = any(%s)")
         params.append(show_ids)
+    if accounts:
+        filters.append(f"({ACCOUNT_SQL}) = any(%s)")
+        params.append(accounts)
     return " and ".join(filters), params
 
 
-def _fetch_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
-    where_clause, params = _duplicate_comment_media_where_clause(season_ids=season_ids, show_ids=show_ids)
+def _fetch_matches(*, season_ids: list[str], show_ids: list[str], accounts: list[str]) -> list[dict[str, object]]:
+    where_clause, params = _duplicate_comment_media_where_clause(
+        season_ids=season_ids,
+        show_ids=show_ids,
+        accounts=accounts,
+    )
     return pg.fetch_all(
         f"""
         with ranked as (
@@ -90,21 +143,22 @@ def _fetch_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[s
             id::text as id,
             season_id::text as season_id,
             show_id::text as show_id,
+            {ACCOUNT_SQL} as account_handle,
             config->>'comment_id' as comment_id,
             config->>'comment_db_id' as comment_db_id,
             config->>'post_id' as post_id,
             {IDENTITY_SQL} as identity_key,
             created_at,
             first_value(id::text) over (
-              partition by platform, ({IDENTITY_SQL})
+              partition by platform, ({ACCOUNT_SQL}), ({IDENTITY_SQL})
               order by created_at desc, id desc
             ) as keep_job_id,
             row_number() over (
-              partition by platform, ({IDENTITY_SQL})
+              partition by platform, ({ACCOUNT_SQL}), ({IDENTITY_SQL})
               order by created_at desc, id desc
             ) as row_num,
             count(*) over (
-              partition by platform, ({IDENTITY_SQL})
+              partition by platform, ({ACCOUNT_SQL}), ({IDENTITY_SQL})
             ) as duplicate_count
           from social.scrape_jobs
           where {where_clause}
@@ -113,6 +167,7 @@ def _fetch_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[s
           id,
           season_id,
           show_id,
+          account_handle,
           comment_id,
           comment_db_id,
           post_id,
@@ -128,8 +183,8 @@ def _fetch_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[s
     )
 
 
-def _retire_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[str, object]]:
-    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+def _retire_matches(*, season_ids: list[str], show_ids: list[str], accounts: list[str]) -> list[dict[str, object]]:
+    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids, accounts=accounts)
     duplicate_ids = [str(row.get("id") or "").strip() for row in matched_rows if str(row.get("id") or "").strip()]
     if not duplicate_ids:
         return []
@@ -155,17 +210,37 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv or sys.argv[1:])
     season_ids = _normalize_text_filters(args.season_id)
     show_ids = _normalize_text_filters(args.show_id)
+    accounts = _normalize_account_filters(args.account)
     dry_run = bool(args.dry_run and not args.apply)
 
-    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids)
+    refusal_reasons = _destructive_refusal_reasons(args, accounts=accounts)
+    if refusal_reasons:
+        print(
+            json.dumps(
+                {
+                    "status": "refused",
+                    "dry_run": True,
+                    "accounts": accounts,
+                    "season_ids": season_ids,
+                    "show_ids": show_ids,
+                    "refusal_reasons": refusal_reasons,
+                    "totals": {"matched_rows": 0, "retired_rows": 0},
+                }
+            )
+        )
+        return 2
+
+    matched_rows = _fetch_matches(season_ids=season_ids, show_ids=show_ids, accounts=accounts)
     stats = CleanupStats(matched_rows=len(matched_rows), retired_rows=0)
     if not dry_run and matched_rows:
-        stats.retired_rows = len(_retire_matches(season_ids=season_ids, show_ids=show_ids))
+        stats.retired_rows = len(_retire_matches(season_ids=season_ids, show_ids=show_ids, accounts=accounts))
 
     print(
         json.dumps(
             {
+                "status": "ok",
                 "dry_run": dry_run,
+                "accounts": accounts,
                 "season_ids": season_ids,
                 "show_ids": show_ids,
                 "totals": {"matched_rows": stats.matched_rows, "retired_rows": stats.retired_rows},

--- a/supabase/migrations/20260501210512_instagram_comments_owner_metadata.sql
+++ b/supabase/migrations/20260501210512_instagram_comments_owner_metadata.sql
@@ -1,0 +1,20 @@
+begin;
+
+-- Phase 2 additive owner-metadata columns for Instagram comments.
+--
+-- Persisted Apify-source fields that IG already ships in the comment payload
+-- but the scraper has not been writing into typed columns. All columns are
+-- nullable; older comment rows remain untouched. Column writes in
+-- _batch_upsert_instagram_comments and _persist_without_season_context are
+-- gated behind _column_exists() so partial deploys remain safe.
+
+alter table social.instagram_comments
+  add column if not exists comment_url text,
+  add column if not exists author_fbid_v2 text,
+  add column if not exists author_is_mentionable boolean,
+  add column if not exists author_is_private boolean,
+  add column if not exists author_latest_reel_media bigint
+    check (author_latest_reel_media is null or author_latest_reel_media >= 0),
+  add column if not exists author_profile_pic_id text;
+
+commit;

--- a/tests/repositories/test_instagram_queryable_repository.py
+++ b/tests/repositories/test_instagram_queryable_repository.py
@@ -28,6 +28,7 @@ def test_apply_instagram_comment_queryable_columns_uses_full_comment_payload(
     comment = SimpleNamespace(
         owner_full_name="Comment Author",
         owner_profile_pic_url_hd="https://cdn.example.com/author-hd.jpg",
+        source_snapshot_type="rendered_hidden_comments",
         to_dict=lambda: {
             "owner": {
                 "full_name": "Raw Name",
@@ -48,7 +49,7 @@ def test_apply_instagram_comment_queryable_columns_uses_full_comment_payload(
         "author_profile_pic_url_hd": "https://cdn.example.com/author-hd.jpg",
         "parent_comment_external_id": "parent-1",
         "reply_depth": 2,
-        "source_snapshot_type": "full_comments_scrape",
+        "source_snapshot_type": "rendered_hidden_comments",
     }
 
 

--- a/tests/repositories/test_social_dispatch_stage_claims.py
+++ b/tests/repositories/test_social_dispatch_stage_claims.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from trr_backend.repositories import social_season_analytics as repo
+from trr_backend.socials.instagram.comments_scrapling import job_runner as comments_job_runner
 
 
 def test_stage_claim_candidates_do_not_let_comments_workers_borrow_posts() -> None:
@@ -36,3 +39,22 @@ def test_effective_runtime_version_tracks_stage_specific_modal_function(monkeypa
     assert comments_runtime["modal_function"] == "run_social_comments_job"
     assert media_runtime["modal_function"] == "run_social_media_job"
     assert posts_runtime["modal_function"] == "run_social_posts_job"
+
+
+def test_comments_scrapling_attempt_defaults_match_queue_defaults() -> None:
+    assert comments_job_runner._job_attempt_state({}) == (1, 3)  # noqa: SLF001
+    assert comments_job_runner._job_attempt_state({"attempt_count": 3, "max_attempts": 3}) == (3, 3)  # noqa: SLF001
+
+
+def test_comments_scrapling_completion_uses_flattened_reply_count() -> None:
+    result = SimpleNamespace(
+        comments=[
+            SimpleNamespace(replies=[SimpleNamespace(replies=[]), SimpleNamespace(replies=[])]),
+            SimpleNamespace(replies=[]),
+        ],
+        fetch_failed=False,
+        auth_failed=False,
+        reported_comment_count=4,
+    )
+
+    assert comments_job_runner._comments_scrape_is_complete(result=result, max_comments_per_post=0) is True  # noqa: SLF001

--- a/tests/repositories/test_social_run_lifecycle_repository.py
+++ b/tests/repositories/test_social_run_lifecycle_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 
 import pytest
+from psycopg2 import OperationalError
 
 import trr_backend.repositories.social_season_analytics as social_repo
 import trr_backend.socials.control_plane.run_lifecycle as run_lifecycle
@@ -234,6 +235,45 @@ def test_update_run_summary_prefers_incremental_counter_columns(monkeypatch: pyt
     assert any("select total_jobs" in call for call in calls)
 
 
+def test_recompute_run_summary_ignores_superseded_instagram_comments_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_fetch_one(sql: str, params: list[object]):
+        captured["sql"] = " ".join(sql.lower().split())
+        captured["params"] = list(params)
+        return {
+            "stats": {
+                "total_jobs": 2,
+                "completed_jobs": 2,
+                "failed_jobs": 0,
+                "active_jobs": 0,
+                "items_found_total": 44,
+            },
+            "stage_counts": {
+                social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE: {
+                    "total": 2,
+                    "completed": 2,
+                    "failed": 0,
+                    "active": 0,
+                }
+            },
+        }
+
+    monkeypatch.setattr(run_lifecycle.legacy.pg, "fetch_one", _fake_fetch_one)
+
+    summary = run_lifecycle._recompute_run_summary_from_jobs("run-1")
+
+    assert summary["failed_jobs"] == 0
+    assert summary["stage_counts"][social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE]["failed"] == 0
+    assert captured["params"] == [social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE, "run-1"]
+    sql_text = str(captured["sql"])
+    assert "superseded_by_comments_rebalance" in sql_text
+    assert "comments_retry_rebalance_source_job_id" in sql_text
+    assert "where not superseded_by_comments_rebalance" in sql_text
+
+
 def test_finalize_run_status_reuses_lock_connection_for_all_reads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -270,13 +310,70 @@ def test_finalize_run_status_reuses_lock_connection_for_all_reads(
     monkeypatch.setattr(run_lifecycle, "_set_run_status", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(run_lifecycle, "_maybe_start_deferred_comments_followup", lambda **_kwargs: None)
     monkeypatch.setattr(run_lifecycle.legacy, "_resolve_pipeline_ingest_mode", lambda value: value)
-    monkeypatch.setattr(run_lifecycle.legacy, "_shared_catalog_fetch_has_terminal_error", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(
+        run_lifecycle.legacy,
+        "_shared_catalog_fetch_has_terminal_error",
+        lambda *_args, **_kwargs: False,
+    )
     monkeypatch.setattr(run_lifecycle.legacy, "_column_exists", lambda *_args, **_kwargs: False)
 
     run_lifecycle._finalize_run_status("run-1")
 
     assert seen_fetch_conns == [lock_conn]
     assert seen_lock_pools == ["social_control"]
+
+
+def test_finalize_run_status_force_recomputes_before_failed_terminal_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lock_conn = object()
+    update_calls: list[bool] = []
+    statuses: list[str] = []
+
+    @contextmanager
+    def fake_advisory_lock(lock_key, *, label, pool_name="default"):
+        del lock_key, label, pool_name
+        yield lock_conn
+
+    def fake_fetch_one(sql: str, params=None, *, conn=None):
+        del params
+        assert conn is lock_conn
+        normalized = " ".join(sql.split()).lower()
+        if "select status, config from social.scrape_runs" in normalized:
+            return {"status": "running", "config": {"pipeline_ingest_mode": "manual"}}
+        if "select sync_session_id::text" in normalized:
+            return {"sync_session_id": None}
+        raise AssertionError(f"Unexpected query: {normalized}")
+
+    def fake_update_summary(_run_id: str, *, force_recompute: bool = False, conn=None):
+        assert conn is lock_conn
+        update_calls.append(force_recompute)
+        if not force_recompute:
+            return {"active_jobs": 0, "failed_jobs": 1, "stage_counts": {}}
+        return {"active_jobs": 0, "failed_jobs": 0, "stage_counts": {}}
+
+    monkeypatch.setattr(run_lifecycle.legacy.pg, "advisory_session_lock", fake_advisory_lock)
+    monkeypatch.setattr(run_lifecycle.legacy.pg, "fetch_one", fake_fetch_one)
+    monkeypatch.setattr(run_lifecycle, "_update_run_summary", fake_update_summary)
+    monkeypatch.setattr(
+        run_lifecycle,
+        "_run_job_status_breakdown",
+        lambda *_args, **_kwargs: {"running_jobs": 0, "queued_jobs": 0, "cancelling_jobs": 0},
+    )
+    monkeypatch.setattr(run_lifecycle, "_set_run_status", lambda _run_id, status, **_kwargs: statuses.append(status))
+    monkeypatch.setattr(run_lifecycle, "_maybe_start_deferred_comments_followup", lambda **_kwargs: None)
+    monkeypatch.setattr(run_lifecycle.legacy, "_resolve_pipeline_ingest_mode", lambda value: value)
+    monkeypatch.setattr(
+        run_lifecycle.legacy,
+        "_shared_catalog_fetch_has_terminal_error",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(run_lifecycle.legacy, "_column_exists", lambda *_args, **_kwargs: False)
+
+    run_lifecycle._finalize_run_status("run-1")
+
+    assert update_calls == [False, True]
+    assert statuses == ["completed"]
 
 
 def test_finalize_run_status_lock_contention_reads_from_social_control_pool(
@@ -303,3 +400,19 @@ def test_finalize_run_status_lock_contention_reads_from_social_control_pool(
 
     assert payload == {"status": "running"}
     assert seen_fetch_pools == ["social_control"]
+
+
+def test_finalize_run_status_defers_connection_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    @contextmanager
+    def fake_advisory_lock(lock_key, *, label, pool_name="default"):
+        del lock_key, label, pool_name
+        raise OperationalError("server closed the connection unexpectedly")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(run_lifecycle.legacy.pg, "advisory_session_lock", fake_advisory_lock)
+
+    payload = run_lifecycle._finalize_run_status("run-1")
+
+    assert payload["status"] == "finalize_deferred"
+    assert payload["finalize_deferred"] is True
+    assert "server closed the connection unexpectedly" in str(payload["error"])

--- a/tests/repositories/test_social_season_analytics.py
+++ b/tests/repositories/test_social_season_analytics.py
@@ -482,6 +482,15 @@ def test_get_social_account_profile_posts_instagram_comments_only_incomplete_fil
     assert captured["page_params"] == ["thetraitorsus", "thetraitorsus", "thetraitorsus", 25, 0]
 
 
+def test_instagram_reported_comments_sql_treats_canonical_zero_as_authoritative() -> None:
+    reported_comments = " ".join(social_repo._instagram_reported_comments_sql("p").split()).lower()
+
+    assert "coalesce(p.comments_count, greatest(" in reported_comments
+    assert "nullif(p.comments_count, 0)" not in reported_comments
+    assert "p.raw_data" in reported_comments
+    assert "greatest(coalesce(p.comments_count, 0)" not in reported_comments
+
+
 def test_get_social_account_profile_posts_instagram_comments_only_not_commentable_filter_uses_reported_zero(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5811,7 +5820,10 @@ def test_ingest_shared_accounts_modal_required_uses_authoritative_runtime_for_ru
 
     assert payload["run_id"] == "catalog-run-fast-2"
     assert captured_run_configs[0]["required_execution_backend"] == "modal"
-    assert captured_run_configs[0]["required_runtime_version"] == modal_runtime
+    assert captured_run_configs[0]["required_runtime_version"] == {
+        **modal_runtime,
+        "modal_function": "run_social_posts_job",
+    }
     assert captured_run_configs[0]["created_by_runtime_version"] == creator_runtime
     assert discovery_calls[0]["required_execution_backend"] == "modal"
 
@@ -6021,6 +6033,50 @@ def test_instagram_incomplete_comment_targets_reuse_comments_tab_filter(
     assert targets == ["C001", "C002", "C003"]
     assert [call["page"] for call in calls] == [1, 2]
     assert {call["comment_filter"] for call in calls} == {"incomplete"}
+
+
+def test_instagram_filter_incomplete_comment_targets_ignores_tolerable_stale_count_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_fetch_all(_sql: str, _params: list[Any]) -> list[dict[str, Any]]:
+        return [
+            {"shortcode": "COMPLETE", "post_missing": False, "reported_comments": 100, "saved_comments": 100},
+            {"shortcode": "SMALLGAP", "post_missing": False, "reported_comments": 100, "saved_comments": 99},
+            {"shortcode": "BIGGAP", "post_missing": False, "reported_comments": 100, "saved_comments": 80},
+            {"shortcode": "MISSING", "post_missing": True, "reported_comments": 0, "saved_comments": 0},
+        ]
+
+    monkeypatch.delenv("SOCIAL_INSTAGRAM_COMMENTS_RECONCILABLE_GAP_MAX", raising=False)
+    monkeypatch.delenv("SOCIAL_INSTAGRAM_COMMENTS_RECONCILABLE_GAP_RATIO", raising=False)
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+
+    targets = social_repo._instagram_filter_incomplete_comment_targets(
+        "thetraitorsus",
+        ["COMPLETE", "SMALLGAP", "BIGGAP", "MISSING"],
+    )
+
+    assert targets == ["BIGGAP", "MISSING"]
+
+
+def test_instagram_filter_incomplete_comment_targets_honors_prefilter_gap_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_fetch_all(_sql: str, _params: list[Any]) -> list[dict[str, Any]]:
+        return [
+            {"shortcode": "TERMINAL", "post_missing": False, "reported_comments": 1000, "saved_comments": 880},
+            {"shortcode": "BIGGAP", "post_missing": False, "reported_comments": 1000, "saved_comments": 700},
+        ]
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PREFILTER_GAP_MAX", "150")
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PREFILTER_GAP_RATIO", "0.10")
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+
+    targets = social_repo._instagram_filter_incomplete_comment_targets(
+        "thetraitorsus",
+        ["TERMINAL", "BIGGAP"],
+    )
+
+    assert targets == ["BIGGAP"]
 
 
 def test_preview_social_account_comments_scrape_incomplete_fill_targets_only_incomplete_posts(
@@ -6391,8 +6447,10 @@ def test_start_social_account_comments_scrape_shards_profile_targets(
     assert created_runs[0]["comments_shard_count"] == 4
     assert created_runs[0]["target_source_ids_count"] == 10
     assert created_runs[0]["comments_proxy_shard_sessions"] is False
+    assert created_runs[0]["comments_max_attempts"] == 12
     assert created_runs[0]["timing"]["target_source_ids_count"] == 10
     assert created_runs[0]["timing"]["target_enumeration_ms"] >= 0
+    assert {job["max_attempts"] for job in created_jobs} == {12}
     assert payload["timing"]["target_source_ids_count"] == 10
     assert dispatch_calls == [{"run_id": "comments-run-1"}]
 
@@ -7030,7 +7088,7 @@ def test_launch_social_account_catalog_backfill_instagram_defaults_selected_task
     assert catalog_calls[0]["details_refresh_skip_media_followups"] is False
     assert comments_calls == []
     assert merged_config_updates[-1]["selected_tasks"] == ["post_details", "comments", "media"]
-    assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
+    assert merged_config_updates[-1]["effective_selected_tasks"] == ["post_details", "comments", "media"]
     assert merged_config_updates[-1]["deferred_comments_followup"]["state"] == "pending"
     assert merged_config_updates[-1]["deferred_comments_followup"]["comments_enable_media_followups"] is True
     assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
@@ -7926,7 +7984,7 @@ def test_launch_social_account_catalog_backfill_instagram_skips_detail_hydration
     assert catalog_calls[0]["details_refresh_skip_media_followups"] is False
     assert comments_calls == []
     assert merged_config_updates[-1]["selected_tasks"] == ["post_details", "comments", "media"]
-    assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
+    assert merged_config_updates[-1]["effective_selected_tasks"] == ["post_details", "comments", "media"]
     assert merged_config_updates[-1]["deferred_comments_followup"]["state"] == "pending"
     assert merged_config_updates[-1]["deferred_comments_followup"]["comments_enable_media_followups"] is True
     assert merged_config_updates[-1]["attached_followups"] == {
@@ -8108,28 +8166,28 @@ def test_launch_social_account_catalog_backfill_reuses_active_comments_run_confl
     )
 
     assert payload["catalog_run_id"] == "catalog-run-1"
-    assert payload["comments_run_id"] == "comments-run-existing"
-    assert payload["comments_status"] == "running"
-    assert payload["comments_deferred_until_catalog_complete"] is False
+    assert payload["comments_run_id"] is None
+    assert payload["comments_status"] is None
+    assert payload["comments_deferred_until_catalog_complete"] is True
     assert payload["attached_followups"] == {
         "comments": {
-            "run_id": "comments-run-existing",
-            "state": "running",
-            "status": "running",
-            "source": "reused_run",
+            "run_id": None,
+            "state": "pending",
+            "status": "pending",
+            "source": "deferred_after_catalog",
         },
         "media": {
             "attachment_id": "media-launch-group-existing-comments",
             "state": "pending",
             "status": "queued",
             "source": "catalog_media_mirror",
-            "enqueued_job_ids": ["media-job-1", "media-job-2"],
-            "enqueued_job_count": 2,
+            "enqueued_job_ids": [],
+            "enqueued_job_count": 0,
         },
     }
     assert len(catalog_calls) == 1
-    assert merged_config_updates[-1]["comments_run_id"] == "comments-run-existing"
-    assert merged_config_updates[-1]["effective_selected_tasks"] == ["comments", "media"]
+    assert merged_config_updates[-1]["deferred_comments_followup"]["state"] == "pending"
+    assert merged_config_updates[-1]["effective_selected_tasks"] == ["post_details", "comments", "media"]
     assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
 
 
@@ -8178,26 +8236,26 @@ def test_launch_social_account_catalog_backfill_reused_comments_tolerates_media_
     )
 
     assert payload["catalog_run_id"] == "catalog-run-1"
-    assert payload["comments_run_id"] == "comments-run-existing"
-    assert payload["comments_status"] == "running"
-    assert payload["comments_deferred_until_catalog_complete"] is False
+    assert payload["comments_run_id"] is None
+    assert payload["comments_status"] is None
+    assert payload["comments_deferred_until_catalog_complete"] is True
     assert payload["attached_followups"] == {
         "comments": {
-            "run_id": "comments-run-existing",
-            "state": "running",
-            "status": "running",
-            "source": "reused_run",
+            "run_id": None,
+            "state": "pending",
+            "status": "pending",
+            "source": "deferred_after_catalog",
         },
         "media": {
             "attachment_id": "media-launch-group-existing-comments",
-            "state": "failed",
-            "status": "failed",
+            "state": "pending",
+            "status": "queued",
             "source": "catalog_media_mirror",
             "enqueued_job_ids": [],
             "enqueued_job_count": 0,
         },
     }
-    assert merged_config_updates[-1]["comments_run_id"] == "comments-run-existing"
+    assert merged_config_updates[-1]["deferred_comments_followup"]["state"] == "pending"
     assert merged_config_updates[-1]["attached_followups"] == payload["attached_followups"]
 
 
@@ -8398,8 +8456,10 @@ def test_launch_social_account_catalog_backfill_instagram_bootstraps_empty_accou
     merged_updates: list[dict[str, Any]] = []
     monkeypatch.setattr(
         social_repo,
-        "_merge_catalog_run_config_with_conn",
-        lambda **kwargs: merged_updates.append(kwargs["metadata_updates"]) or {"config": kwargs["metadata_updates"]},
+        "_merge_catalog_run_config",
+        lambda *, run_id, metadata_updates: (
+            merged_updates.append(metadata_updates) or {"id": run_id, "config": metadata_updates}
+        ),
     )
     monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
     monkeypatch.setattr(
@@ -11045,6 +11105,93 @@ def test_get_social_account_catalog_post_detail_instagram_preserves_saved_discus
     assert payload["total_comments_in_db"] == 1
 
 
+def test_get_social_account_catalog_post_detail_instagram_falls_back_to_post_id_comments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(social_repo, "_assert_social_account_profile_exists", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        social_repo,
+        "_fetch_shared_catalog_rows",
+        lambda *_args, **_kwargs: [
+            {
+                "id": "catalog-1",
+                "source_id": "ABC123",
+                "season_id": "stale-season",
+                "assignment_status": "assigned",
+                "posted_at": datetime(2026, 4, 1, tzinfo=UTC),
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: {
+            "id": "post-1",
+            "shortcode": "ABC123",
+            "season_id": "current-season",
+            "posted_at": datetime(2026, 4, 1, tzinfo=UTC),
+            "caption": "Recap caption",
+            "likes": 22,
+            "comments_count": 2,
+            "raw_data": {},
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "get_post_comments",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("Post not found")),
+    )
+
+    def _fake_fetch_all(sql: str, params: list[Any]) -> list[dict[str, Any]]:
+        normalized_sql = " ".join(sql.lower().split())
+        assert "from social.instagram_comments c" in normalized_sql
+        assert "where c.post_id = %s" in normalized_sql
+        assert params == ["post-1"]
+        return [
+            {
+                "id": "comment-1-row",
+                "comment_id": "comment-1",
+                "parent_comment_id": None,
+                "author": "viewer_a",
+                "text": "Top level",
+                "likes": 3,
+                "is_reply": False,
+                "reply_count": 1,
+                "media_urls": ["https://cdn.example/sticker.png"],
+                "hosted_media_urls": ["https://hosted.example/sticker.png"],
+                "media_mirror_status": "complete",
+                "created_at": datetime(2026, 4, 1, 12, 30, tzinfo=UTC),
+            },
+            {
+                "id": "comment-2-row",
+                "comment_id": "comment-2",
+                "parent_comment_id": "comment-1-row",
+                "author": "viewer_b",
+                "text": "Reply",
+                "likes": 1,
+                "is_reply": True,
+                "reply_count": 0,
+                "media_urls": [],
+                "hosted_media_urls": [],
+                "media_mirror_status": None,
+                "created_at": datetime(2026, 4, 1, 12, 31, tzinfo=UTC),
+            },
+        ]
+
+    monkeypatch.setattr(social_repo.pg, "fetch_all", _fake_fetch_all)
+
+    payload = social_repo.get_social_account_catalog_post_detail("instagram", "bravotv", source_id="ABC123")
+
+    assert payload["saved_comments"] == 2
+    assert payload["total_comments_in_db"] == 2
+    assert len(payload["discussion_items"]) == 2
+    assert payload["discussion_items"][0]["username"] == "viewer_b"
+    assert payload["discussion_items"][0]["is_reply"] is True
+    assert payload["discussion_items"][1]["username"] == "viewer_a"
+    assert payload["discussion_items"][1]["media_urls"] == ["https://cdn.example/sticker.png"]
+    assert payload["comments"][0]["replies"][0]["author"] == "viewer_b"
+
+
 def test_get_social_account_profile_comments_tiktok_uses_persisted_post_detail_for_modal_reads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -11529,6 +11676,62 @@ def test_instagram_social_account_comments_target_counts_returns_available_and_e
     assert "count(*)::int as available_posts" in captured["sql"]
     assert "as eligible_posts" in captured["sql"]
     assert "and greatest(0, coalesce(p.comments_count, 0)) > 0" not in captured["sql"]
+
+
+def test_instagram_comments_coverage_diagnostics_separates_saved_media_and_job_buckets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(social_repo, "_social_account_profile_owner_match_sql", lambda *_args, **_kwargs: "1 = 1")
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda *_args, **_kwargs: True)
+
+    def _fake_fetch_one(sql: str, params: list[Any] | None = None):  # noqa: ANN001
+        captured["sql"] = " ".join(sql.split()).lower()
+        captured["params"] = params
+        return {
+            "available_posts": 12,
+            "eligible_posts": 8,
+            "missing_posts": 2,
+            "stale_posts": 3,
+            "reported_comments": 120,
+            "saved_top_level_comments": 70,
+            "saved_reply_comments": 25,
+            "flattened_saved_comments": 95,
+            "saved_media_comments": 4,
+            "hidden_recovered_comments": 6,
+            "missing_marked_comments": 7,
+            "retryable_jobs": 2,
+            "retryable_targets": 11,
+            "terminal_unavailable_jobs": 1,
+            "terminal_unavailable_targets": 5,
+            "last_run_id": "run-1",
+            "last_run_job_id": "job-1",
+            "last_run_status": "failed",
+            "last_job_status": "failed",
+            "last_error_code": "modal_dispatch_blocked",
+            "last_error_message": "blocked",
+        }
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+
+    payload = social_repo.get_social_account_comments_coverage_diagnostics("instagram", "bravotv")
+
+    assert payload["reported_comments"] == 120
+    assert payload["saved_top_level_comments"] == 70
+    assert payload["saved_reply_comments"] == 25
+    assert payload["flattened_saved_comments"] == 95
+    assert payload["saved_media_comments"] == 4
+    assert payload["hidden_recovered_comments"] == 6
+    assert payload["missing_marked_comments"] == 7
+    assert payload["retryable"] == 11
+    assert payload["terminal_unavailable"] == 5
+    assert payload["last_run_metadata"]["last_error_code"] == "modal_dispatch_blocked"
+    assert "saved_top_level_comments" in captured["sql"]
+    assert "saved_reply_comments" in captured["sql"]
+    assert "saved_media_comments" in captured["sql"]
+    assert "hidden_recovered_comments" in captured["sql"]
+    assert captured["params"][0] == "bravotv"
 
 
 def test_shared_catalog_summary_totals_aliases_catalog_table(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -12812,7 +13015,10 @@ def test_social_account_profile_post_item_uses_instagram_raw_caption_fallback() 
         account_handle="thetraitorsus",
     )
 
-    assert payload["content"] == "Foreshadowing at its finest.\n\nAll episodes of #TheTraitorsUS are streaming on Peacock."
+    assert (
+        payload["content"]
+        == "Foreshadowing at its finest.\n\nAll episodes of #TheTraitorsUS are streaming on Peacock."
+    )
 
 
 def test_touch_shared_account_source_serializes_datetime_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -18915,6 +19121,124 @@ def test_upsert_instagram_comment_tree_respects_media_followup_flag(
     assert len(enqueued) == expected_enqueues
 
 
+def test_batch_upsert_instagram_comments_persists_media_and_reply_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.socials.instagram.scraper import InstagramComment
+
+    captured_batches: list[list[dict[str, Any]]] = []
+    enqueued: list[dict[str, Any]] = []
+
+    social_repo._instagram_comment_has_profile_pic = None
+    social_repo._instagram_comment_has_verified = None
+    social_repo._instagram_comment_has_media = None
+    social_repo._instagram_comment_has_hosted_media = None
+    social_repo._instagram_comment_has_media_mirror_status = None
+    social_repo._instagram_comment_has_media_mirror_error = None
+
+    reply = InstagramComment(
+        comment_id="reply-1",
+        text="reply image",
+        username="viewer_reply",
+        user_id="user-reply",
+        created_at=1_775_000_100,
+        date_time="2026-04-01 10:01:40",
+        likes=1,
+        is_reply=True,
+        parent_comment_id="comment-1",
+        reply_count=0,
+        reply_depth=1,
+        media_urls=["https://images.example/reply-sticker.gif"],
+        hosted_media_urls=["https://cdn.example/reply-sticker.gif"],
+    )
+    comment = InstagramComment(
+        comment_id="comment-1",
+        text="top level image",
+        username="viewer",
+        user_id="user-1",
+        created_at=1_775_000_000,
+        date_time="2026-04-01 10:00:00",
+        likes=3,
+        is_reply=False,
+        parent_comment_id=None,
+        reply_count=1,
+        media_urls=["https://images.example/top-gift.gif"],
+        hosted_media_urls=["https://cdn.example/top-gift.gif"],
+        replies=[reply],
+    )
+
+    def _fake_upsert_many(
+        _table: str,
+        batch: list[dict[str, Any]],
+        *,
+        conflict_col: list[str],
+        conn: object | None = None,
+    ) -> list[dict[str, Any]]:
+        captured_batches.append([dict(item) for item in batch])
+        return [
+            {"id": f"row-{item['comment_id']}", "comment_id": item["comment_id"], "post_id": item["post_id"]}
+            for item in batch
+        ]
+
+    monkeypatch.setattr(social_repo, "_pg_upsert_many", _fake_upsert_many)
+    monkeypatch.setattr(social_repo, "_comment_lifecycle_supported", lambda table: table == "instagram_comments")
+    monkeypatch.setattr(
+        social_repo,
+        "_column_exists",
+        lambda _schema, _table, column, **_kwargs: column
+        in {
+            "media_urls",
+            "hosted_media_urls",
+            "media_mirror_status",
+            "media_mirror_error",
+            "parent_comment_external_id",
+            "reply_depth",
+            "source_snapshot_type",
+        },
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_enqueue_platform_comment_media_mirror_job",
+        lambda _context, **kwargs: enqueued.append(dict(kwargs)) or f"mirror-{kwargs['comment_row']['comment_id']}",
+    )
+
+    context = SeasonContext(
+        season_id="season-1",
+        show_id="show-1",
+        show_name="Test Show",
+        season_number=6,
+        anchor_date=date(2025, 1, 1),
+    )
+    stats = social_repo._new_comment_persist_stats()
+
+    written = social_repo._batch_upsert_instagram_comments(
+        context,
+        job_id="job-1",
+        run_id="run-1",
+        account="bravotv",
+        post_id="post-1",
+        comments=[comment],
+        persist_stats=stats,
+    )
+
+    assert written == 2
+    assert captured_batches[0][0]["media_urls"] == ["https://images.example/top-gift.gif"]
+    assert captured_batches[0][0]["hosted_media_urls"] == ["https://cdn.example/top-gift.gif"]
+    assert captured_batches[0][0]["media_mirror_status"] == "pending"
+    assert captured_batches[0][0]["parent_comment_external_id"] is None
+    assert captured_batches[0][0]["reply_depth"] == 0
+    assert captured_batches[0][0]["source_snapshot_type"] == "full_comments_scrape"
+    assert captured_batches[1][0]["media_urls"] == ["https://images.example/reply-sticker.gif"]
+    assert captured_batches[1][0]["hosted_media_urls"] == ["https://cdn.example/reply-sticker.gif"]
+    assert captured_batches[1][0]["media_mirror_status"] == "pending"
+    assert captured_batches[1][0]["parent_comment_id"] == "row-comment-1"
+    assert captured_batches[1][0]["parent_comment_external_id"] == "comment-1"
+    assert captured_batches[1][0]["reply_depth"] == 1
+    assert captured_batches[1][0]["source_snapshot_type"] == "full_comments_scrape"
+    assert stats["comment_media_mirror_jobs_enqueued"] == 2
+    assert [call["comment_row"]["comment_id"] for call in enqueued] == ["comment-1", "reply-1"]
+
+
 def test_upsert_tiktok_comment_tree_without_run_id_preserves_last_seen_run(monkeypatch) -> None:
     captured_payload: dict[str, object] = {}
 
@@ -19825,7 +20149,173 @@ def test_recover_stale_running_jobs_updates_worker_state_and_run_summaries(monke
     assert "worker_id = null" in sql_text
     assert "comments_retry_rebalance" in sql_text
     assert "remaining_target_source_ids" in sql_text
+    assert "activity,posts_checked" in sql_text
+    assert "incomplete_target_source_ids" in sql_text
+    assert "activity,incomplete_target_source_ids" in sql_text
+    assert "auth_failed_target_source_ids" in sql_text
+    assert "activity,auth_failed_target_source_ids" in sql_text
+    assert "post_auth_failures,target_source_ids" in sql_text
+    assert "target.value #>> '{}'" in sql_text
+    assert "jsonb_array_elements(j.config->'target_source_ids')" in sql_text
+    assert sql_text.index("when jsonb_typeof(j.config->'target_source_ids')") < sql_text.index(
+        "retry_rebalance,remaining_target_source_ids"
+    )
     assert social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE in params
+
+
+def test_set_job_running_clears_stale_error_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_sql: dict[str, object] = {}
+
+    def _fake_fetch_one(sql: str, params: list[object]):
+        captured_sql["sql"] = sql
+        captured_sql["params"] = list(params)
+        return {"id": "job-1"}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+
+    social_repo._set_job_running("job-1", worker_id="worker-1")
+
+    sql_text = str(captured_sql.get("sql") or "")
+    assert "error_message = null" in sql_text
+    assert "last_error_code = null" in sql_text
+    assert "last_error_class = null" in sql_text
+    assert captured_sql["params"] == ["worker-1", "job-1"]
+
+
+def test_touch_job_heartbeat_refuses_requeued_job_after_lease_loss(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_sql: dict[str, object] = {}
+    worker_touches: list[dict[str, object]] = []
+
+    def _fake_fetch_one(sql: str, params: list[object]):
+        captured_sql["sql"] = sql
+        captured_sql["params"] = list(params)
+        return None
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(
+        social_repo,
+        "_touch_worker_heartbeat_for_job",
+        lambda **kwargs: worker_touches.append(kwargs),
+    )
+
+    touched = social_repo._touch_job_heartbeat("job-1", worker_id="worker-1")
+
+    sql_text = " ".join(str(captured_sql.get("sql") or "").split()).lower()
+    assert touched is False
+    assert "status = 'running'" in sql_text
+    assert "claimed_at is not null" in sql_text
+    assert "status in ('queued', 'pending', 'retrying'" not in sql_text
+    assert captured_sql["params"] == ["worker-1", "job-1", "worker-1", "worker-1", "worker-1"]
+    assert worker_touches == []
+
+
+def test_update_job_progress_requires_running_claimed_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_sql: dict[str, object] = {}
+    worker_touches: list[dict[str, object]] = []
+
+    def _fake_fetch_one(sql: str, params: list[object]):
+        captured_sql["sql"] = sql
+        captured_sql["params"] = list(params)
+        return None
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(
+        social_repo,
+        "_touch_worker_heartbeat_for_job",
+        lambda **kwargs: worker_touches.append(kwargs),
+    )
+
+    updated = social_repo._update_job_progress(
+        "job-1",
+        items_found=10,
+        metadata={"activity": {"phase": "running"}},
+        worker_id="worker-1",
+    )
+
+    sql_text = " ".join(str(captured_sql.get("sql") or "").split()).lower()
+    assert updated is False
+    assert "status = 'running'" in sql_text
+    assert "claimed_at is not null" in sql_text
+    assert "status in ('queued', 'pending', 'retrying'" not in sql_text
+    assert captured_sql["params"][2:] == ["job-1", "worker-1", "worker-1", "worker-1"]
+    assert worker_touches == []
+
+
+def test_instagram_comments_scrapling_uses_longer_stale_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_JOB_STALE_SECONDS", "300")
+    monkeypatch.delenv("SOCIAL_JOB_STALE_SECONDS_INSTAGRAM_COMMENTS_SCRAPLING", raising=False)
+
+    assert (
+        social_repo._resolve_social_job_stale_seconds(
+            stage=social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+            platform="instagram",
+        )
+        == 1800
+    )
+
+    expr, params = social_repo._build_social_job_stale_seconds_sql_expr(
+        table_alias="j",
+        has_queue_fields=True,
+    )
+    assert social_repo.INSTAGRAM_COMMENTS_SCRAPLING_STAGE in expr
+    assert params[2:] == [1800, 300]
+
+
+def test_claim_job_by_id_clears_stale_error_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_sql: dict[str, object] = {}
+
+    def _fake_fetch_one(sql: str, params: list[object]):
+        captured_sql["sql"] = sql
+        captured_sql["params"] = list(params)
+        return {"id": "job-1"}
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+
+    row = social_repo._claim_job_by_id(job_id="job-1", worker_id="worker-1")
+
+    assert row == {"id": "job-1"}
+    sql_text = str(captured_sql.get("sql") or "")
+    assert "error_message = null" in sql_text
+    assert "last_error_code = null" in sql_text
+    assert "last_error_class = null" in sql_text
+    assert captured_sql["params"] == ["worker-1", "job-1"]
+
+
+def test_finish_job_expected_worker_skips_stale_terminal_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_sql: dict[str, object] = {}
+    side_effects: list[str] = []
+
+    def _fake_fetch_one(sql: str, params: list[object]):
+        captured_sql["sql"] = sql
+        captured_sql["params"] = list(params)
+        return None
+
+    monkeypatch.setattr(social_repo.pg, "fetch_one", _fake_fetch_one)
+    monkeypatch.setattr(
+        social_repo,
+        "_clear_worker_heartbeat_for_job",
+        lambda **_kwargs: side_effects.append("clear_worker"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_update_shared_account_partition_status_for_job",
+        lambda **_kwargs: side_effects.append("partition"),
+    )
+    monkeypatch.setattr(social_repo, "_invalidate_queue_status_cache", lambda: side_effects.append("cache"))
+
+    social_repo._finish_job(
+        "job-1",
+        status="completed",
+        items_found=10,
+        expected_worker_id="worker-1",
+    )
+
+    sql_text = " ".join(str(captured_sql.get("sql") or "").split()).lower()
+    assert "prior.prior_status = 'running'" in sql_text
+    assert "social.scrape_jobs.claimed_at is not null" in sql_text
+    assert "social.scrape_jobs.worker_id = %s::text" in sql_text
+    assert captured_sql["params"][-3:] == ["worker-1", "worker-1", "worker-1"]
+    assert side_effects == []
 
 
 def test_recover_stale_running_jobs_uses_exponential_power_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -19981,7 +20471,8 @@ def test_finish_job_retrying_releases_claim_ownership(monkeypatch: pytest.Monkey
     params = list(update_calls[0][1] or [])
     assert "worker_id = case when %s = 'retrying' then null else worker_id end" in sql_text
     assert "claimed_at = case when %s = 'retrying' then null else claimed_at end" in sql_text
-    assert params[-2:] == ["retrying", "retrying"]
+    assert params[-5:-3] == ["retrying", "retrying"]
+    assert params[-3:] == [None, None, None]
     assert increments
     assert increments[0]["new_status"] == "retrying"
     assert cleared == []
@@ -20069,6 +20560,9 @@ def test_claim_next_jobs_uses_batch_limit_and_run_fairness(monkeypatch: pytest.M
     assert "run_in_flight" in sql_text
     assert "row_number() over" in sql_text
     assert "coalesce(rif.in_flight, 0) < %s" in sql_text
+    assert "error_message = null" in sql_text
+    assert "last_error_code = null" in sql_text
+    assert "last_error_class = null" in sql_text
     assert params[-3] == 4  # run in-flight cap
     assert params[-2] == 25  # capped batch limit
     assert params[-1] == "worker-1"
@@ -20099,7 +20593,7 @@ def test_claim_next_queued_jobs_treats_empty_platform_filter_as_none(
     assert captured["limit"] == 2  # default batch size
 
 
-def test_execute_run_comments_stage_claims_posts_when_comments_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_execute_run_comments_stage_does_not_claim_posts_when_comments_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     claim_calls: list[tuple[str | None, int]] = []
     executed_job_ids: list[str] = []
 
@@ -20162,8 +20656,8 @@ def test_execute_run_comments_stage_claims_posts_when_comments_empty(monkeypatch
 
     result = social_repo.execute_run("run-1", worker_id="worker-1", stage="comments", platform=None)
 
-    assert executed_job_ids == ["job-post-1"]
-    assert claim_calls[:2] == [("comments", 2), ("posts", 1)]
+    assert executed_job_ids == []
+    assert claim_calls == [("comments", 2)]
     assert result["id"] == "run-1"
 
 
@@ -29070,6 +29564,7 @@ def test_rebalance_failed_instagram_comments_shard_creates_smaller_retry_jobs(
     assert payload["retry_group_id"] == "retry-group-1"
     assert [job["config"]["target_source_ids"] for job in created_jobs] == [["A", "B"], ["C", "D"], ["E"]]
     assert {job["priority"] for job in created_jobs} == {110}
+    assert {job["max_attempts"] for job in created_jobs} == {12}
 
 
 def test_rebalance_failed_instagram_comments_shard_falls_back_to_job_targets(
@@ -29109,6 +29604,7 @@ def test_rebalance_failed_instagram_comments_shard_falls_back_to_job_targets(
 
     assert payload["created_job_ids"] == ["retry-1", "retry-2"]
     assert [job["config"]["target_source_ids"] for job in created_jobs] == [["A", "B"], ["C"]]
+    assert {job["max_attempts"] for job in created_jobs} == {12}
 
 
 def test_repair_instagram_comments_scrape_run_target_gaps_creates_missing_target_jobs(
@@ -29172,6 +29668,7 @@ def test_repair_instagram_comments_scrape_run_target_gaps_creates_missing_target
     assert [job["config"]["target_source_ids"] for job in created_jobs] == [["D"], ["E"]]
     assert [job["config"]["comments_shard_index"] for job in created_jobs] == [5, 6]
     assert {job["config"]["comments_shard_count"] for job in created_jobs} == {6}
+    assert {job["max_attempts"] for job in created_jobs} == {12}
     assert dispatch_calls == [{"run_id": run_id}]
 
 
@@ -29233,6 +29730,7 @@ def test_repair_instagram_comments_scrape_run_target_gaps_retries_finished_stale
     assert payload["created_job_ids"] == ["repair-1"]
     assert payload["missing_target_source_ids_count"] == 2
     assert created_jobs[0]["config"]["target_source_ids"] == ["A", "C"]
+    assert created_jobs[0]["max_attempts"] == 12
     assert payload["assigned_target_source_ids_count"] == 1
 
 
@@ -30854,8 +31352,10 @@ def test_instagram_backfill_with_media_and_comments_materializes_posts_before_fo
     )
     monkeypatch.setattr(
         social_repo,
-        "_merge_catalog_run_config_with_conn",
-        lambda **kwargs: run_config_state.update(kwargs["metadata_updates"]) or {"config": dict(run_config_state)},
+        "_merge_catalog_run_config",
+        lambda *, run_id, metadata_updates: (
+            run_config_state.update(metadata_updates) or {"id": run_id, "config": dict(run_config_state)}
+        ),
     )
     monkeypatch.setattr(social_repo.pg, "db_connection", lambda **_kwargs: nullcontext(object()))
 
@@ -32455,9 +32955,15 @@ def test_create_job_modal_runtime_metadata_uses_authoritative_runtime_and_preser
     assert job_id == "job-1"
     inserted_config = json.loads(captured_params[3])
     inserted_metadata = json.loads(captured_params[11])
-    assert inserted_config["required_runtime_version"] == modal_runtime
+    assert inserted_config["required_runtime_version"] == {
+        **modal_runtime,
+        "modal_function": "run_social_posts_job",
+    }
     assert inserted_config["created_by_runtime_version"] == creator_runtime
-    assert inserted_metadata["runtime_version"] == modal_runtime
+    assert inserted_metadata["runtime_version"] == {
+        **modal_runtime,
+        "modal_function": "run_social_posts_job",
+    }
     assert inserted_metadata["created_by_runtime_version"] == creator_runtime
 
 

--- a/tests/scripts/test_benchmark_instagram_comments_shards.py
+++ b/tests/scripts/test_benchmark_instagram_comments_shards.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import scripts.socials.instagram.benchmark_comments_shards as cli
+
+
+def test_fixture_tiny_profile_reports_required_metrics() -> None:
+    args = cli._parse_args(["--fixture-profile", "tiny"])
+
+    rc, payload = cli.run_benchmark(args)
+
+    assert rc == 0
+    assert payload["status"] == "ok"
+    assert payload["mode"] == "fixture"
+    assert payload["fixture_profile"] == "tiny"
+    assert payload["safety"]["fixture_mode_default"] is True
+    assert payload["safety"]["launched_scrape"] is False
+    assert payload["totals"]["posts_processed"] == 3
+    assert payload["totals"]["top_level_comments"] == 34
+    assert payload["totals"]["replies"] == 17
+    assert payload["totals"]["flattened_saved"] == 54
+    assert payload["totals"]["media_comments"] == 2
+    assert payload["totals"]["hidden_reveal_attempts"] == 1
+    assert payload["timing"]["per_post_p95_ms"] >= payload["timing"]["per_post_median_ms"]
+    assert payload["transport"]["session_count"] == 3
+
+
+def test_live_mode_refuses_without_explicit_flags() -> None:
+    args = cli._parse_args(["--live", "--account", "thetraitorsus"])
+
+    rc, payload = cli.run_benchmark(args)
+
+    assert rc == 2
+    assert payload["status"] == "refused"
+    assert payload["error"] == "live_mode_requires_explicit_flags"
+    assert "--confirm-live" in payload["missing_flags"]
+    assert "--active-job-preflight" in payload["missing_flags"]
+    assert payload["safety"]["launched_scrape"] is False
+
+
+def test_live_mode_blocks_when_active_jobs_exist(monkeypatch) -> None:
+    args = cli._parse_args(
+        [
+            "--live",
+            "--account",
+            "@thetraitorsus",
+            "--confirm-live",
+            "--active-job-preflight",
+        ]
+    )
+    monkeypatch.setattr(
+        cli,
+        "_active_live_comments_jobs",
+        lambda _account: {"active_comment_jobs": 2, "active_run_ids": ["run-1"]},
+    )
+    monkeypatch.setattr(cli, "_summarize_live_rows", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError))
+
+    rc, payload = cli.run_benchmark(args)
+
+    assert rc == 2
+    assert payload["status"] == "blocked_active_jobs"
+    assert payload["account"] == "thetraitorsus"
+    assert payload["active_job_preflight"] == {"active_comment_jobs": 2, "active_run_ids": ["run-1"]}
+    assert payload["safety"]["launched_scrape"] is False
+
+
+def test_live_summary_reads_runner_metadata_shape(monkeypatch) -> None:
+    class _FakePg:
+        @staticmethod
+        def fetch_all(_sql, _params):  # noqa: ANN001
+            return [
+                {
+                    "job_id": "job-1",
+                    "status": "completed",
+                    "items_found": 16,
+                    "last_error_code": None,
+                    "metadata": {
+                        "stage_counters": {"posts": 2, "comments": 14},
+                        "persist_counters": {"comments_upserted": 10},
+                        "post_latency": {
+                            "samples": [
+                                {"top_level_comment_count": 6, "observed_comment_count": 8},
+                                {"top_level_comment_count": 4, "observed_comment_count": 6},
+                            ]
+                        },
+                        "fetcher_runtime": {
+                            "hidden_comments": {"render_attempts": 1, "merged_comments": 3},
+                            "retry_reason_counts": {"http_429": 2},
+                        },
+                    },
+                }
+            ]
+
+    monkeypatch.setattr(cli, "_load_db_helpers", lambda: (_FakePg, lambda: None))
+
+    payload = cli._summarize_live_rows("thetraitorsus", limit_posts=5)
+
+    assert payload["totals"]["top_level_comments"] == 10
+    assert payload["totals"]["replies"] == 4
+    assert payload["totals"]["flattened_saved"] == 14
+    assert payload["totals"]["hidden_reveal_attempts"] == 1
+    assert payload["totals"]["hidden_comments_merged"] == 3
+    assert payload["totals"]["transport_retries"] == 2

--- a/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -7,14 +7,32 @@ import scripts.socials.retire_duplicate_instagram_comment_media_mirror_jobs as m
 
 
 def _base_args(**overrides):
-    values = {"season_id": [], "show_id": [], "dry_run": False, "apply": False}
+    values = {
+        "season_id": [],
+        "show_id": [],
+        "account": [],
+        "dry_run": False,
+        "apply": False,
+        "confirm_destructive": False,
+        "confirm_account": None,
+    }
     values.update(overrides)
     return SimpleNamespace(**values)
 
 
 def test_main_apply_retires_duplicate_comment_media_rows(monkeypatch, capsys) -> None:
     monkeypatch.setattr(mod, "load_env", lambda: None)
-    monkeypatch.setattr(mod, "_parse_args", lambda _argv: _base_args(apply=True, show_id=["show-1"]))
+    monkeypatch.setattr(
+        mod,
+        "_parse_args",
+        lambda _argv: _base_args(
+            apply=True,
+            show_id=["show-1"],
+            account=["@thetraitorsus"],
+            confirm_destructive=True,
+            confirm_account="thetraitorsus",
+        ),
+    )
     monkeypatch.setattr(
         mod,
         "_fetch_matches",
@@ -28,12 +46,31 @@ def test_main_apply_retires_duplicate_comment_media_rows(monkeypatch, capsys) ->
     )
 
     assert mod.main([]) == 0
-    assert retire_calls == [{"season_ids": [], "show_ids": ["show-1"]}]
+    assert retire_calls == [{"season_ids": [], "show_ids": ["show-1"], "accounts": ["thetraitorsus"]}]
 
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["dry_run"] is False
+    assert payload["accounts"] == ["thetraitorsus"]
     assert payload["show_ids"] == ["show-1"]
     assert payload["totals"] == {"matched_rows": 1, "retired_rows": 1}
+
+
+def test_main_apply_refuses_without_destructive_confirmation(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(mod, "load_env", lambda: None)
+    monkeypatch.setattr(
+        mod,
+        "_parse_args",
+        lambda _argv: _base_args(apply=True, account=["thetraitorsus"], confirm_account="thetraitorsus"),
+    )
+    monkeypatch.setattr(mod, "_fetch_matches", lambda **_kwargs: (_ for _ in ()).throw(AssertionError("queried")))
+
+    assert mod.main([]) == 2
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["status"] == "refused"
+    assert payload["dry_run"] is True
+    assert payload["accounts"] == ["thetraitorsus"]
+    assert "missing --confirm-destructive" in payload["refusal_reasons"]
 
 
 def test_retire_matches_marks_duplicate_comment_media_jobs_cancelled(monkeypatch) -> None:
@@ -49,7 +86,7 @@ def test_retire_matches_marks_duplicate_comment_media_jobs_cancelled(monkeypatch
         lambda query, params=None: calls.append({"query": query, "params": list(params or [])}) or [{"id": "job-1"}],
     )
 
-    rows = mod._retire_matches(season_ids=["season-1"], show_ids=[])
+    rows = mod._retire_matches(season_ids=["season-1"], show_ids=[], accounts=["thetraitorsus"])
 
     assert rows == [{"id": "job-1"}]
     assert len(calls) == 1
@@ -60,3 +97,4 @@ def test_retire_matches_marks_duplicate_comment_media_jobs_cancelled(monkeypatch
     assert json.loads(calls[0]["params"][3]) == {"duplicate_active_comment_media_mirror_job": True}
     assert calls[0]["params"][4] == ["job-1"]
     assert "concat(config->>'post_id', ':', config->>'comment_id')" in mod.IDENTITY_SQL
+    assert "owner_username" in mod.ACCOUNT_SQL

--- a/tests/socials/instagram/comments_scrapling/test_job_attempt_state.py
+++ b/tests/socials/instagram/comments_scrapling/test_job_attempt_state.py
@@ -1,0 +1,37 @@
+"""Phase 1.3 / 1.4 regression tests for ``_job_attempt_state`` and the
+incomplete-run raise threshold."""
+
+from __future__ import annotations
+
+from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+
+def test_job_attempt_state_floors_attempt_and_max_attempts_to_at_least_one():
+    """Both inputs default to 1 when missing; max_attempts is then forced to 2
+    so can_retry doesn't short-circuit on the first transient failure."""
+    attempt_count, max_attempts = jr._job_attempt_state({})
+    assert attempt_count == 1
+    assert max_attempts >= attempt_count + 1
+
+
+def test_job_attempt_state_enforces_max_attempts_above_attempt_count():
+    """Phase 1.3 / audit: even when the row carries equal attempt_count and
+    max_attempts (e.g. legacy enqueue without explicit max_attempts), the
+    runner must allow at least one more retry before terminal failure."""
+    attempt_count, max_attempts = jr._job_attempt_state({"attempt_count": 1, "max_attempts": 1})
+    assert attempt_count == 1
+    assert max_attempts == 2  # 1 + 1
+
+
+def test_job_attempt_state_preserves_explicit_max_when_above_threshold():
+    """Explicit higher max_attempts wins over the +1 floor."""
+    attempt_count, max_attempts = jr._job_attempt_state({"attempt_count": 2, "max_attempts": 12})
+    assert attempt_count == 2
+    assert max_attempts == 12
+
+
+def test_job_attempt_state_caps_attempt_count_at_one_when_invalid():
+    """Garbage values fall back to the queue defaults; the +1 floor still applies."""
+    attempt_count, max_attempts = jr._job_attempt_state({"attempt_count": "garbage", "max_attempts": None})
+    assert attempt_count == 1
+    assert max_attempts >= attempt_count + 1

--- a/tests/socials/instagram/comments_scrapling/test_persistence.py
+++ b/tests/socials/instagram/comments_scrapling/test_persistence.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trr_backend.socials.instagram.comments_scrapling import persistence
+from trr_backend.socials.instagram.scraper import InstagramComment
+
+
+def _comment(
+    comment_id: str,
+    *,
+    is_reply: bool = False,
+    parent_comment_id: str | None = None,
+    media_urls: list[str] | None = None,
+    hosted_media_urls: list[str] | None = None,
+    replies: list[InstagramComment] | None = None,
+) -> InstagramComment:
+    return InstagramComment(
+        comment_id=comment_id,
+        text=f"text {comment_id}",
+        username=f"user_{comment_id}",
+        user_id=f"user-id-{comment_id}",
+        created_at=1_775_000_000,
+        date_time="2026-04-01 10:00:00",
+        likes=1,
+        is_reply=is_reply,
+        parent_comment_id=parent_comment_id,
+        reply_count=len(replies or []),
+        reply_depth=1 if is_reply else 0,
+        media_urls=list(media_urls or []),
+        hosted_media_urls=list(hosted_media_urls or []),
+        replies=list(replies or []),
+    )
+
+
+def test_no_season_persistence_preserves_media_and_reply_metadata() -> None:
+    captured_batches: list[list[dict[str, Any]]] = []
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+
+    def _flatten(comment: InstagramComment, parent_external_id: str | None = None):
+        result = [(comment, parent_external_id)]
+        external_id = str(comment.comment_id or "").strip()
+        for reply in comment.replies:
+            result.extend(_flatten(reply, external_id or parent_external_id))
+        return result
+
+    def _fake_upsert_many(
+        _table: str,
+        batch: list[dict[str, Any]],
+        *,
+        conflict_col: list[str],
+        conn: object | None = None,
+    ) -> list[dict[str, Any]]:
+        captured_batches.append([dict(item) for item in batch])
+        return [
+            {"id": f"row-{item['comment_id']}", "comment_id": item["comment_id"], "post_id": item["post_id"]}
+            for item in batch
+        ]
+
+    fake_repo = SimpleNamespace(
+        _column_exists=lambda _schema, _table, column: column
+        in {
+            "media_urls",
+            "hosted_media_urls",
+            "media_mirror_status",
+            "media_mirror_error",
+            "parent_comment_external_id",
+            "reply_depth",
+            "source_snapshot_type",
+        },
+        _comment_lifecycle_supported=lambda table: table == "instagram_comments",
+        _flatten_instagram_comment_tree=_flatten,
+        _new_comment_persist_stats=lambda: {},
+        _now_utc=lambda: now,
+        _parse_instagram_time=lambda value: datetime.fromtimestamp(int(value), tz=UTC),
+        _apply_instagram_comment_queryable_columns=lambda payload, _comment, **kwargs: payload.update(
+            {
+                "parent_comment_external_id": kwargs["parent_external_id"],
+                "reply_depth": kwargs["reply_depth"],
+                "source_snapshot_type": kwargs.get("source_snapshot_type", "full_comments_scrape"),
+            }
+        ),
+        _pg_upsert_many=_fake_upsert_many,
+    )
+    reply = _comment(
+        "reply-1",
+        is_reply=True,
+        parent_comment_id="comment-1",
+        media_urls=["https://images.example/reply-sticker.gif"],
+        hosted_media_urls=["https://cdn.example/reply-sticker.gif"],
+    )
+    comment = _comment(
+        "comment-1",
+        media_urls=["https://images.example/comment-gift.gif"],
+        hosted_media_urls=["https://cdn.example/comment-gift.gif"],
+        replies=[reply],
+    )
+    stats: dict[str, int] = {}
+
+    written = persistence._persist_without_season_context(
+        repo=fake_repo,
+        post_id="post-1",
+        account_handle="bravotv",
+        comments=[comment],
+        run_id="run-1",
+        job_id="job-1",
+        observed_comment_ids=set(),
+        persist_stats=stats,
+        enable_media_followups=True,
+        conn=object(),
+    )
+
+    assert written == 2
+    assert captured_batches[0][0]["media_urls"] == ["https://images.example/comment-gift.gif"]
+    assert captured_batches[0][0]["hosted_media_urls"] == ["https://cdn.example/comment-gift.gif"]
+    assert captured_batches[0][0]["media_mirror_status"] == "deferred"
+    assert captured_batches[0][0]["media_mirror_error"] == "season_context_missing"
+    assert captured_batches[0][0]["source_snapshot_type"] == "full_comments_scrape"
+    assert captured_batches[1][0]["media_urls"] == ["https://images.example/reply-sticker.gif"]
+    assert captured_batches[1][0]["hosted_media_urls"] == ["https://cdn.example/reply-sticker.gif"]
+    assert captured_batches[1][0]["media_mirror_status"] == "deferred"
+    assert captured_batches[1][0]["media_mirror_error"] == "season_context_missing"
+    assert captured_batches[1][0]["parent_comment_id"] == "row-comment-1"
+    assert captured_batches[1][0]["parent_comment_external_id"] == "comment-1"
+    assert captured_batches[1][0]["reply_depth"] == 1
+    assert captured_batches[1][0]["source_snapshot_type"] == "full_comments_scrape"
+
+
+def test_partial_persistence_does_not_mark_missing_or_reconcile(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_repo = SimpleNamespace(
+        _new_comment_persist_stats=lambda: {},
+        _mark_missing_comments_for_anchor=lambda **_kwargs: pytest.fail("partial scrape marked comments missing"),
+        _reconcile_post_comment_count=lambda **_kwargs: pytest.fail("partial scrape reconciled comment count"),
+        _count_stored_comments=lambda _post_ids, _platform, **_kwargs: {"post-1": 4},
+    )
+
+    monkeypatch.setattr(persistence, "_load_repo_helpers", lambda: fake_repo)
+    monkeypatch.setattr(
+        persistence,
+        "_materialize_instagram_post_for_comments",
+        lambda **_kwargs: {"id": "post-1", "season_id": None},
+    )
+    monkeypatch.setattr(persistence, "_persist_without_season_context", lambda **_kwargs: 0)
+
+    result = persistence.persist_instagram_comments_for_post(
+        account_handle="bravotv",
+        shortcode="ABC123",
+        comments=[],
+        run_id="run-1",
+        job_id="job-1",
+        is_complete="false",  # type: ignore[arg-type]
+        conn=object(),
+    )
+
+    assert result.comments_marked_missing == 0
+    assert result.stored_total_comments == 4

--- a/tests/socials/instagram/comments_scrapling/test_proxy.py
+++ b/tests/socials/instagram/comments_scrapling/test_proxy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from trr_backend.socials.instagram.comments_scrapling import proxy as comments_proxy
+
+
+def test_explicit_proxy_urls_default_to_first_without_session_key(monkeypatch):
+    monkeypatch.setattr(comments_proxy, "_build_proxy_rotator", lambda selected: {"selected": selected})
+    monkeypatch.setenv(
+        "SOCIAL_INSTAGRAM_COMMENTS_PROXY_URLS",
+        "http://user-one:secret-one@proxy-one.test:8000,http://user-two:secret-two@proxy-two.test:9000",
+    )
+
+    config = comments_proxy.select_comments_proxy()
+
+    assert config is not None
+    assert config.browser_proxy == "http://user-one:secret-one@proxy-one.test:8000"
+    assert config.api_proxy_url == "http://user-one:secret-one@proxy-one.test:8000"
+    assert config.fingerprint == "proxy-one.test:8000:explicit"
+    assert config.session_mode == "explicit"
+
+
+def test_explicit_proxy_urls_shard_deterministically_by_session_key(monkeypatch):
+    monkeypatch.setattr(comments_proxy, "_build_proxy_rotator", lambda selected: {"selected": selected})
+    monkeypatch.setenv(
+        "SOCIAL_INSTAGRAM_COMMENTS_PROXY_URLS",
+        ",".join(
+            [
+                "http://user-one:secret-one@proxy-one.test:8000",
+                "http://user-two:secret-two@proxy-two.test:9000",
+                "http://user-three:secret-three@proxy-three.test:7000",
+            ]
+        ),
+    )
+
+    first = comments_proxy.select_comments_proxy(session_key="thetraitorsus:comments:1")
+    repeated = comments_proxy.select_comments_proxy(session_key="thetraitorsus:comments:1")
+    shard_values = {
+        comments_proxy.select_comments_proxy(session_key=f"thetraitorsus:comments:{index}").browser_proxy
+        for index in range(1, 12)
+    }
+
+    assert first is not None
+    assert repeated is not None
+    assert first.browser_proxy == repeated.browser_proxy
+    assert first.session_mode == "explicit_sharded"
+    assert len(shard_values) > 1
+
+
+def test_explicit_proxy_fingerprint_never_exposes_credentials(monkeypatch):
+    monkeypatch.setattr(comments_proxy, "_build_proxy_rotator", lambda selected: {"selected": selected})
+    monkeypatch.setenv(
+        "SOCIAL_INSTAGRAM_COMMENTS_PROXY_URLS",
+        "http://sensitive-user:sensitive-password@proxy-one.test:8000",
+    )
+
+    config = comments_proxy.select_comments_proxy(session_key="bravotv")
+
+    assert config is not None
+    assert config.fingerprint == "proxy-one.test:8000:explicit"
+    assert "sensitive-user" not in config.fingerprint
+    assert "sensitive-password" not in config.fingerprint

--- a/tests/socials/instagram/comments_scrapling/test_proxy.py
+++ b/tests/socials/instagram/comments_scrapling/test_proxy.py
@@ -59,3 +59,60 @@ def test_explicit_proxy_fingerprint_never_exposes_credentials(monkeypatch):
     assert config.fingerprint == "proxy-one.test:8000:explicit"
     assert "sensitive-user" not in config.fingerprint
     assert "sensitive-password" not in config.fingerprint
+
+
+def test_explicit_proxy_rotator_receives_full_list_when_multiple_urls(monkeypatch):
+    """Phase 5.1 / audit: ProxyRotator should see every configured URL so
+    Scrapling can rotate IPs during warmup. ``browser_proxy`` /
+    ``api_proxy_url`` stay pinned to the deterministic per-shard selection so
+    api-side requests keep a stable session.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(values):
+        captured["values"] = values
+        return {"rotator_built_with": values}
+
+    monkeypatch.setattr(comments_proxy, "_build_proxy_rotator", _capture)
+    monkeypatch.setenv(
+        "SOCIAL_INSTAGRAM_COMMENTS_PROXY_URLS",
+        ",".join(
+            [
+                "http://user-one:secret-one@proxy-one.test:8000",
+                "http://user-two:secret-two@proxy-two.test:9000",
+                "http://user-three:secret-three@proxy-three.test:7000",
+            ]
+        ),
+    )
+
+    config = comments_proxy.select_comments_proxy(session_key="thetraitorsus:comments:1")
+
+    assert config is not None
+    # Rotator received the full list, not a single string.
+    assert isinstance(captured["values"], list)
+    assert len(captured["values"]) == 3
+    assert "http://user-one:secret-one@proxy-one.test:8000" in captured["values"]
+    assert "http://user-three:secret-three@proxy-three.test:7000" in captured["values"]
+    # The persisted browser_proxy / api_proxy_url stay deterministic single URLs.
+    assert config.browser_proxy in captured["values"]
+    assert config.api_proxy_url == config.browser_proxy
+
+
+def test_explicit_proxy_rotator_passes_single_url_when_only_one_configured(monkeypatch):
+    """Phase 5.1 edge: a single configured URL must NOT be wrapped as a list."""
+    captured: dict[str, object] = {}
+
+    def _capture(value):
+        captured["value"] = value
+        return {"rotator_built_with": value}
+
+    monkeypatch.setattr(comments_proxy, "_build_proxy_rotator", _capture)
+    monkeypatch.setenv(
+        "SOCIAL_INSTAGRAM_COMMENTS_PROXY_URLS",
+        "http://user-one:secret-one@proxy-one.test:8000",
+    )
+
+    config = comments_proxy.select_comments_proxy(session_key="thetraitorsus:comments:1")
+
+    assert config is not None
+    assert captured["value"] == "http://user-one:secret-one@proxy-one.test:8000"

--- a/tests/socials/instagram/test_constants_doc_id_override.py
+++ b/tests/socials/instagram/test_constants_doc_id_override.py
@@ -1,0 +1,37 @@
+"""Phase 4.1 regression tests for ``resolve_profile_posts_doc_ids``."""
+
+from __future__ import annotations
+
+from trr_backend.socials.instagram.constants import (
+    _PROFILE_POSTS_DOC_IDS_FALLBACK,
+    PROFILE_POSTS_DOC_IDS_ENV,
+    resolve_profile_posts_doc_ids,
+)
+
+
+def test_unset_env_returns_hardcoded_fallback(monkeypatch):
+    monkeypatch.delenv(PROFILE_POSTS_DOC_IDS_ENV, raising=False)
+    assert resolve_profile_posts_doc_ids() == _PROFILE_POSTS_DOC_IDS_FALLBACK
+
+
+def test_single_id_override(monkeypatch):
+    monkeypatch.setenv(PROFILE_POSTS_DOC_IDS_ENV, "12345678901234567")
+    assert resolve_profile_posts_doc_ids() == ("12345678901234567",)
+
+
+def test_multi_id_override_dedupes_and_strips_whitespace(monkeypatch):
+    monkeypatch.setenv(
+        PROFILE_POSTS_DOC_IDS_ENV,
+        "  111 ,  222, 111 ,333,  ",
+    )
+    assert resolve_profile_posts_doc_ids() == ("111", "222", "333")
+
+
+def test_invalid_entries_are_skipped(monkeypatch):
+    monkeypatch.setenv(PROFILE_POSTS_DOC_IDS_ENV, "abc, 123, def-ghi, 456")
+    assert resolve_profile_posts_doc_ids() == ("123", "456")
+
+
+def test_all_invalid_entries_falls_back_to_hardcoded_default(monkeypatch):
+    monkeypatch.setenv(PROFILE_POSTS_DOC_IDS_ENV, "abc, ,, def")
+    assert resolve_profile_posts_doc_ids() == _PROFILE_POSTS_DOC_IDS_FALLBACK

--- a/tests/socials/instagram/test_scraper_parse_comment.py
+++ b/tests/socials/instagram/test_scraper_parse_comment.py
@@ -1,0 +1,144 @@
+"""Phase 1.2 + Phase 2 regression tests for ``InstagramScraper._parse_comment``.
+
+Locks down:
+- Phase 1.2: nested preview replies no longer overwrite ``reply_count``;
+  observed nested-reply count lives on its own field so the fetcher's reply
+  guard (``reply_count > reply_count_observed``) keeps firing.
+- Phase 2: the parser builds ``comment_url``, ``created_at_iso``, and reads
+  the Apify-source owner-metadata fields (``fbid_v2``, ``is_mentionable``,
+  ``is_private``, ``latest_reel_media``, ``profile_pic_id``).
+"""
+
+from __future__ import annotations
+
+from trr_backend.socials.instagram.scraper import InstagramScraper
+
+
+def _make_scraper() -> InstagramScraper:
+    return InstagramScraper(cookies={"sessionid": "test"}, browser_account_id="bravotv")
+
+
+def test_parse_comment_preserves_reported_reply_count_when_inline_previews_present():
+    """Phase 1.2 / audit: previously the parser overwrote
+    ``comment.reply_count`` with ``len(comment.replies)`` when IG didn't ship
+    a count. That hid tail-reply gaps from the fetcher's reply guard.
+    """
+    scraper = _make_scraper()
+    payload = {
+        "pk": "comment-1",
+        "text": "parent",
+        "user": {"username": "alice", "pk": "u1"},
+        "child_comment_count": 50,  # IG-reported
+        "replies": [
+            {"pk": "reply-a", "text": "first", "user": {"username": "bob", "pk": "u2"}},
+            {"pk": "reply-b", "text": "second", "user": {"username": "carol", "pk": "u3"}},
+        ],
+    }
+
+    comment = scraper._parse_comment(payload, shortcode="ABC123", post_url="https://www.instagram.com/p/ABC123/")
+
+    # IG-reported reply_count is preserved for the fetcher's reply guard.
+    assert comment.reply_count == 50
+    # Observed nested replies are recorded separately.
+    assert comment.reply_count_observed == 2
+    assert len(comment.replies) == 2
+
+
+def test_parse_comment_records_observed_count_when_no_reported_count():
+    """When IG omits ``child_comment_count``, ``reply_count`` stays 0 (so the
+    fetcher will pull the full reply tail) and the observed count is captured
+    separately for the persistence layer.
+    """
+    scraper = _make_scraper()
+    payload = {
+        "pk": "comment-1",
+        "text": "parent",
+        "user": {"username": "alice", "pk": "u1"},
+        # No child_comment_count, repliesCount, reply_count, replies_count.
+        "replies": [
+            {"pk": "reply-a", "text": "first", "user": {"username": "bob", "pk": "u2"}},
+        ],
+    }
+
+    comment = scraper._parse_comment(payload, shortcode="ABC123", post_url="https://www.instagram.com/p/ABC123/")
+
+    assert comment.reply_count == 0  # was wrongly forced to 1 by the old code
+    assert comment.reply_count_observed == 1
+
+
+def test_parse_comment_builds_comment_url_and_iso_timestamp():
+    """Phase 2: ``comment_url`` and ``created_at_iso`` populate from shortcode
+    + comment_id and an integer epoch timestamp respectively.
+    """
+    scraper = _make_scraper()
+    payload = {
+        "pk": "1234567890",
+        "text": "hello",
+        "user": {"username": "alice", "pk": "u1"},
+        "created_at": 1_705_320_600,  # 2024-01-15T10:30:00Z
+    }
+
+    comment = scraper._parse_comment(payload, shortcode="ABC123", post_url="https://www.instagram.com/p/ABC123/")
+
+    assert comment.comment_url == "https://www.instagram.com/p/ABC123/c/1234567890/"
+    assert comment.created_at_iso is not None
+    assert comment.created_at_iso.endswith("Z")
+    assert "T" in comment.created_at_iso
+    # Existing legacy fields stay populated for downstream consumers.
+    assert comment.created_at == 1_705_320_600
+
+
+def test_parse_comment_extracts_apify_source_owner_metadata():
+    """Phase 2: the parser reads ``fbid_v2``, ``is_mentionable``,
+    ``is_private``, ``latest_reel_media``, ``profile_pic_id`` from the owner
+    or user payload variants IG ships.
+    """
+    scraper = _make_scraper()
+    payload = {
+        "pk": "comment-1",
+        "text": "parent",
+        "user": {
+            "username": "alice",
+            "pk": "u1",
+            "fbid_v2": "fbid_987",
+            "is_mentionable": True,
+            "is_private": False,
+            "latest_reel_media": 1_705_320_600,
+            "profile_pic_id": "pic_abc",
+        },
+    }
+
+    comment = scraper._parse_comment(payload, shortcode="ABC123", post_url="https://www.instagram.com/p/ABC123/")
+
+    assert comment.owner_fbid_v2 == "fbid_987"
+    assert comment.owner_is_mentionable is True
+    assert comment.owner_is_private is False
+    assert comment.owner_latest_reel_media == 1_705_320_600
+    assert comment.owner_profile_pic_id == "pic_abc"
+
+
+def test_parse_comment_owner_metadata_falls_back_to_camel_case():
+    """IG sometimes ships these fields with camelCase keys; the fallback must
+    cover both shapes."""
+    scraper = _make_scraper()
+    payload = {
+        "pk": "comment-1",
+        "text": "parent",
+        "owner": {
+            "username": "alice",
+            "id": "u1",
+            "fbidV2": "fbid_camel",
+            "isMentionable": False,
+            "isPrivate": True,
+            "latestReelMedia": 999,
+            "profilePicId": "pic_camel",
+        },
+    }
+
+    comment = scraper._parse_comment(payload, shortcode="ABC123", post_url="https://www.instagram.com/p/ABC123/")
+
+    assert comment.owner_fbid_v2 == "fbid_camel"
+    assert comment.owner_is_mentionable is False
+    assert comment.owner_is_private is True
+    assert comment.owner_latest_reel_media == 999
+    assert comment.owner_profile_pic_id == "pic_camel"

--- a/tests/socials/test_comment_scraper_fixes.py
+++ b/tests/socials/test_comment_scraper_fixes.py
@@ -2901,6 +2901,47 @@ def test_instagram_parse_comment_synthetic_comment_media_payload_extracts_urls()
     assert reply.likes == 2
 
 
+def test_instagram_parse_comment_extracts_sticker_gift_and_giphy_media_shapes() -> None:
+    scraper = InstagramScraper(cookies={})
+    comment_payload = {
+        "pk": "17900000000000003",
+        "text": "",
+        "user": {"pk": "3003", "username": "visual_commenter"},
+        "created_at": 1735689800,
+        "sticker": {
+            "image_versions2": {
+                "candidates": [
+                    {"url": "https://scontent.example/sticker-1080.webp"},
+                ]
+            }
+        },
+        "gift": {
+            "media": {
+                "uri": "https://scontent.example/gift-image.webp",
+            }
+        },
+        "giphy_media_info": {
+            "images": {
+                "original": {"url": "https://media.giphy.example/original.gif"},
+                "fixed_height": {"webp": "https://media.giphy.example/fixed-height.webp"},
+            }
+        },
+    }
+
+    parsed = scraper.parse_comment(
+        comment_payload,
+        "COMMENTMEDIA",
+        "https://www.instagram.com/p/COMMENTMEDIA/",
+    )
+
+    assert parsed.media_urls == [
+        "https://scontent.example/sticker-1080.webp",
+        "https://scontent.example/gift-image.webp",
+        "https://media.giphy.example/original.gif",
+        "https://media.giphy.example/fixed-height.webp",
+    ]
+
+
 def test_instagram_scrape_graphql_backfills_owner_avatar_from_profile_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2988,6 +3029,8 @@ def test_instagram_fetch_comments_paginates_with_headload_flag(monkeypatch: pyte
     comments = scraper.fetch_comments("ABC123", fetch_replies=False, delay=0)
     assert len(comments) == 2
     assert len(seen_params) == 2
+    assert seen_params[0].get("sort_order") == "recent"
+    assert seen_params[1].get("sort_order") == "recent"
     assert seen_params[1].get("min_id") == "cursor-1"
 
 

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from contextlib import nullcontext
 from datetime import UTC, datetime
 from pathlib import Path
@@ -13,12 +14,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from trr_backend.socials.instagram.comments_scrapling.counts import flattened_comment_count, missing_reply_count
 from trr_backend.socials.instagram.comments_scrapling.fetcher import (
     InstagramCommentsFetchResult,
     InstagramCommentsScraplingFetcher,
     InstagramCommentsWarmupError,
     _extract_rendered_permalink_comments,
+    _pace_global_api_request,
+    _record_global_api_cooldown,
 )
+from trr_backend.socials.instagram.constants import resolve_comment_sort_order
 from trr_backend.socials.instagram.scraper import InstagramComment
 
 _FIXTURE_DIR = Path(__file__).parents[1] / "fixtures" / "instagram" / "scrapling"
@@ -47,6 +52,29 @@ def _build_fetcher() -> InstagramCommentsScraplingFetcher:
         # Pre-build httpx client so tests don't need warmup.
         asyncio.run(fetcher._rebuild_http_client())
         return fetcher
+
+
+def _comment(
+    comment_id: str,
+    *,
+    reply_count: int = 0,
+    replies: list[InstagramComment] | None = None,
+    is_reply: bool = False,
+    parent_comment_id: str | None = None,
+) -> InstagramComment:
+    return InstagramComment(
+        comment_id=comment_id,
+        text=comment_id,
+        username=f"user_{comment_id}",
+        user_id=comment_id,
+        created_at=1,
+        date_time="1970-01-01T00:00:01+00:00",
+        likes=0,
+        is_reply=is_reply,
+        parent_comment_id=parent_comment_id,
+        reply_count=reply_count,
+        replies=list(replies or []),
+    )
 
 
 def test_extract_rendered_hidden_comment_from_post_dom() -> None:
@@ -79,6 +107,58 @@ def test_extract_rendered_hidden_comment_from_post_dom() -> None:
     )
     assert comments[0].likes == 2
     assert comments[0].created_at == int(datetime(2026, 4, 27, 21, 16, 21, tzinfo=UTC).timestamp())
+    assert comments[0].is_hidden_by_instagram is True
+    assert comments[0].source_snapshot_type == "rendered_hidden_comments"
+
+
+def test_extract_rendered_hidden_comment_ignores_dynamic_owner_not_literal_handle() -> None:
+    html = """
+    <div>
+      <a href="/thetraitorsus/">commenter profile</a>
+      <a href="/bravotv/">post owner hover card</a>
+      <a href="/p/DXpWUKECX3t/c/18109809979882643/" role="link">
+        <time datetime="2026-04-27T21:16:21.000Z">3d</time>
+      </a>
+      <span dir="auto">Hidden comment body</span>
+    </div>
+    """
+
+    comments = _extract_rendered_permalink_comments(
+        html,
+        shortcode="DXpWUKECX3t",
+        post_url="https://www.instagram.com/p/DXpWUKECX3t/",
+        ignored_usernames=["bravotv"],
+    )
+
+    assert len(comments) == 1
+    assert comments[0].username == "thetraitorsus"
+
+
+def test_extract_rendered_hidden_media_only_comment_from_post_dom() -> None:
+    html = """
+    <div>
+      <a href="/viewer_account/">commenter profile</a>
+      <a href="/p/DXpWUKECX3t/c/18109809979882644/" role="link">
+        <time datetime="2026-04-27T21:16:21.000Z">3d</time>
+      </a>
+      <img alt="Comment sticker" src="https://scontent.example/comment-sticker.webp" />
+      <span dir="auto">Reply</span>
+    </div>
+    """
+
+    comments = _extract_rendered_permalink_comments(
+        html,
+        shortcode="DXpWUKECX3t",
+        post_url="https://www.instagram.com/p/DXpWUKECX3t/",
+    )
+
+    assert len(comments) == 1
+    assert comments[0].comment_id == "18109809979882644"
+    assert comments[0].username == "viewer_account"
+    assert comments[0].text == ""
+    assert comments[0].media_urls == ["https://scontent.example/comment-sticker.webp"]
+    assert comments[0].is_hidden_by_instagram is True
+    assert comments[0].source_snapshot_type == "rendered_hidden_comments"
 
 
 def test_fetch_comments_reveals_hidden_comments_when_api_is_short(monkeypatch) -> None:
@@ -175,6 +255,316 @@ def test_fetch_comments_skips_hidden_reveal_when_api_matches_reported_count(monk
     fetcher._fetch_rendered_comments_after_revealing_hidden.assert_not_awaited()
 
 
+def test_fetch_comments_reconciles_tiny_unavailable_hidden_gap_after_reveal(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        return_value=InstagramComment(
+            comment_id="visible",
+            text="visible",
+            username="alpha",
+            user_id="1",
+            created_at=1,
+            date_time="1970-01-01 00:00:01",
+            likes=0,
+            is_reply=False,
+            parent_comment_id=None,
+            reply_count=0,
+        )
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {"comments": [{"id": "visible"}], "has_more_comments": False},
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "DXpWUKECX3t",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=3,
+        )
+    )
+
+    assert len(result.comments) == 1
+    assert result.fetch_failed is False
+    assert result.retryable is False
+    assert result.fetch_reason == "hidden_comments_unavailable_reconciled"
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_awaited_once()
+
+
+def test_fetch_comments_uses_flattened_count_for_expected_total(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    top_level_comments = [_comment(f"c{i}", reply_count=1) for i in range(50)]
+    fetcher._parser._parse_comment = MagicMock(side_effect=top_level_comments)
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": comment.comment_id} for comment in top_level_comments],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    async def fake_replies(**kwargs):
+        parent_id = kwargs["comment_id"]
+        return InstagramCommentsFetchResult(
+            comments=[_comment(f"{parent_id}-r1", is_reply=True, parent_comment_id=parent_id)],
+            fetch_failed=False,
+            auth_failed=False,
+            retryable=False,
+        )
+
+    fetcher._fetch_comment_replies = AsyncMock(side_effect=fake_replies)
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=True,
+            expected_comment_count=100,
+        )
+    )
+
+    assert flattened_comment_count(result.comments) == 100
+    assert result.fetch_failed is False
+    assert result.fetch_reason is None
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_not_awaited()
+
+
+def test_flattened_count_ignores_idless_comments_that_cannot_be_persisted() -> None:
+    comments = [
+        _comment("c1"),
+        _comment(""),
+        _comment("c2", replies=[_comment("", is_reply=True), _comment("r1", is_reply=True)]),
+        _comment("c1"),
+    ]
+
+    assert flattened_comment_count(comments) == 3
+
+
+def test_comments_scrape_is_complete_accepts_reconciled_hidden_unavailable_gap() -> None:
+    from trr_backend.socials.instagram.comments_scrapling.job_runner import _comments_scrape_is_complete
+
+    result = InstagramCommentsFetchResult(
+        comments=[_comment("c1")],
+        fetch_failed=False,
+        auth_failed=False,
+        fetch_reason="hidden_comments_unavailable_reconciled",
+        reported_comment_count=3,
+        retryable=False,
+    )
+
+    assert _comments_scrape_is_complete(result=result, max_comments_per_post=0) is True
+
+
+def test_fetch_comments_fetches_tail_when_preview_replies_are_short(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    preview_replies = [_comment(f"r{i}", is_reply=True, parent_comment_id="c1") for i in range(20)]
+    fetcher._parser._parse_comment = MagicMock(
+        return_value=_comment("c1", reply_count=50, replies=preview_replies)
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c1"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    tail_replies = [_comment(f"r{i}", is_reply=True, parent_comment_id="c1") for i in range(20, 50)]
+    fetcher._fetch_comment_replies = AsyncMock(
+        return_value=InstagramCommentsFetchResult(
+            comments=tail_replies,
+            fetch_failed=False,
+            auth_failed=False,
+            retryable=False,
+        )
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=True,
+            expected_comment_count=51,
+        )
+    )
+
+    assert flattened_comment_count(result.comments) == 51
+    assert missing_reply_count(result.comments) == 0
+    assert fetcher._fetch_comment_replies.await_count == 1
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_not_awaited()
+
+
+def test_fetch_comments_skips_hidden_reveal_when_reply_tail_gap_explains_shortfall(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    preview_replies = [_comment(f"r{i}", is_reply=True, parent_comment_id="c1") for i in range(20)]
+    fetcher._parser._parse_comment = MagicMock(
+        return_value=_comment("c1", reply_count=50, replies=preview_replies)
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c1"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    fetcher._fetch_comment_replies = AsyncMock(
+        return_value=InstagramCommentsFetchResult(
+            comments=[],
+            fetch_failed=False,
+            auth_failed=False,
+            retryable=False,
+        )
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=True,
+            expected_comment_count=51,
+        )
+    )
+
+    assert flattened_comment_count(result.comments) == 21
+    assert missing_reply_count(result.comments) == 30
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "reply_tail_incomplete"
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_not_awaited()
+
+
+def test_fetch_comments_reply_only_retries_when_saved_parent_reply_tail_is_still_short() -> None:
+    fetcher = _build_fetcher()
+    parent = _comment("c1", reply_count=3)
+    existing_reply = _comment("r1", is_reply=True, parent_comment_id="c1")
+    fetched_reply = _comment("r2", is_reply=True, parent_comment_id="c1")
+    fetcher._fetch_json_response = AsyncMock()
+    fetcher._fetch_comment_replies = AsyncMock(
+        return_value=InstagramCommentsFetchResult(comments=[fetched_reply], fetch_failed=False, auth_failed=False)
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=True,
+            expected_comment_count=10,
+            persisted_replies_by_parent={"c1": [existing_reply]},
+            persisted_top_level_comments=[parent],
+            reply_only=True,
+        )
+    )
+
+    fetcher._fetch_json_response.assert_not_awaited()
+    fetcher._fetch_comment_replies.assert_awaited_once()
+    assert [reply.comment_id for reply in result.comments[0].replies] == ["r1", "r2"]
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "reply_tail_incomplete"
+
+
+def test_fetch_comments_checkpoints_remaining_replies_after_reply_tail_budget(monkeypatch) -> None:
+    clock = {"now": 100.0}
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_REPLY_TAIL_TOTAL_MAX_SECONDS_PER_POST", "1")
+    fetcher = _build_fetcher()
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.time.monotonic",
+        lambda: clock["now"],
+    )
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            _comment("c1", reply_count=1),
+            _comment("c2", reply_count=1),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c1"}, {"id": "c2"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    async def fake_replies(**kwargs):
+        parent_id = kwargs["comment_id"]
+        clock["now"] = 102.0
+        return InstagramCommentsFetchResult(
+            comments=[_comment(f"{parent_id}-r1", is_reply=True, parent_comment_id=parent_id)],
+            fetch_failed=False,
+            auth_failed=False,
+            retryable=False,
+        )
+
+    fetcher._fetch_comment_replies = AsyncMock(side_effect=fake_replies)
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=True,
+            expected_comment_count=4,
+        )
+    )
+
+    assert flattened_comment_count(result.comments) == 3
+    assert missing_reply_count(result.comments) == 1
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "reply_tail_budget_exhausted"
+    assert fetcher._fetch_comment_replies.await_count == 1
+    assert result.reply_checkpoints[-1]["stop_reason"] == "reply_tail_budget_exhausted"
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_not_awaited()
+
+
+def test_reply_tail_budget_gap_can_reconcile_stale_reported_count() -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    result = InstagramCommentsFetchResult(
+        comments=[_comment("c1")],
+        fetch_failed=True,
+        auth_failed=False,
+        fetch_reason="reply_tail_budget_exhausted",
+        reported_comment_count=100,
+        retryable=True,
+    )
+
+    assert jr._persisted_comment_coverage_gap_is_reconcilable(
+        result=result,
+        stored_total_comments=99,
+        max_comments_per_post=0,
+    )
+
+
 def test_rebuild_http_client_closes_previous_client(monkeypatch) -> None:
     fetcher = _build_fetcher()
     old = _TrackingClient()
@@ -250,7 +640,7 @@ def test_fetch_comments_preserves_reply_failure_across_later_pages(monkeypatch) 
     assert result.fetch_reason == "reply_timeout"
 
 
-def test_fetch_comments_stops_reply_requests_after_retryable_reply_failure(monkeypatch) -> None:
+def test_fetch_comments_continues_reply_requests_after_retryable_parent_failure(monkeypatch) -> None:
     fetcher = _build_fetcher()
     fetcher._parser._parse_comment = MagicMock(
         side_effect=[
@@ -309,11 +699,74 @@ def test_fetch_comments_stops_reply_requests_after_retryable_reply_failure(monke
     assert result.retryable is True
     assert result.fetch_reason == "http_429"
     assert len(result.comments) == 2
+    assert fetcher._fetch_comment_replies.await_count == 2
+    assert "reply_fetch_circuit_open" not in fetcher.runtime_metadata["retry_reason_counts"]
+
+
+def test_fetch_comments_dedupes_top_level_parents_before_reply_fetch(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    duplicate_parent = InstagramComment(
+        comment_id="c1",
+        text="one",
+        username="alpha",
+        user_id="1",
+        created_at=1,
+        date_time="1970-01-01T00:00:01+00:00",
+        likes=0,
+        is_reply=False,
+        parent_comment_id=None,
+        reply_count=2,
+    )
+    fetcher._parser.parse_comment = MagicMock(return_value=duplicate_parent)
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": False,
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+    fetcher._fetch_comment_replies = AsyncMock(
+        return_value=InstagramCommentsFetchResult(
+            comments=[
+                _comment("r1", is_reply=True, parent_comment_id="c1"),
+                _comment("r2", is_reply=True, parent_comment_id="c1"),
+            ],
+            fetch_failed=False,
+            auth_failed=False,
+            fetch_reason=None,
+            request_count=1,
+            retryable=False,
+        )
+    )
+
+    result = asyncio.run(fetcher.fetch_comments_for_shortcode("ABC123", max_comments=10, fetch_replies=True))
+
+    assert result.fetch_failed is False
+    assert flattened_comment_count(result.comments) == 3
+    assert [comment.comment_id for comment in result.comments] == ["c1"]
+    assert [reply.comment_id for reply in result.comments[0].replies] == ["r1", "r2"]
     assert fetcher._fetch_comment_replies.await_count == 1
-    assert fetcher.runtime_metadata["retry_reason_counts"]["reply_fetch_circuit_open"] == 1
 
 
-def test_fetch_comments_marks_repeated_cursor_retryable(monkeypatch) -> None:
+def test_fetch_comments_repeated_cursor_without_expected_count_is_retryable(monkeypatch) -> None:
     fetcher = _build_fetcher()
     fetcher._parser._parse_comment = MagicMock(
         side_effect=[
@@ -378,6 +831,533 @@ def test_fetch_comments_marks_repeated_cursor_retryable(monkeypatch) -> None:
     assert result.fetch_reason == "pagination_repeated_cursor"
 
 
+def test_fetch_comments_marks_repeated_cursor_retryable_when_expected_gap_remains(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            InstagramComment(
+                comment_id="c1",
+                text="one",
+                username="alpha",
+                user_id="1",
+                created_at=1,
+                date_time="1970-01-01T00:00:01+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+            InstagramComment(
+                comment_id="c2",
+                text="two",
+                username="beta",
+                user_id="2",
+                created_at=2,
+                date_time="1970-01-01T00:00:02+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c2"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=10,
+            fetch_replies=True,
+            expected_comment_count=3,
+        )
+    )
+
+    assert len(result.comments) == 2
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "pagination_repeated_cursor"
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_awaited_once()
+
+
+def test_fetch_comments_repeated_cursor_reveals_hidden_comments_before_retrying(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            InstagramComment(
+                comment_id="c1",
+                text="one",
+                username="alpha",
+                user_id="1",
+                created_at=1,
+                date_time="1970-01-01T00:00:01+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+            InstagramComment(
+                comment_id="c2",
+                text="two",
+                username="beta",
+                user_id="2",
+                created_at=2,
+                date_time="1970-01-01T00:00:02+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c2"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(
+        return_value=[
+            InstagramComment(
+                comment_id="c3",
+                text="hidden",
+                username="gamma",
+                user_id="3",
+                created_at=3,
+                date_time="1970-01-01T00:00:03+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            )
+        ]
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=10,
+            fetch_replies=True,
+            expected_comment_count=3,
+        )
+    )
+
+    assert len(result.comments) == 3
+    assert result.fetch_failed is False
+    assert result.retryable is False
+    assert result.fetch_reason == "hidden_comments_recovered"
+    assert fetcher.runtime_metadata["hidden_comments"]["merged_comments"] == 1
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_awaited_once()
+
+
+def test_fetch_comments_repeated_cursor_is_complete_when_expected_count_met(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            InstagramComment(
+                comment_id="c1",
+                text="one",
+                username="alpha",
+                user_id="1",
+                created_at=1,
+                date_time="1970-01-01T00:00:01+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+            InstagramComment(
+                comment_id="c2",
+                text="two",
+                username="beta",
+                user_id="2",
+                created_at=2,
+                date_time="1970-01-01T00:00:02+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c2"}],
+                    "has_more_comments": True,
+                    "next_min_id": "cursor-1",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=10,
+            fetch_replies=True,
+            expected_comment_count=2,
+        )
+    )
+
+    assert flattened_comment_count(result.comments) == 2
+    assert result.fetch_failed is False
+    assert result.retryable is False
+    assert result.fetch_reason == "coverage_target_met"
+    fetcher._fetch_rendered_comments_after_revealing_hidden.assert_not_awaited()
+
+
+def test_fetch_comments_records_top_level_resume_checkpoint_at_page_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_PAGES", "1")
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(return_value=_comment("c1"))
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c1"}],
+                "has_more_comments": True,
+                "next_min_id": "cursor-2",
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=10,
+        )
+    )
+
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "pagination_page_cap_reached"
+    assert result.top_level_checkpoint is not None
+    assert result.top_level_checkpoint["target_shortcode"] == "ABC123"
+    assert result.top_level_checkpoint["next_top_level_cursor"] == "cursor-2"
+    assert result.top_level_checkpoint["pages_seen"] == 1
+    assert fetcher.runtime_metadata["top_level_checkpoint_metadata"]["items"][-1][
+        "next_top_level_cursor"
+    ] == "cursor-2"
+
+
+def test_fetch_comments_resumes_from_top_level_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(return_value=_comment("c2"))
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c2"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=1,
+            top_level_cursor="cursor-2",
+        )
+    )
+
+    assert result.fetch_failed is False
+    assert [comment.comment_id for comment in result.comments] == ["c2"]
+    assert fetcher._fetch_json_response.await_args.kwargs["params"]["min_id"] == "cursor-2"
+    assert fetcher._fetch_json_response.await_args.kwargs["params"]["sort_order"] == "recent"
+
+
+def test_fetch_comments_can_disable_explicit_sort_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_SORT_ORDER", "none")
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(return_value=_comment("c1"))
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c1"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=1,
+        )
+    )
+
+    assert result.fetch_failed is False
+    assert "sort_order" not in fetcher._fetch_json_response.await_args.kwargs["params"]
+
+
+def test_comment_sort_order_resolver_defaults_to_recent_for_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SOCIAL_INSTAGRAM_COMMENTS_SORT_ORDER", raising=False)
+    assert resolve_comment_sort_order(None) == "recent"
+    assert resolve_comment_sort_order("popular") == "popular"
+    assert resolve_comment_sort_order("bogus") == "recent"
+    assert resolve_comment_sort_order("none") is None
+
+
+def test_fetch_comments_uses_max_id_for_tail_comment_pagination() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(side_effect=[_comment("c1"), _comment("c2")])
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "has_more_headload_comments": True,
+                    "next_max_id": "tail-cursor",
+                    "next_min_id": "head-cursor",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c2"}],
+                    "has_more_comments": False,
+                    "has_more_headload_comments": False,
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=2,
+        )
+    )
+
+    assert result.fetch_failed is False
+    assert [comment.comment_id for comment in result.comments] == ["c1", "c2"]
+    assert fetcher._fetch_json_response.await_args_list[1].kwargs["params"]["sort_order"] == "recent"
+    assert fetcher._fetch_json_response.await_args_list[1].kwargs["params"]["max_id"] == "tail-cursor"
+    assert "min_id" not in fetcher._fetch_json_response.await_args_list[1].kwargs["params"]
+
+
+def test_fetch_comment_replies_resumes_with_checkpoint_cursor_param() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(return_value=_comment("reply-1", is_reply=True))
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "child_comments": [{"id": "reply-1"}],
+                "has_more_tail_child_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    result = asyncio.run(
+        fetcher._fetch_comment_replies(  # noqa: SLF001
+            media_id="123",
+            comment_id="parent-1",
+            shortcode="ABC123",
+            post_url="https://www.instagram.com/p/ABC123/",
+            expected_reply_count=1,
+            resume_cursor="tail-cursor",
+            resume_cursor_param="max_id",
+        )
+    )
+
+    assert result.fetch_failed is False
+    assert fetcher._fetch_json_response.await_args.kwargs["params"] == {"max_id": "tail-cursor"}
+
+
+def test_fetch_comments_skips_reply_tail_when_persisted_replies_satisfy_count() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(return_value=_comment("c1", reply_count=2))
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c1"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+    fetcher._fetch_comment_replies = AsyncMock()
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=True,
+            expected_comment_count=3,
+            persisted_replies_by_parent={
+                "c1": [
+                    _comment("r1", is_reply=True, parent_comment_id="c1"),
+                    _comment("r2", is_reply=True, parent_comment_id="c1"),
+                ]
+            },
+        )
+    )
+
+    assert flattened_comment_count(result.comments) == 3
+    assert [reply.comment_id for reply in result.comments[0].replies] == ["r1", "r2"]
+    fetcher._fetch_comment_replies.assert_not_awaited()
+
+
+def test_fetch_comments_reply_only_uses_persisted_top_level_parents() -> None:
+    fetcher = _build_fetcher()
+    parent = _comment("c1", reply_count=2)
+    existing_reply = _comment("r1", is_reply=True, parent_comment_id="c1")
+    fetched_reply = _comment("r2", is_reply=True, parent_comment_id="c1")
+    fetcher._fetch_json_response = AsyncMock()
+    fetcher._fetch_comment_replies = AsyncMock(
+        return_value=InstagramCommentsFetchResult(comments=[fetched_reply], fetch_failed=False, auth_failed=False)
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=True,
+            expected_comment_count=10,
+            persisted_replies_by_parent={"c1": [existing_reply]},
+            persisted_top_level_comments=[parent],
+            reply_only=True,
+        )
+    )
+
+    fetcher._fetch_json_response.assert_not_awaited()
+    fetcher._fetch_comment_replies.assert_awaited_once()
+    assert [reply.comment_id for reply in result.comments[0].replies] == ["r1", "r2"]
+    assert result.fetch_failed is False
+    assert result.retryable is False
+    assert result.fetch_reason == "reply_tail_coverage_complete"
+
+
+def test_fetch_comments_resumes_top_level_cursor_with_recorded_param() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(return_value=_comment("c2"))
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "comments": [{"id": "c2"}],
+                "has_more_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=0,
+            fetch_replies=False,
+            expected_comment_count=1,
+            top_level_cursor="cursor-2",
+            top_level_cursor_param="max_id",
+        )
+    )
+
+    assert result.fetch_failed is False
+    assert fetcher._fetch_json_response.await_args.kwargs["params"]["max_id"] == "cursor-2"
+    assert "min_id" not in fetcher._fetch_json_response.await_args.kwargs["params"]
+
+
 def test_fetch_comment_replies_marks_page_cap_retryable(monkeypatch) -> None:
     monkeypatch.setenv("SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES", "1")
     fetcher = _build_fetcher()
@@ -433,6 +1413,7 @@ def test_fetch_comment_replies_marks_page_cap_retryable(monkeypatch) -> None:
             "attempt_count": 0,
             "last_error_code": "pagination_page_cap_reached",
             "next_reply_cursor": "reply-cursor-2",
+            "next_reply_cursor_param": "min_id",
             "saved_reply_count_observed": 1,
             "pages_seen": 1,
             "retryable": True,
@@ -444,6 +1425,153 @@ def test_fetch_comment_replies_marks_page_cap_retryable(monkeypatch) -> None:
     assert checkpoint_metadata["dropped_count"] == 0
     assert checkpoint_metadata["truncated"] is False
     assert checkpoint_metadata["items"] == result.reply_checkpoints
+
+
+def test_fetch_comment_replies_respects_parent_post_deadline(monkeypatch) -> None:
+    fetcher = _build_fetcher()
+    fetcher._fetch_json_response = AsyncMock()
+
+    result = asyncio.run(
+        fetcher._fetch_comment_replies(
+            media_id="media-1",
+            comment_id="parent-1",
+            shortcode="ABC123",
+            post_url="https://www.instagram.com/p/ABC123/",
+            expected_reply_count=10,
+            deadline=time.monotonic() - 0.01,
+        )
+    )
+
+    assert result.fetch_failed is True
+    assert result.retryable is True
+    assert result.fetch_reason == "pagination_deadline_exceeded"
+    assert result.reply_checkpoints[0]["stop_reason"] == "pagination_deadline_exceeded"
+    fetcher._fetch_json_response.assert_not_awaited()
+
+
+def test_fetch_comment_replies_resumes_from_checkpoint_cursor() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(return_value=_comment("r2", is_reply=True, parent_comment_id="c1"))
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "child_comments": [{"id": "r2"}],
+                "has_more_tail_child_comments": False,
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    result = asyncio.run(
+        fetcher._fetch_comment_replies(
+            media_id="media-1",
+            comment_id="c1",
+            shortcode="ABC123",
+            post_url="https://www.instagram.com/p/ABC123/",
+            expected_reply_count=2,
+            resume_cursor="reply-cursor-2",
+        )
+    )
+
+    assert [comment.comment_id for comment in result.comments] == ["r2"]
+    assert result.fetch_failed is False
+    assert fetcher._fetch_json_response.await_args.kwargs["params"] == {"min_id": "reply-cursor-2"}
+
+
+def test_fetch_comment_replies_follows_head_more_with_min_cursor() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            _comment("r1", is_reply=True, parent_comment_id="c1"),
+            _comment("r2", is_reply=True, parent_comment_id="c1"),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "child_comments": [{"id": "r1"}],
+                    "has_more_head_child_comments": True,
+                    "has_more_tail_child_comments": False,
+                    "next_min_child_cursor": "reply-cursor-2",
+                    "next_max_child_cursor": None,
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "child_comments": [{"id": "r2"}],
+                    "has_more_head_child_comments": False,
+                    "has_more_tail_child_comments": False,
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+
+    result = asyncio.run(
+        fetcher._fetch_comment_replies(
+            media_id="media-1",
+            comment_id="c1",
+            shortcode="ABC123",
+            post_url="https://www.instagram.com/p/ABC123/",
+            expected_reply_count=2,
+        )
+    )
+
+    assert [comment.comment_id for comment in result.comments] == ["r1", "r2"]
+    assert result.fetch_failed is False
+    assert result.retryable is False
+    assert result.reply_checkpoints == []
+    assert fetcher._fetch_json_response.await_args_list[0].kwargs["params"] is None
+    assert fetcher._fetch_json_response.await_args_list[1].kwargs["params"] == {"min_id": "reply-cursor-2"}
+
+
+def test_fetch_comment_replies_counts_existing_preview_replies_before_retrying(monkeypatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES", "1")
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        return_value=_comment("r2", is_reply=True, parent_comment_id="c1")
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        return_value={
+            "payload": {
+                "child_comments": [{"id": "r2"}],
+                "has_more_tail_child_comments": True,
+                "next_min_child_cursor": "reply-cursor-2",
+            },
+            "failed": False,
+            "auth_failed": False,
+            "reason": None,
+            "retryable": False,
+        }
+    )
+
+    result = asyncio.run(
+        fetcher._fetch_comment_replies(
+            media_id="media-1",
+            comment_id="c1",
+            shortcode="ABC123",
+            post_url="https://www.instagram.com/p/ABC123/",
+            expected_reply_count=2,
+            existing_replies=[_comment("r1", is_reply=True, parent_comment_id="c1")],
+        )
+    )
+
+    assert len(result.comments) == 1
+    assert result.fetch_failed is False
+    assert result.retryable is False
+    assert result.fetch_reason == "pagination_page_cap_reached"
+    assert result.reply_checkpoints == []
 
 
 def test_reply_checkpoint_metadata_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -532,10 +1660,136 @@ def test_fetch_retries_on_429_then_succeeds() -> None:
     assert result["retryable"] is False
 
 
+def test_fetch_rebuilds_http_client_after_429_before_retry() -> None:
+    """Decodo can rotate on a new proxy connection; don't pin all 429
+    retries to one stale httpx client.
+    """
+    fetcher = _build_fetcher()
+    responses = [
+        _mock_httpx_response(status_code=429, headers={"retry-after": "0"}),
+        _mock_httpx_response(status_code=200, json_data={"status": "ok"}),
+    ]
+    fetcher._fetch_api = AsyncMock(side_effect=responses)
+    fetcher._rebuild_http_client = AsyncMock()
+
+    with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.asyncio.sleep", AsyncMock()):
+        result = asyncio.run(
+            fetcher._fetch_json_response(
+                "https://www.instagram.com/api/v1/media/1/comments/",
+                referer="https://www.instagram.com/p/ABC/",
+            )
+        )
+
+    assert result["failed"] is False
+    fetcher._rebuild_http_client.assert_awaited_once()
+
+
+def test_fetch_records_shared_cooldown_after_429() -> None:
+    """A 429 should slow sibling local workers, not only the current coroutine."""
+    fetcher = _build_fetcher()
+    responses = [
+        _mock_httpx_response(status_code=429),
+        _mock_httpx_response(status_code=200, json_data={"status": "ok"}),
+    ]
+    fetcher._fetch_api = AsyncMock(side_effect=responses)
+    fetcher._rebuild_http_client = AsyncMock()
+
+    with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.asyncio.sleep", AsyncMock()):
+        with patch(
+            "trr_backend.socials.instagram.comments_scrapling.fetcher._record_global_api_cooldown"
+        ) as cooldown_mock:
+            result = asyncio.run(
+                fetcher._fetch_json_response(
+                    "https://www.instagram.com/api/v1/media/1/comments/",
+                    referer="https://www.instagram.com/p/ABC/",
+                )
+            )
+
+    assert result["failed"] is False
+    cooldown_mock.assert_called_once_with(
+        key=fetcher._global_rate_limit_key,
+        delay_seconds=pytest.approx(15.0, abs=0.01),
+    )
+
+
+def test_fetch_429_shared_cooldown_uses_env_floor_and_multiplier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_429_COOLDOWN_MIN_SEC", "3")
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_429_COOLDOWN_MULTIPLIER", "4")
+    fetcher = _build_fetcher()
+    responses = [
+        _mock_httpx_response(status_code=429, headers={"retry-after": "2"}),
+        _mock_httpx_response(status_code=200, json_data={"status": "ok"}),
+    ]
+    fetcher._fetch_api = AsyncMock(side_effect=responses)
+    fetcher._rebuild_http_client = AsyncMock()
+
+    with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.asyncio.sleep", AsyncMock()):
+        with patch(
+            "trr_backend.socials.instagram.comments_scrapling.fetcher._record_global_api_cooldown"
+        ) as cooldown_mock:
+            result = asyncio.run(
+                fetcher._fetch_json_response(
+                    "https://www.instagram.com/api/v1/media/1/comments/",
+                    referer="https://www.instagram.com/p/ABC/",
+                )
+            )
+
+    assert result["failed"] is False
+    cooldown_mock.assert_called_once_with(
+        key=fetcher._global_rate_limit_key,
+        delay_seconds=pytest.approx(8.0, abs=0.01),
+    )
+
+
+def test_fetch_429_backoff_respects_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK_ON_429", "false")
+    fetcher = _build_fetcher()
+    fetcher._fetch_api = AsyncMock(return_value=_mock_httpx_response(status_code=429, headers={"retry-after": "5"}))
+    fetcher._rebuild_http_client = AsyncMock()
+
+    result = asyncio.run(
+        fetcher._fetch_json_response(
+            "https://www.instagram.com/api/v1/media/1/comments/",
+            referer="https://www.instagram.com/p/ABC/",
+            deadline=time.monotonic() + 0.01,
+        )
+    )
+
+    assert result["failed"] is True
+    assert result["retryable"] is True
+    assert result["reason"] == "pagination_deadline_exceeded"
+    fetcher._fetch_api.assert_awaited_once()
+
+
+def test_fetch_uses_browser_api_fallback_after_repeated_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK_ON_429_ATTEMPT", "1")
+    fetcher = _build_fetcher()
+    fetcher._fetch_api = AsyncMock(return_value=_mock_httpx_response(status_code=429))
+    fetcher._fetch_api_with_browser = AsyncMock(
+        return_value=_mock_httpx_response(status_code=200, json_data={"status": "ok"})
+    )
+    fetcher._rebuild_http_client = AsyncMock()
+
+    with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.asyncio.sleep", AsyncMock()):
+        result = asyncio.run(
+            fetcher._fetch_json_response(
+                "https://www.instagram.com/api/v1/media/1/comments/",
+                referer="https://www.instagram.com/p/ABC/",
+            )
+        )
+
+    assert result["failed"] is False
+    assert result["payload"] == {"status": "ok"}
+    fetcher._fetch_api.assert_awaited_once()
+    fetcher._fetch_api_with_browser.assert_awaited_once()
+    assert fetcher.runtime_metadata["retry_reason_counts"]["browser_api_fallback_after_429"] == 1
+
+
 @pytest.mark.parametrize(
     "error_message",
     [
         "[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2590)",
+        "[SSL] record layer failure (_ssl.c:2590)",
         "SSL connection has been closed unexpectedly\n",
     ],
 )
@@ -566,8 +1820,9 @@ def test_fetch_retries_raw_ssl_oserror_then_succeeds(error_message: str) -> None
     fetcher._rebuild_http_client.assert_awaited_once()
 
 
-def test_fetch_gives_up_after_max_retries_with_retryable_true() -> None:
+def test_fetch_gives_up_after_max_retries_with_retryable_true(monkeypatch: pytest.MonkeyPatch) -> None:
     """Exhausting retries surfaces retryable=True for queue requeue."""
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK_ON_429", "false")
     fetcher = _build_fetcher()
     responses = [_mock_httpx_response(status_code=429, headers={"retry-after": "0"}) for _ in range(10)]
     fetcher._fetch_api = AsyncMock(side_effect=responses)
@@ -591,6 +1846,7 @@ def test_fetch_gives_up_after_max_retries_with_retryable_true() -> None:
 
 def test_fetch_retry_count_can_be_raised_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_TRANSIENT_RETRIES", "7")
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK_ON_429", "false")
     fetcher = _build_fetcher()
     responses = [_mock_httpx_response(status_code=429, headers={"retry-after": "0"}) for _ in range(10)]
     fetcher._fetch_api = AsyncMock(side_effect=responses)
@@ -630,6 +1886,16 @@ def test_reply_fetch_retry_count_can_stay_lower_than_top_level(monkeypatch: pyte
     assert fetcher.runtime_metadata["max_transient_retries"] == 9
     assert fetcher.runtime_metadata["reply_max_transient_retries"] == 2
     assert fetcher._fetch_api.await_count == 3
+
+
+def test_reply_fetch_retry_count_defaults_to_top_level_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENT_TRANSIENT_RETRIES", "9")
+    monkeypatch.delenv("SOCIAL_INSTAGRAM_COMMENT_REPLY_TRANSIENT_RETRIES", raising=False)
+
+    fetcher = _build_fetcher()
+
+    assert fetcher.runtime_metadata["max_transient_retries"] == 9
+    assert fetcher.runtime_metadata["reply_max_transient_retries"] == 9
 
 
 def test_fetch_4xx_validation_is_not_retryable() -> None:
@@ -773,6 +2039,60 @@ def test_pace_api_requests_honors_comment_delay() -> None:
     sleep_mock.assert_awaited_once_with(pytest.approx(0.15, abs=0.01))
 
 
+def test_global_api_pacing_ignores_legacy_wall_clock_lockfile(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "trr-instagram-comments-rate"
+    lock_dir.mkdir()
+    lock_path = lock_dir / "legacy.lock"
+    lock_path.write_text("1700000000.0", encoding="utf-8")
+    sleep_mock = MagicMock()
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.tempfile.gettempdir",
+        return_value=str(tmp_path),
+    ):
+        with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.time.monotonic", return_value=100.0):
+            with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.time.sleep", sleep_mock):
+                _pace_global_api_request(key="legacy", delay_seconds=1.0)
+
+    sleep_mock.assert_not_called()
+    assert float(lock_path.read_text(encoding="utf-8")) == 100.0
+
+
+def test_global_api_pacing_honors_shared_429_cooldown(tmp_path: Path) -> None:
+    sleep_mock = MagicMock()
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.tempfile.gettempdir",
+        return_value=str(tmp_path),
+    ):
+        with patch(
+            "trr_backend.socials.instagram.comments_scrapling.fetcher.time.monotonic",
+            side_effect=[100.0, 100.0, 100.0],
+        ):
+            _record_global_api_cooldown(key="shared", delay_seconds=5.0)
+            with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.time.sleep", sleep_mock):
+                _pace_global_api_request(key="shared", delay_seconds=0.0)
+
+    sleep_mock.assert_called_once_with(pytest.approx(5.0, abs=0.01))
+
+
+def test_global_api_pacing_stops_when_cooldown_exceeds_deadline(tmp_path: Path) -> None:
+    sleep_mock = MagicMock()
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.tempfile.gettempdir",
+        return_value=str(tmp_path),
+    ):
+        _record_global_api_cooldown(key="deadline", delay_seconds=5.0)
+        deadline = time.monotonic() + 0.01
+        with patch("trr_backend.socials.instagram.comments_scrapling.fetcher.time.sleep", sleep_mock):
+            paced = _pace_global_api_request(key="deadline", delay_seconds=0.0, deadline=deadline)
+
+    assert paced is False
+    sleep_mock.assert_called_once()
+    assert sleep_mock.call_args.args[0] == pytest.approx(0.01, abs=0.01)
+
+
 # ---------------------------------------------------------------------------
 # 3xx redirect handling
 # ---------------------------------------------------------------------------
@@ -908,6 +2228,7 @@ def test_3xx_redirect_to_homepage_uses_browser_api_fallback_after_recovery_retry
         "https://www.instagram.com/api/v1/media/1/comments/",
         referer="https://www.instagram.com/p/DXpWUKECX3t/",
         params={"can_support_threading": "true", "permalink_enabled": "false"},
+        deadline=None,
     )
     assert fetcher.runtime_metadata["retry_reason_counts"]["browser_api_fallback"] == 1
 
@@ -1172,7 +2493,12 @@ def test_job_runner_uses_shard_proxy_session_only_when_enabled(monkeypatch: pyte
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        return_value={
+            "id": "job-1",
+            "status": "running",
+            "worker_id": "test-worker",
+            "claimed_at": datetime(2026, 5, 1, tzinfo=UTC),
+        },
     ):
         jr.run_instagram_comments_scrapling_job(base_job, worker_id="test-worker")
         disabled_string_job = {
@@ -1211,6 +2537,24 @@ def _fake_comments_session() -> MagicMock:
     fake_session.auth_session.resolver_version = 2
     fake_session.browser_account_id = "testaccount"
     return fake_session
+
+
+def _active_comments_job_fetch_one(final_status: str = "completed"):
+    def _fake_fetch_one(sql: str, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        normalized = " ".join(str(sql or "").split()).lower()
+        if "select status, worker_id, claimed_at" in normalized:
+            return {
+                "status": "running",
+                "worker_id": "test-worker",
+                "claimed_at": datetime(2026, 5, 1, tzinfo=UTC),
+            }
+        if "select status from social.scrape_jobs" in normalized:
+            return {"status": "running"}
+        if "select status from social.scrape_runs" in normalized:
+            return {"status": "running"}
+        return {"id": "job-1", "status": final_status}
+
+    return _fake_fetch_one
 
 
 def test_job_runner_aborts_queued_sibling_shards_after_run_level_auth_failure(
@@ -1255,7 +2599,7 @@ def test_job_runner_aborts_queued_sibling_shards_after_run_level_auth_failure(
     assert finish_calls[0]["metadata"]["account"] == "thetraitorsus"
 
 
-def test_job_runner_skips_isolated_post_auth_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_job_runner_tracks_isolated_post_auth_failure_for_retry(monkeypatch: pytest.MonkeyPatch) -> None:
     from trr_backend.repositories import social_season_analytics as repo
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
     from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
@@ -1328,11 +2672,17 @@ def test_job_runner_skips_isolated_post_auth_failure(monkeypatch: pytest.MonkeyP
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "running"},
+        return_value={
+            "id": "job-1",
+            "status": "running",
+            "worker_id": "test-worker",
+            "claimed_at": datetime(2026, 5, 1, tzinfo=UTC),
+        },
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
-    assert finish_calls[-1]["status"] == "completed"
+    assert finish_calls[-1]["status"] == "failed"
+    assert finish_calls[-1]["last_error_code"] == "instagram_comments_incomplete_retryable"
     assert persist_calls == ["OKPOST"]
     metadata = finish_calls[-1]["metadata"]
     assert [sample["shortcode"] for sample in metadata["post_latency"]["samples"]] == ["AUTHFAIL", "OKPOST"]
@@ -1341,6 +2691,39 @@ def test_job_runner_skips_isolated_post_auth_failure(monkeypatch: pytest.MonkeyP
     assert metadata["post_auth_failures"]["fetch_reasons"] == {
         "AUTHFAIL": "html_challenge_or_auth_required"
     }
+    assert metadata["auth_failed_target_source_ids"] == ["AUTHFAIL"]
+    assert metadata["runtime_metadata"]["incomplete_target_source_ids"] == ["AUTHFAIL"]
+    assert metadata["retry_rebalance"]["remaining_target_source_ids"] == ["AUTHFAIL"]
+
+
+def test_job_runner_lease_check_rejects_requeued_job(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        lambda *_, **__: {"status": "retrying", "worker_id": None, "claimed_at": None},
+    )
+
+    with pytest.raises(jr.ScraplingJobLeaseLostError) as exc_info:
+        jr._raise_if_job_lease_lost(job_id="job-1", worker_id="worker-1")
+
+    assert exc_info.value.job_status == "retrying"
+    assert exc_info.value.job_worker_id is None
+
+
+def test_job_runner_lease_check_accepts_child_worker_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        lambda *_, **__: {
+            "status": "running",
+            "worker_id": "worker-parent",
+            "claimed_at": datetime(2026, 5, 1, tzinfo=UTC),
+        },
+    )
+
+    jr._raise_if_job_lease_lost(job_id="job-1", worker_id="worker-parent:p1")
 
 
 def test_job_runner_fails_after_post_auth_failure_circuit(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1396,7 +2779,12 @@ def test_job_runner_fails_after_post_auth_failure_circuit(monkeypatch: pytest.Mo
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "running"},
+        return_value={
+            "id": "job-1",
+            "status": "running",
+            "worker_id": "test-worker",
+            "claimed_at": datetime(2026, 5, 1, tzinfo=UTC),
+        },
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -1472,7 +2860,7 @@ def test_comments_job_runner_stops_before_targets_when_warmup_has_no_cookies(
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "retrying"},
+        side_effect=_active_comments_job_fetch_one("retrying"),
     ):
         payload = jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -1536,7 +2924,7 @@ def test_comments_job_runner_retries_raw_warmup_transport_error(
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "retrying"},
+        side_effect=_active_comments_job_fetch_one("retrying"),
     ):
         payload = jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -1551,6 +2939,7 @@ def test_comments_job_runner_treats_closed_ssl_connection_as_transport_error() -
     from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
 
     assert jr._is_comments_transport_error(Exception("SSL connection has been closed unexpectedly"))
+    assert jr._is_comments_transport_error(Exception("[SSL] record layer failure (_ssl.c:2590)"))
 
 
 def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1617,7 +3006,11 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
     from trr_backend.repositories import social_season_analytics as repo
 
     monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
-    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(
+        repo,
+        "_emit_job_progress",
+        lambda **_kwargs: None,
+    )
     monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
@@ -1642,7 +3035,7 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "retrying"},
+        side_effect=_active_comments_job_fetch_one("retrying"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -1653,13 +3046,430 @@ def test_job_runner_partial_progress_persists_before_error(monkeypatch: pytest.M
     assert metadata["comments_shard_index"] == 1
     assert metadata["comments_shard_count"] == 3
     assert metadata["comments_shard_target_count"] == 3
-    assert metadata["post_latency"]["sample_count"] == 2
-    assert [sample["shortcode"] for sample in metadata["post_latency"]["samples"]] == ["SHORT1", "SHORT2"]
+    assert metadata["post_latency"]["sample_count"] == 3
+    assert [sample["shortcode"] for sample in metadata["post_latency"]["samples"]] == ["SHORT1", "SHORT2", "SHORT3"]
+    assert metadata["post_latency"]["samples"][2]["completion_reason"] == "post_fetch_failed_retryable_skipped"
     assert metadata["comment_completeness"]["complete_posts"] == 2
     assert metadata["retry_rebalance"] == {
         "remaining_target_source_ids": ["SHORT3"],
         "eligible": True,
     }
+
+
+def test_job_runner_continues_after_first_retryable_post_fetch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    persist_calls: list[str] = []
+    progress_activities: list[dict[str, Any] | None] = []
+
+    def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append(shortcode)
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    fetch_results = [
+        InstagramCommentsFetchResult(
+            comments=[],
+            fetch_failed=True,
+            fetch_reason="hidden_comments_unresolved",
+            retryable=True,
+            reported_comment_count=39,
+        ),
+        InstagramCommentsFetchResult(comments=[object()], fetch_failed=False),
+        InstagramCommentsFetchResult(comments=[object()], fetch_failed=False),
+    ]
+    fetch_call_idx = {"i": 0}
+
+    async def fake_fetch_method(shortcode, *, max_comments, fetch_replies, expected_comment_count=None):
+        idx = fetch_call_idx["i"]
+        fetch_call_idx["i"] += 1
+        return fetch_results[idx]
+
+    fake_fetcher = MagicMock()
+    fake_fetcher._request_count = 3
+    fake_fetcher.warmup = AsyncMock()
+    fake_fetcher.fetch_comments_for_shortcode = fake_fetch_method
+    fake_fetcher.aclose = AsyncMock()
+    fake_fetcher.runtime_metadata = {"transport": "test"}
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: fake_fetcher)
+
+    from trr_backend.repositories import social_season_analytics as repo
+
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(
+        repo,
+        "_emit_job_progress",
+        lambda **kwargs: progress_activities.append(kwargs.get("activity")),
+    )
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2", "SHORT3"],
+            "comments_shard_index": 1,
+            "comments_shard_count": 3,
+            "comments_shard_target_count": 3,
+            "max_comments_per_post": 0,
+            "fetch_replies": False,
+            "post_fetch_failure_circuit_limit": 3,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("retrying"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert persist_calls == ["SHORT2", "SHORT3"]
+    skip_activity = progress_activities[1]
+    assert skip_activity is not None
+    assert skip_activity["posts_checked"] == 1
+    assert skip_activity["incomplete_target_source_ids"] == ["SHORT1"]
+    assert skip_activity["incomplete_fetch_reasons"] == {"SHORT1": "hidden_comments_unresolved"}
+    finish_kwargs = finish_calls[-1]
+    assert finish_kwargs["status"] == "retrying"
+    metadata = finish_kwargs["metadata"]
+    assert metadata["post_latency"]["sample_count"] == 3
+    assert [sample["shortcode"] for sample in metadata["post_latency"]["samples"]] == ["SHORT1", "SHORT2", "SHORT3"]
+    assert metadata["post_latency"]["samples"][0]["completion_reason"] == "post_fetch_failed_retryable_skipped"
+    assert metadata["post_latency"]["samples"][0]["reported_comment_count"] == 39
+    assert metadata["comment_completeness"]["complete_posts"] == 2
+    assert metadata["comment_completeness"]["incomplete_posts"] == 1
+    assert metadata["retry_rebalance"] == {
+        "remaining_target_source_ids": ["SHORT1"],
+        "eligible": True,
+    }
+    assert metadata["post_fetch_failures"]["target_source_ids"] == ["SHORT1"]
+    assert metadata["post_fetch_failures"]["fetch_reasons"] == {"SHORT1": "hidden_comments_unresolved"}
+
+
+def test_job_runner_passes_top_level_resume_cursor_from_prior_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    fetch_kwargs: list[dict[str, Any]] = []
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": 1}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, _shortcode: str, **kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_kwargs.append(dict(kwargs))
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        jr,
+        "persist_instagram_comments_for_post",
+        lambda **_kwargs: PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        ),
+    )
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: _fake_comments_session())
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(jr, "_load_expected_comment_counts", lambda **_kwargs: {})
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: True)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda **_kwargs: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "status": "retrying",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "max_comments_per_post": 0,
+            "fetch_replies": False,
+        },
+        "metadata": {
+            "top_level_checkpoints": [
+                {
+                    "target_shortcode": "SHORT1",
+                    "stop_reason": "pagination_deadline_exceeded",
+                    "next_top_level_cursor": "cursor-2",
+                    "next_top_level_cursor_param": "max_id",
+                }
+            ]
+        },
+        "attempt_count": 2,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert fetch_kwargs == [
+        {
+            "max_comments": 0,
+            "fetch_replies": False,
+            "expected_comment_count": None,
+            "top_level_cursor": "cursor-2",
+            "top_level_cursor_param": "max_id",
+        }
+    ]
+
+
+def test_job_runner_does_not_resume_terminal_repeated_top_level_cursor() -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    job = {
+        "metadata": {
+            "top_level_checkpoints": [
+                {
+                    "target_shortcode": "SHORT1",
+                    "stop_reason": "pagination_repeated_cursor",
+                    "last_top_level_cursor": "stuck-cursor",
+                    "last_top_level_cursor_param": "max_id",
+                    "next_top_level_cursor": None,
+                }
+            ]
+        }
+    }
+
+    assert jr._top_level_resume_cursors_from_job(job) == {}
+    assert jr._top_level_resume_cursor_params_from_job(job) == {}
+
+
+def test_job_runner_passes_reply_resume_cursors_from_prior_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    fetch_kwargs: list[dict[str, Any]] = []
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": 1}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, _shortcode: str, **kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_kwargs.append(dict(kwargs))
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        jr,
+        "persist_instagram_comments_for_post",
+        lambda **_kwargs: PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        ),
+    )
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: _fake_comments_session())
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(jr, "_load_expected_comment_counts", lambda **_kwargs: {})
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: True)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda **_kwargs: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "status": "retrying",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "max_comments_per_post": 0,
+            "fetch_replies": True,
+        },
+        "metadata": {
+            "fetcher_runtime": {
+                "reply_checkpoint_metadata": {
+                    "items": [
+                        {
+                            "target_shortcode": "SHORT1",
+                            "parent_comment_id": "parent-1",
+                            "stop_reason": "pagination_deadline_exceeded",
+                            "next_reply_cursor": "reply-cursor-2",
+                            "next_reply_cursor_param": "max_id",
+                        }
+                    ]
+                }
+            }
+        },
+        "attempt_count": 2,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert fetch_kwargs == [
+        {
+            "max_comments": 0,
+            "fetch_replies": True,
+            "expected_comment_count": None,
+            "reply_resume_cursors": {"parent-1": "reply-cursor-2"},
+            "reply_resume_cursor_params": {"parent-1": "max_id"},
+        }
+    ]
+
+
+def test_job_runner_uses_reply_only_retry_for_persisted_missing_reply_parents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    persisted_parent = _comment("parent-1", reply_count=3)
+    fetch_kwargs: list[dict[str, Any]] = []
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": 1}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, _shortcode: str, **kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_kwargs.append(dict(kwargs))
+            return InstagramCommentsFetchResult(
+                comments=[persisted_parent],
+                fetch_failed=True,
+                fetch_reason="reply_tail_incomplete",
+                retryable=True,
+                auth_failed=False,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        jr,
+        "persist_instagram_comments_for_post",
+        lambda **_kwargs: PersistedInstagramComments(
+            post_id="post-id",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        ),
+    )
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: _fake_comments_session())
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(jr, "_load_expected_comment_counts", lambda **_kwargs: {})
+    monkeypatch.setattr(jr, "_load_persisted_replies_by_parent", lambda **_kwargs: {})
+    monkeypatch.setattr(
+        jr,
+        "_load_persisted_top_level_comments_for_reply_retry",
+        lambda **_kwargs: [persisted_parent],
+    )
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: True)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda **_kwargs: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "status": "queued",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "max_comments_per_post": 0,
+            "fetch_replies": True,
+        },
+        "metadata": {
+            "incomplete_fetch_reasons": {
+                "SHORT1": "http_429",
+            }
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("retrying"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert fetch_kwargs == [
+        {
+            "max_comments": 0,
+            "fetch_replies": True,
+            "expected_comment_count": None,
+            "persisted_top_level_comments": [persisted_parent],
+            "reply_only": True,
+        }
+    ]
 
 
 def test_job_runner_reports_actual_comments_posts_checked(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1732,7 +3542,7 @@ def test_job_runner_reports_actual_comments_posts_checked(monkeypatch: pytest.Mo
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -1835,13 +3645,174 @@ def test_job_runner_retry_skips_already_complete_targets(monkeypatch: pytest.Mon
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
     assert fetch_calls == ["SHORT2"]
     assert persist_calls == ["SHORT2"]
     assert progress_activities[-1]["posts_checked"] == 2
+    assert finish_calls[-1]["status"] == "completed"
+    assert finish_calls[-1]["metadata"]["skipped_complete_target_source_ids"] == ["SHORT1"]
+    assert finish_calls[-1]["metadata"]["post_latency"]["samples"][0]["completion_reason"] == "already_complete"
+
+
+def test_job_runner_incomplete_fill_skips_targets_completed_by_prior_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    fetch_calls: list[str] = []
+    finish_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": 1}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, shortcode: str, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_calls.append(shortcode)
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(repo, "_instagram_filter_incomplete_comment_targets", lambda *_args, **_kwargs: ["SHORT2"])
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda **_kwargs: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "target_filter": "incomplete",
+            "incomplete_fill": True,
+            "max_comments_per_post": 10,
+            "fetch_replies": False,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert fetch_calls == ["SHORT2"]
+    assert finish_calls[-1]["status"] == "completed"
+    assert finish_calls[-1]["metadata"]["skipped_complete_target_source_ids"] == ["SHORT1"]
+    assert finish_calls[-1]["metadata"]["post_latency"]["samples"][0]["completion_reason"] == "already_complete"
+
+
+def test_job_runner_retrying_job_prefilters_complete_targets_without_retry_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    fetch_calls: list[str] = []
+    finish_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=1,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": 1}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, shortcode: str, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_calls.append(shortcode)
+            return InstagramCommentsFetchResult(comments=[object()], fetch_failed=False, auth_failed=False)
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(repo, "_instagram_filter_incomplete_comment_targets", lambda *_args, **_kwargs: ["SHORT2"])
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda **_kwargs: None)
+    monkeypatch.setattr(repo, "_finish_job", lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}))
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "status": "retrying",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1", "SHORT2"],
+            "max_comments_per_post": 10,
+            "fetch_replies": False,
+        },
+        "attempt_count": 2,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert fetch_calls == ["SHORT2"]
     assert finish_calls[-1]["status"] == "completed"
     assert finish_calls[-1]["metadata"]["skipped_complete_target_source_ids"] == ["SHORT1"]
     assert finish_calls[-1]["metadata"]["post_latency"]["samples"][0]["completion_reason"] == "already_complete"
@@ -1913,7 +3884,7 @@ def test_job_runner_marks_uncapped_success_complete(monkeypatch: pytest.MonkeyPa
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -1991,7 +3962,7 @@ def test_job_runner_keeps_capped_success_incomplete_when_local_cap_is_hit(monkey
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -2119,7 +4090,7 @@ def test_job_runner_retries_only_retryable_incomplete_posts(monkeypatch: pytest.
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "retrying"},
+        side_effect=_active_comments_job_fetch_one("retrying"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -2161,6 +4132,462 @@ def test_job_runner_retries_only_retryable_incomplete_posts(monkeypatch: pytest.
             "updated_at": "2026-04-30T12:00:00+00:00",
         },
     }
+
+
+def test_job_runner_accepts_retryable_fetch_when_stored_comment_coverage_is_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    config_update_calls: list[dict[str, Any]] = []
+    persist_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, shortcode: str, is_complete: bool, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append({"shortcode": shortcode, "is_complete": is_complete})
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=10,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 2
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(
+                comments=[
+                    InstagramComment(
+                        comment_id="c1",
+                        text="visible",
+                        username="alpha",
+                        user_id="1",
+                        created_at=1,
+                        date_time="1970-01-01T00:00:01+00:00",
+                        likes=0,
+                        is_reply=False,
+                        parent_comment_id=None,
+                        reply_count=0,
+                    )
+                ],
+                fetch_failed=True,
+                auth_failed=False,
+                fetch_reason="hidden_comments_unresolved",
+                reported_comment_count=10,
+                request_count=2,
+                retryable=True,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(repo, "_update_job_config", lambda *a, **k: config_update_calls.append(dict(k)))
+    monkeypatch.setattr(
+        repo,
+        "_finish_job",
+        lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}),
+    )
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "fetch_replies": True,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert persist_calls == [{"shortcode": "SHORT1", "is_complete": False}]
+    assert config_update_calls == []
+    assert finish_calls[-1]["status"] == "completed"
+    metadata = finish_calls[-1]["metadata"]
+    assert metadata["incomplete_target_source_ids"] == []
+    assert metadata["post_latency"]["samples"][0]["completion_reason"] == "stored_comment_coverage_complete"
+    assert metadata["post_latency"]["samples"][0]["stored_total_comments"] == 10
+
+
+def test_job_runner_reconciles_tiny_stored_reply_gap_without_retrying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    persist_calls: list[dict[str, Any]] = []
+    reconcile_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, shortcode: str, is_complete: bool, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append({"shortcode": shortcode, "is_complete": is_complete})
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=9,
+            comments_upserted=1,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 2
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(
+                comments=[
+                    InstagramComment(
+                        comment_id="c1",
+                        text="visible",
+                        username="alpha",
+                        user_id="1",
+                        created_at=1,
+                        date_time="1970-01-01T00:00:01+00:00",
+                        likes=0,
+                        is_reply=False,
+                        parent_comment_id=None,
+                        reply_count=0,
+                    )
+                ],
+                fetch_failed=True,
+                auth_failed=False,
+                fetch_reason="reply_tail_incomplete",
+                reported_comment_count=10,
+                request_count=2,
+                retryable=True,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(
+        repo,
+        "_reconcile_post_comment_count",
+        lambda **kwargs: reconcile_calls.append(kwargs) or 9,
+    )
+    monkeypatch.setattr(
+        repo,
+        "_finish_job",
+        lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}),
+    )
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "fetch_replies": True,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert persist_calls == [{"shortcode": "SHORT1", "is_complete": False}]
+    assert reconcile_calls[0]["post_db_id"] == "post-SHORT1"
+    assert finish_calls[-1]["status"] == "completed"
+    metadata = finish_calls[-1]["metadata"]
+    assert metadata["incomplete_target_source_ids"] == []
+    assert metadata["post_latency"]["samples"][0]["completion_reason"] == "stored_comment_coverage_reconciled_gap"
+    assert metadata["post_latency"]["samples"][0]["stored_total_comments"] == 9
+
+
+def test_job_runner_reconciles_high_coverage_terminal_pagination_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    persist_calls: list[dict[str, Any]] = []
+    reconcile_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, shortcode: str, is_complete: bool, **_kwargs: Any) -> PersistedInstagramComments:
+        persist_calls.append({"shortcode": shortcode, "is_complete": is_complete})
+        return PersistedInstagramComments(
+            post_id=f"post-{shortcode}",
+            stored_total_comments=910,
+            comments_upserted=10,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 8
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {"transport": "test", "request_count": self._request_count}
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(
+                comments=[
+                    InstagramComment(
+                        comment_id="c1",
+                        text="visible",
+                        username="alpha",
+                        user_id="1",
+                        created_at=1,
+                        date_time="1970-01-01T00:00:01+00:00",
+                        likes=0,
+                        is_reply=False,
+                        parent_comment_id=None,
+                        reply_count=0,
+                    )
+                ],
+                fetch_failed=True,
+                auth_failed=False,
+                fetch_reason="pagination_repeated_cursor",
+                reported_comment_count=1000,
+                request_count=8,
+                retryable=True,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(
+        repo,
+        "_reconcile_post_comment_count",
+        lambda **kwargs: reconcile_calls.append(kwargs) or 910,
+    )
+    monkeypatch.setattr(
+        repo,
+        "_finish_job",
+        lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}),
+    )
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "fetch_replies": True,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert persist_calls == [{"shortcode": "SHORT1", "is_complete": False}]
+    assert reconcile_calls[0]["post_db_id"] == "post-SHORT1"
+    assert finish_calls[-1]["status"] == "completed"
+    metadata = finish_calls[-1]["metadata"]
+    assert metadata["incomplete_target_source_ids"] == []
+    assert (
+        metadata["post_latency"]["samples"][0]["completion_reason"]
+        == "stored_comment_coverage_terminal_gap_reconciled"
+    )
+    assert metadata["post_latency"]["samples"][0]["stored_total_comments"] == 910
+
+
+def test_job_runner_reconciles_high_coverage_terminal_transient_gap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.instagram.comments_scrapling.persistence import PersistedInstagramComments
+
+    finish_calls: list[dict[str, Any]] = []
+    reconcile_calls: list[dict[str, Any]] = []
+
+    def fake_persist(*, is_complete: bool, **_kwargs: Any) -> PersistedInstagramComments:
+        assert is_complete is False
+        return PersistedInstagramComments(
+            post_id="post-SHORT1",
+            stored_total_comments=847,
+            comments_upserted=12,
+            comments_marked_missing=0,
+            comment_media_mirror_jobs_enqueued=0,
+            comment_media_mirror_job_enqueue_errors=0,
+        )
+
+    class _FakeFetcher:
+        _request_count = 14
+
+        @property
+        def runtime_metadata(self) -> dict[str, Any]:
+            return {
+                "transport": "test",
+                "request_count": self._request_count,
+                "retry_reason_counts": {"http_429": 14},
+            }
+
+        async def warmup(self) -> None:
+            return None
+
+        async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            return InstagramCommentsFetchResult(
+                comments=[
+                    InstagramComment(
+                        comment_id="c1",
+                        text="visible",
+                        username="alpha",
+                        user_id="1",
+                        created_at=1,
+                        date_time="1970-01-01T00:00:01+00:00",
+                        likes=0,
+                        is_reply=False,
+                        parent_comment_id=None,
+                        reply_count=0,
+                    )
+                ],
+                fetch_failed=True,
+                auth_failed=False,
+                fetch_reason="http_429",
+                reported_comment_count=876,
+                request_count=14,
+                retryable=True,
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    fake_session = MagicMock()
+    fake_session.cookies = []
+    fake_session.auth_session.cookies = {}
+    fake_session.auth_session.metadata = {"source": "test"}
+    fake_session.browser_account_id = "testaccount"
+
+    monkeypatch.setattr(jr, "persist_instagram_comments_for_post", fake_persist)
+    monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
+    monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
+    monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
+    monkeypatch.setattr(repo, "_new_job_progress_state", lambda: {})
+    monkeypatch.setattr(
+        repo,
+        "_reconcile_post_comment_count",
+        lambda **kwargs: reconcile_calls.append(kwargs) or 847,
+    )
+    monkeypatch.setattr(
+        repo,
+        "_finish_job",
+        lambda job_id, **kwargs: finish_calls.append({"job_id": job_id, **kwargs}),
+    )
+    monkeypatch.setattr(jr.pg, "db_connection", lambda **_kwargs: nullcontext(MagicMock()))
+
+    job = {
+        "id": "job-1",
+        "run_id": "run-1",
+        "config": {
+            "mode": "profile",
+            "account": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "fetch_replies": True,
+        },
+        "attempt_count": 1,
+        "max_attempts": 3,
+    }
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
+        side_effect=_active_comments_job_fetch_one("completed"),
+    ):
+        jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
+
+    assert reconcile_calls[0]["post_db_id"] == "post-SHORT1"
+    assert finish_calls[-1]["status"] == "completed"
+    metadata = finish_calls[-1]["metadata"]
+    assert metadata["incomplete_target_source_ids"] == []
+    assert (
+        metadata["post_latency"]["samples"][0]["completion_reason"]
+        == "stored_comment_coverage_terminal_gap_reconciled"
+    )
+    assert metadata["post_latency"]["samples"][0]["stored_total_comments"] == 847
 
 
 def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
@@ -2261,23 +4688,23 @@ def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "retrying"},
+        side_effect=_active_comments_job_fetch_one("retrying"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
-    assert persist_calls == ["SHORT1"]
+    assert persist_calls == ["SHORT1", "SHORT3"]
     assert config_update_calls == [
         {
-            "target_source_ids": ["SHORT2", "SHORT3"],
-            "comments_shard_target_count": 2,
+            "target_source_ids": ["SHORT2"],
+            "comments_shard_target_count": 1,
             "comments_retry_incomplete": True,
             "comments_retry_incomplete_source_job_id": "job-1",
         }
     ]
     assert finish_calls[-1]["status"] == "retrying"
-    assert finish_calls[-1]["last_error_code"] == "http_429"
+    assert finish_calls[-1]["last_error_code"] == "instagram_comments_incomplete_retryable"
     assert finish_calls[-1]["metadata"]["retry_rebalance"] == {
-        "remaining_target_source_ids": ["SHORT2", "SHORT3"],
+        "remaining_target_source_ids": ["SHORT2"],
         "eligible": True,
     }
 
@@ -2355,7 +4782,7 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -2373,6 +4800,10 @@ def test_job_runner_completed_metadata_reports_final_request_count(monkeypatch: 
         "incomplete_posts": 0,
         "completion_reasons": {"pagination_exhausted": 1},
     }
+    assert metadata["incomplete_target_source_ids"] == []
+    assert metadata["incomplete_fetch_reasons"] == {}
+    assert metadata["auth_failed_target_source_ids"] == []
+    assert metadata["auth_failed_fetch_reasons"] == {}
     assert metadata["timing"]["job_runner_started_at"] is not None
     assert metadata["timing"]["warmup_completed_at"] is not None
     assert metadata["timing"]["first_post_persisted_at"] is not None
@@ -2411,7 +4842,7 @@ def test_job_runner_persists_partial_success_when_auth_failed_but_comments_prese
 
         async def fetch_comments_for_shortcode(self, *_args: Any, **_kwargs: Any) -> InstagramCommentsFetchResult:
             return InstagramCommentsFetchResult(
-                comments=[object()] * 22,
+                    comments=[object() for _ in range(22)],
                 fetch_failed=False,
                 auth_failed=True,
                 fetch_reason=None,
@@ -2458,7 +4889,7 @@ def test_job_runner_persists_partial_success_when_auth_failed_but_comments_prese
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         payload = jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -2535,7 +4966,7 @@ def test_job_runner_reuses_one_db_connection_for_all_post_persists(monkeypatch: 
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -2608,7 +5039,7 @@ def test_job_runner_commits_each_post_persist(monkeypatch: pytest.MonkeyPatch) -
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        return_value={"id": "job-1", "status": "completed"},
+        side_effect=_active_comments_job_fetch_one("completed"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -2666,6 +2666,11 @@ def test_job_runner_tracks_isolated_post_auth_failure_for_retry(monkeypatch: pyt
             "max_comments_per_post": 10,
             "fetch_replies": False,
         },
+        # Phase 1.3 / audit: with max_attempts == attempt_count, the job_runner
+        # used to short-circuit can_retry to False on the first transient
+        # failure. _job_attempt_state now enforces max_attempts >= attempt_count
+        # + 1, so this row reaches "retrying" instead of "failed" — which is
+        # the correct behavior the test name (..._for_retry) already implied.
         "attempt_count": 1,
         "max_attempts": 1,
     }
@@ -2681,7 +2686,7 @@ def test_job_runner_tracks_isolated_post_auth_failure_for_retry(monkeypatch: pyt
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
-    assert finish_calls[-1]["status"] == "failed"
+    assert finish_calls[-1]["status"] == "retrying"
     assert finish_calls[-1]["last_error_code"] == "instagram_comments_incomplete_retryable"
     assert persist_calls == ["OKPOST"]
     metadata = finish_calls[-1]["metadata"]

--- a/trr_backend/repositories/social_season_analytics.py
+++ b/trr_backend/repositories/social_season_analytics.py
@@ -136,6 +136,7 @@ SOCIAL_QUEUE_STATUS_CACHE_TTL_SECONDS_DEFAULT = 20
 SOCIAL_WORKER_HEALTH_CACHE_TTL_SECONDS_DEFAULT = 5
 SOCIAL_INSTAGRAM_COOKIE_VALIDATION_TTL_SECONDS_DEFAULT = 900
 SOCIAL_INSTAGRAM_COMMENTS_TARGET_PREVIEW_CACHE_TTL_SECONDS_DEFAULT = 60
+SOCIAL_INSTAGRAM_COMMENTS_MAX_ATTEMPTS_DEFAULT = 12
 SOCIAL_INSTAGRAM_COOKIE_REFRESH_TIMEOUT_SECONDS_DEFAULT = 120
 SOCIAL_QUEUE_STATUS_STALE_FALLBACK_SECONDS_DEFAULT = 120
 SOCIAL_QUEUE_STATUS_STUCK_JOBS_LIMIT_DEFAULT = 100
@@ -10341,7 +10342,10 @@ def _set_job_running(job_id: str, *, worker_id: str | None = None) -> None:
           claimed_at = now(),
           heartbeat_at = now(),
           worker_id = coalesce(%s, worker_id),
-          attempt_count = attempt_count + 1
+          attempt_count = attempt_count + 1,
+          error_message = null,
+          last_error_code = null,
+          last_error_class = null
         where id = %s
         returning id::text
         """,
@@ -10349,23 +10353,34 @@ def _set_job_running(job_id: str, *, worker_id: str | None = None) -> None:
     )
 
 
-def _touch_job_heartbeat(job_id: str, *, worker_id: str | None = None) -> None:
-    pg.fetch_one(
+def _touch_job_heartbeat(job_id: str, *, worker_id: str | None = None) -> bool:
+    row = pg.fetch_one(
         """
         update social.scrape_jobs
         set
           heartbeat_at = now(),
           worker_id = coalesce(%s, worker_id)
         where id = %s
+          and status = 'running'
+          and claimed_at is not null
+          and (
+            %s::text is null
+            or worker_id is null
+            or worker_id = %s::text
+            or %s::text like worker_id || '%%'
+          )
         returning id::text
         """,
-        [worker_id, job_id],
+        [worker_id, job_id, worker_id, worker_id, worker_id],
     )
+    if not row:
+        return False
     _touch_worker_heartbeat_for_job(
         job_id=job_id,
         status="working",
         metadata={"source": "job_heartbeat"},
     )
+    return True
 
 
 def _job_dispatch_metadata(job_row: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -10670,7 +10685,10 @@ def _claim_job_by_id(*, job_id: str, worker_id: str) -> dict[str, Any] | None:
           claimed_at = now(),
           heartbeat_at = now(),
           worker_id = %s,
-          attempt_count = attempt_count + 1
+          attempt_count = attempt_count + 1,
+          error_message = null,
+          last_error_code = null,
+          last_error_class = null
         where id = %s::uuid
           and status in ('queued', 'pending', 'retrying')
           and available_at <= now()
@@ -10697,8 +10715,9 @@ def _update_job_progress(
     *,
     items_found: int,
     metadata: dict[str, Any] | None = None,
-) -> None:
-    pg.fetch_one(
+    worker_id: str | None = None,
+) -> bool:
+    row = pg.fetch_one(
         """
         update social.scrape_jobs
         set
@@ -10706,16 +10725,26 @@ def _update_job_progress(
           metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb,
           heartbeat_at = now()
         where id = %s
-          and status in ('queued', 'pending', 'retrying', 'running')
+          and status = 'running'
+          and claimed_at is not null
+          and (
+            %s::text is null
+            or worker_id is null
+            or worker_id = %s::text
+            or %s::text like worker_id || '%%'
+          )
         returning id::text
         """,
-        [items_found, _json_dumps(_metadata_dict(metadata)), job_id],
+        [items_found, _json_dumps(_metadata_dict(metadata)), job_id, worker_id, worker_id, worker_id],
     )
+    if not row:
+        return False
     _touch_worker_heartbeat_for_job(
         job_id=job_id,
         status="working",
         metadata={"source": "job_progress"},
     )
+    return True
 
 
 def _finish_job(
@@ -10728,6 +10757,7 @@ def _finish_job(
     last_error_code: str | None = None,
     last_error_class: str | None = None,
     next_available_at: datetime | None = None,
+    expected_worker_id: str | None = None,
 ) -> None:
     is_terminal = status in {"completed", "failed", "cancelled"}
     completed_expr = "now()" if is_terminal else "completed_at"
@@ -10762,6 +10792,17 @@ def _finish_job(
           claimed_at = case when %s = 'retrying' then null else claimed_at end
         from prior
         where social.scrape_jobs.id = prior.id
+          and (
+            %s::text is null
+            or (
+              prior.prior_status = 'running'
+              and social.scrape_jobs.claimed_at is not null
+              and (
+                social.scrape_jobs.worker_id = %s::text
+                or %s::text like social.scrape_jobs.worker_id || '%%'
+              )
+            )
+          )
         returning
           social.scrape_jobs.id::text as id,
           prior.run_id as run_id,
@@ -10780,8 +10821,19 @@ def _finish_job(
             next_available_at,
             status,
             status,
+            expected_worker_id,
+            expected_worker_id,
+            expected_worker_id,
         ],
     )
+    if not row:
+        logger.warning(
+            "[finish_job] skipped stale finish for job=%s status=%s expected_worker_id=%s",
+            job_id,
+            status,
+            expected_worker_id,
+        )
+        return
     if row and row.get("run_id"):
         try:
             _increment_run_counters_on_job_finish(
@@ -11142,7 +11194,7 @@ def _instagram_reported_comments_sql(alias: str = "p") -> str:
         f"{raw} -> 'metrics' ->> 'comments'",
     ]
     raw_expr = ", ".join(_sql_json_text_non_negative_int(expr) for expr in raw_candidates)
-    return f"greatest(coalesce({safe_alias}.comments_count, 0), {raw_expr})"
+    return f"coalesce({safe_alias}.comments_count, greatest({raw_expr}), 0)"
 
 
 def _new_job_progress_state() -> dict[str, Any]:
@@ -11176,7 +11228,9 @@ def _emit_job_progress(
     comments_upserted: int,
     activity: dict[str, Any] | None,
     progress_state: dict[str, Any],
+    worker_id: str | None = None,
     force: bool = False,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> bool:
     now = _now_utc()
     scraped_posts_value = _normalize_non_negative_int(scraped_posts)
@@ -11210,7 +11264,14 @@ def _emit_job_progress(
         },
         "activity": _build_progress_activity_payload(activity, now=now),
     }
-    _update_job_progress(job_id, items_found=items_found, metadata=metadata)
+    if extra_metadata:
+        metadata.update(_metadata_dict(extra_metadata))
+    update_kwargs: dict[str, Any] = {"items_found": items_found, "metadata": metadata}
+    if worker_id is not None:
+        update_kwargs["worker_id"] = worker_id
+    updated = _update_job_progress(job_id, **update_kwargs)
+    if updated is False:
+        return False
     progress_state["last_items_found"] = items_found
     progress_state["last_progress_at"] = now
     return True
@@ -11270,6 +11331,12 @@ def _resolve_social_job_stale_seconds(*, stage: Any = None, platform: Any = None
             max(base_seconds, 900),
             minimum=30,
         )
+    if normalized_platform == "instagram" and normalized_stage == INSTAGRAM_COMMENTS_SCRAPLING_STAGE:
+        return _resolve_positive_int_env(
+            "SOCIAL_JOB_STALE_SECONDS_INSTAGRAM_COMMENTS_SCRAPLING",
+            max(base_seconds, 1800),
+            minimum=300,
+        )
     if normalized_stage == POST_CLASSIFY_STAGE:
         return _resolve_positive_int_env(
             "SOCIAL_JOB_STALE_SECONDS_POST_CLASSIFY",
@@ -11287,7 +11354,15 @@ def _build_social_job_stale_seconds_sql_expr(
     default_seconds = _resolve_social_job_stale_seconds()
     youtube_posts_seconds = _resolve_social_job_stale_seconds(stage="posts", platform="youtube")
     youtube_comments_seconds = _resolve_social_job_stale_seconds(stage="comments", platform="youtube")
-    if youtube_posts_seconds == default_seconds and youtube_comments_seconds == default_seconds:
+    instagram_comments_seconds = _resolve_social_job_stale_seconds(
+        stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+        platform="instagram",
+    )
+    if (
+        youtube_posts_seconds == default_seconds
+        and youtube_comments_seconds == default_seconds
+        and instagram_comments_seconds == default_seconds
+    ):
         return "%s", [default_seconds]
 
     stage_expr = (
@@ -11302,9 +11377,10 @@ def _build_social_job_stale_seconds_sql_expr(
             f"when {platform_expr} = 'youtube' and ({stage_expr} = 'posts' or {stage_expr} like '%%_posts') then %s "
             f"when {platform_expr} = 'youtube' and "
             f"({stage_expr} = 'comments' or {stage_expr} like '%%_comments') then %s "
+            f"when {platform_expr} = 'instagram' and {stage_expr} = '{INSTAGRAM_COMMENTS_SCRAPLING_STAGE}' then %s "
             "else %s end"
         ),
-        [youtube_posts_seconds, youtube_comments_seconds, default_seconds],
+        [youtube_posts_seconds, youtube_comments_seconds, instagram_comments_seconds, default_seconds],
     )
 
 
@@ -11442,7 +11518,102 @@ def recover_stale_running_jobs(
             j.platform,
             coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type, '') as stage,
             lower(coalesce(j.config->>'account', j.metadata->>'account', '')) as account_handle,
-            j.worker_id as prior_worker_id
+            j.worker_id as prior_worker_id,
+            case
+              when coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type)
+                = '{INSTAGRAM_COMMENTS_SCRAPLING_STAGE}'
+              then
+                case
+                  when jsonb_typeof(j.config->'target_source_ids') = 'array'
+                  then (
+                    select coalesce(jsonb_agg(target.value order by target.ordinality), '[]'::jsonb)
+                    from jsonb_array_elements(j.config->'target_source_ids') with ordinality
+                      as target(value, ordinality)
+                    where
+                      target.ordinality > greatest(
+                        0,
+                        case
+                          when coalesce(
+                            j.metadata #>> '{{activity,posts_checked}}',
+                            j.metadata #>> '{{activity,saved_posts}}',
+                            '0'
+                          ) ~ '^[0-9]+$'
+                          then coalesce(
+                            j.metadata #>> '{{activity,posts_checked}}',
+                            j.metadata #>> '{{activity,saved_posts}}',
+                            '0'
+                          )::int
+                          else 0
+                        end
+                      )
+                      or target.value #>> '{{}}' in (
+                        select skipped.value
+                        from (
+                          select value
+                          from jsonb_array_elements_text(
+                            case
+                              when jsonb_typeof(j.metadata->'incomplete_target_source_ids') = 'array'
+                                then j.metadata->'incomplete_target_source_ids'
+                              else '[]'::jsonb
+                            end
+                          )
+                          union
+                          select value
+                          from jsonb_array_elements_text(
+                            case
+                              when jsonb_typeof(j.metadata #> '{{activity,incomplete_target_source_ids}}') = 'array'
+                                then j.metadata #> '{{activity,incomplete_target_source_ids}}'
+                              else '[]'::jsonb
+                            end
+                          )
+                          union
+                          select value
+                          from jsonb_array_elements_text(
+                            case
+                              when jsonb_typeof(j.metadata->'auth_failed_target_source_ids') = 'array'
+                                then j.metadata->'auth_failed_target_source_ids'
+                              else '[]'::jsonb
+                            end
+                          )
+                          union
+                          select value
+                          from jsonb_array_elements_text(
+                            case
+                              when jsonb_typeof(j.metadata #> '{{activity,auth_failed_target_source_ids}}') = 'array'
+                                then j.metadata #> '{{activity,auth_failed_target_source_ids}}'
+                              else '[]'::jsonb
+                            end
+                          )
+                          union
+                          select value
+                          from jsonb_array_elements_text(
+                            case
+                              when jsonb_typeof(j.metadata #> '{{post_auth_failures,target_source_ids}}') = 'array'
+                                then j.metadata #> '{{post_auth_failures,target_source_ids}}'
+                              else '[]'::jsonb
+                            end
+                          )
+                        ) as skipped(value)
+                        where nullif(btrim(skipped.value), '') is not null
+                      )
+                  )
+                  when jsonb_array_length(
+                    case
+                      when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
+                        then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
+                      else '[]'::jsonb
+                    end
+                  ) > 0
+                  then
+                    case
+                      when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
+                        then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
+                      else '[]'::jsonb
+                    end
+                  else '[]'::jsonb
+                end
+              else '[]'::jsonb
+            end as comments_recovery_target_source_ids
           from social.scrape_jobs j
           where j.status = 'running'
             and coalesce(j.heartbeat_at, j.started_at, j.claimed_at, j.created_at) <
@@ -11465,32 +11636,16 @@ def recover_stale_running_jobs(
           end,
           config = case
             when coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
-              and jsonb_array_length(
-                case
-                  when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
-                    then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
-                  else '[]'::jsonb
-                end
-              ) > 0
+              and jsonb_array_length(stale_jobs.comments_recovery_target_source_ids) > 0
             then coalesce(j.config, '{{}}'::jsonb) || jsonb_build_object(
               'target_source_ids',
-              case
-                when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
-                  then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
-                else '[]'::jsonb
-              end,
+              stale_jobs.comments_recovery_target_source_ids,
               'comments_retry_rebalance',
               true,
               'comments_retry_rebalance_source_job_id',
               j.id::text,
               'comments_shard_target_count',
-              jsonb_array_length(
-                case
-                  when jsonb_typeof(j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}') = 'array'
-                    then j.metadata #> '{{retry_rebalance,remaining_target_source_ids}}'
-                  else '[]'::jsonb
-                end
-              )
+              jsonb_array_length(stale_jobs.comments_recovery_target_source_ids)
             )
             else j.config
           end,
@@ -16450,7 +16605,13 @@ def _resolve_effective_runtime_version(
         required_execution_backend=required_execution_backend
     )
     if authoritative_runtime_version:
-        return dict(authoritative_runtime_version)
+        payload = dict(authoritative_runtime_version)
+        runtime_backend = str(payload.get("execution_backend") or required_execution_backend or "").strip().lower()
+        if runtime_backend == "modal":
+            modal_function = modal_social_job_function_name_for_stage(stage)
+            if modal_function:
+                payload["modal_function"] = modal_function
+        return payload
     if str(required_execution_backend or "").strip().lower() == "modal":
         modal_function = modal_social_job_function_name_for_stage(stage)
         return {"modal_function": modal_function} if modal_function else {}
@@ -18842,7 +19003,10 @@ def _apply_instagram_comment_queryable_columns(
     if _column_exists("social", "instagram_comments", "reply_depth"):
         payload["reply_depth"] = max(0, int(reply_depth or 0))
     if _column_exists("social", "instagram_comments", "source_snapshot_type"):
-        payload["source_snapshot_type"] = source_snapshot_type
+        payload["source_snapshot_type"] = (
+            str(getattr(comment, "source_snapshot_type", "") or source_snapshot_type).strip()
+            or source_snapshot_type
+        )
 
 
 def _upsert_instagram_comment_tree(
@@ -18926,15 +19090,24 @@ def _upsert_instagram_comment_tree(
         payload["author_is_verified"] = getattr(comment, "owner_is_verified", None)
     if _column_exists("social", "instagram_comments", "media_urls"):
         payload["media_urls"] = media_urls
+    if _column_exists("social", "instagram_comments", "hosted_media_urls"):
+        payload["hosted_media_urls"] = [
+            str(url).strip() for url in (getattr(comment, "hosted_media_urls", []) or []) if str(url).strip()
+        ]
     if media_urls and _column_exists("social", "instagram_comments", "media_mirror_status"):
         payload["media_mirror_status"] = "pending"
     if media_urls and _column_exists("social", "instagram_comments", "media_mirror_error"):
         payload["media_mirror_error"] = None
+    effective_reply_depth = _instagram_comment_effective_reply_depth(
+        comment,
+        parent_external_id=parent_comment_external_id,
+        fallback=reply_depth,
+    )
     _apply_instagram_comment_queryable_columns(
         payload,
         comment,
         parent_external_id=parent_comment_external_id,
-        reply_depth=reply_depth,
+        reply_depth=effective_reply_depth,
     )
     row = _pg_upsert("instagram_comments", payload, conflict_col=["post_id", "comment_id"], conn=conn)
     comment_db_id = (row or {}).get("id")
@@ -19011,6 +19184,19 @@ _BATCH_UPSERT_COMMENT_SIZE = _resolve_positive_int_env(
 _instagram_comment_has_profile_pic: bool | None = None
 _instagram_comment_has_verified: bool | None = None
 _instagram_comment_has_media: bool | None = None
+_instagram_comment_has_hosted_media: bool | None = None
+_instagram_comment_has_media_mirror_status: bool | None = None
+_instagram_comment_has_media_mirror_error: bool | None = None
+
+
+def _instagram_comment_effective_reply_depth(comment: Any, *, parent_external_id: str | None, fallback: int) -> int:
+    try:
+        parsed_depth = int(getattr(comment, "reply_depth", 0) or 0)
+    except (TypeError, ValueError):
+        parsed_depth = 0
+    if parsed_depth > 0 or not parent_external_id:
+        return max(0, parsed_depth)
+    return max(0, int(fallback or 0))
 
 
 def _batch_upsert_instagram_comments(
@@ -19032,7 +19218,12 @@ def _batch_upsert_instagram_comments(
     Flattens the comment tree, batch-upserts top-level comments first to get
     their DB IDs, then batch-upserts replies with parent references resolved.
     """
-    global _instagram_comment_has_media, _instagram_comment_has_profile_pic, _instagram_comment_has_verified  # noqa: PLW0603
+    global _instagram_comment_has_hosted_media  # noqa: PLW0603
+    global _instagram_comment_has_media  # noqa: PLW0603
+    global _instagram_comment_has_media_mirror_error  # noqa: PLW0603
+    global _instagram_comment_has_media_mirror_status  # noqa: PLW0603
+    global _instagram_comment_has_profile_pic  # noqa: PLW0603
+    global _instagram_comment_has_verified  # noqa: PLW0603
 
     if not comments:
         return 0
@@ -19044,6 +19235,16 @@ def _batch_upsert_instagram_comments(
         _instagram_comment_has_verified = _column_exists("social", "instagram_comments", "author_is_verified")
     if _instagram_comment_has_media is None:
         _instagram_comment_has_media = _column_exists("social", "instagram_comments", "media_urls")
+    if _instagram_comment_has_hosted_media is None:
+        _instagram_comment_has_hosted_media = _column_exists("social", "instagram_comments", "hosted_media_urls")
+    if _instagram_comment_has_media_mirror_status is None:
+        _instagram_comment_has_media_mirror_status = _column_exists(
+            "social", "instagram_comments", "media_mirror_status"
+        )
+    if _instagram_comment_has_media_mirror_error is None:
+        _instagram_comment_has_media_mirror_error = _column_exists(
+            "social", "instagram_comments", "media_mirror_error"
+        )
     has_lifecycle = _comment_lifecycle_supported("instagram_comments")
 
     # Flatten all comment trees
@@ -19101,20 +19302,27 @@ def _batch_upsert_instagram_comments(
             )
         if _instagram_comment_has_verified:
             payload["author_is_verified"] = getattr(comment_obj, "owner_is_verified", None)
+        media_urls = [str(url).strip() for url in (getattr(comment_obj, "media_urls", []) or []) if str(url).strip()]
         if _instagram_comment_has_media:
-            media_urls = [
-                str(url).strip() for url in (getattr(comment_obj, "media_urls", []) or []) if str(url).strip()
-            ]
             payload["media_urls"] = media_urls
-            if media_urls and _column_exists("social", "instagram_comments", "media_mirror_status"):
-                payload["media_mirror_status"] = "pending"
-            if media_urls and _column_exists("social", "instagram_comments", "media_mirror_error"):
-                payload["media_mirror_error"] = None
+        if _instagram_comment_has_hosted_media:
+            payload["hosted_media_urls"] = [
+                str(url).strip() for url in (getattr(comment_obj, "hosted_media_urls", []) or []) if str(url).strip()
+            ]
+        if _instagram_comment_has_media_mirror_status:
+            payload["media_mirror_status"] = "pending" if media_urls else None
+        if _instagram_comment_has_media_mirror_error:
+            payload["media_mirror_error"] = None
+        effective_reply_depth = _instagram_comment_effective_reply_depth(
+            comment_obj,
+            parent_external_id=parent_ext_id,
+            fallback=1 if parent_ext_id else 0,
+        )
         _apply_instagram_comment_queryable_columns(
             payload,
             comment_obj,
             parent_external_id=parent_ext_id,
-            reply_depth=1 if parent_ext_id else 0,
+            reply_depth=effective_reply_depth,
         )
 
         if parent_ext_id is None:
@@ -28361,7 +28569,10 @@ _ATTACHED_FOLLOWUP_ACTIVE_STATES = {"queued", "pending", "retrying", "running", 
 def _coerce_attached_followup_state_for_status(status: str | None, state: str | None) -> str | None:
     normalized_status = str(status or "").strip().lower()
     normalized_state = str(state or "").strip().lower()
-    if normalized_status in _ATTACHED_FOLLOWUP_TERMINAL_STATUSES and normalized_state in _ATTACHED_FOLLOWUP_ACTIVE_STATES:
+    if (
+        normalized_status in _ATTACHED_FOLLOWUP_TERMINAL_STATUSES
+        and normalized_state in _ATTACHED_FOLLOWUP_ACTIVE_STATES
+    ):
         return normalized_status
     return normalized_state or None
 
@@ -28597,7 +28808,11 @@ def _resolve_run_attached_followups(
         )
         comments_source = str(comments_entry.get("source") or "new_run").strip().lower()
         comments_state = str(comments_entry.get("state") or "").strip().lower() or None
-        if cancelled_or_failed_parent_status and not effective_comments_run_id and comments_source == "deferred_after_catalog":
+        if (
+            cancelled_or_failed_parent_status
+            and not effective_comments_run_id
+            and comments_source == "deferred_after_catalog"
+        ):
             effective_comments_status = cancelled_or_failed_parent_status
             comments_state = cancelled_or_failed_parent_status
         resolved["comments"] = _build_attached_comments_followup(
@@ -36211,7 +36426,10 @@ def _claim_next_jobs(
           claimed_at = now(),
           heartbeat_at = now(),
           worker_id = coalesce(%s, j.worker_id),
-          attempt_count = j.attempt_count + 1
+          attempt_count = j.attempt_count + 1,
+          error_message = null,
+          last_error_code = null,
+          last_error_class = null
         from candidate
         where j.id = candidate.id
           and j.status in ('queued', 'pending', 'retrying')
@@ -49826,6 +50044,68 @@ def _social_discussion_items_from_post_detail(
     return sorted(items, key=_social_discussion_item_sort_key, reverse=True)
 
 
+def _fetch_instagram_post_comment_detail_payload(
+    post_id: str | None,
+    *,
+    source_id: str | None = None,
+    conn: Any | None = None,
+) -> dict[str, Any] | None:
+    """Return threaded Instagram comments by materialized post id for account catalog detail reads."""
+    normalized_post_id = str(post_id or "").strip()
+    if not normalized_post_id:
+        return None
+    sql = """
+        select c.id, c.comment_id, c.parent_comment_id,
+               c.username as author,
+               c.user_id,
+               nullif(coalesce(to_jsonb(c) ->> 'author_full_name', ''), '') as author_full_name,
+               nullif(coalesce(to_jsonb(c) ->> 'author_profile_pic_url', ''), '') as author_profile_pic_url,
+               nullif(
+                 coalesce(to_jsonb(c) ->> 'hosted_author_profile_pic_url', ''),
+                 ''
+               ) as hosted_author_profile_pic_url,
+               nullif(coalesce(to_jsonb(c) ->> 'author_profile_pic_url_hd', ''), '') as author_profile_pic_url_hd,
+               case
+                 when lower(coalesce(to_jsonb(c) ->> 'author_is_verified', '')) in ('true', 'false')
+                 then (to_jsonb(c) ->> 'author_is_verified')::boolean
+                 else null
+               end as author_is_verified,
+               nullif(
+                 coalesce(to_jsonb(c) ->> 'parent_comment_external_id', ''),
+                 ''
+               ) as parent_comment_external_id,
+               nullif(coalesce(to_jsonb(c) ->> 'source_snapshot_type', ''), '') as source_snapshot_type,
+               case
+                 when coalesce(to_jsonb(c) ->> 'reply_depth', '') ~ '^[0-9]+$'
+                 then (to_jsonb(c) ->> 'reply_depth')::int
+                 else null
+               end as reply_depth,
+               c.text,
+               coalesce(c.likes, 0) as likes,
+               coalesce(c.is_reply, false) as is_reply,
+               coalesce(c.reply_count, 0) as reply_count,
+               coalesce(to_jsonb(c) -> 'media_urls', '[]'::jsonb) as media_urls,
+               coalesce(to_jsonb(c) -> 'hosted_media_urls', '[]'::jsonb) as hosted_media_urls,
+               nullif(coalesce(to_jsonb(c) ->> 'media_mirror_status', ''), '') as media_mirror_status,
+               c.created_at
+        from social.instagram_comments c
+        where c.post_id = %s
+          and coalesce(c.is_missing, false) = false
+        order by c.likes desc nulls last, c.created_at asc
+    """
+    if conn is not None:
+        with pg.db_cursor(conn=conn, label="instagram_post_comment_detail") as cur:
+            comments = pg.fetch_all_with_cursor(cur, sql, [normalized_post_id])
+    else:
+        comments = pg.fetch_all(sql, [normalized_post_id])
+    return {
+        "platform": "instagram",
+        "source_id": str(source_id or "").strip() or None,
+        "total_comments_in_db": len(comments),
+        "comments": [_serialize_comment_tree(node) for node in _thread_comments(comments)],
+    }
+
+
 def get_post_comments(
     season_id: str,
     *,
@@ -57008,6 +57288,294 @@ def _instagram_comments_stale_after_hours() -> int:
     )
 
 
+_INSTAGRAM_COMMENTS_TERMINAL_UNAVAILABLE_ERROR_CODES = (
+    INSTAGRAM_LOCAL_EXECUTOR_BLOCKED_ERROR_CODE,
+    INSTAGRAM_REMOTE_EXECUTOR_BLOCKED_ERROR_CODE,
+    STALE_MODAL_DISPATCH_UNCLAIMED_ERROR_CODE,
+    "instagram_comments_auth_failed",
+    "instagram_comments_warmup_auth_failed",
+    "instagram_comments_warmup_no_cookies",
+    "modal_dispatch_blocked",
+    "no_authenticated_modal_workers",
+)
+
+
+def _instagram_comments_target_count_expr(alias: str = "j") -> str:
+    return f"""
+        case
+          when jsonb_typeof(coalesce({alias}.config->'target_source_ids', {alias}.metadata->'target_source_ids'))
+            = 'array'
+          then jsonb_array_length(coalesce({alias}.config->'target_source_ids', {alias}.metadata->'target_source_ids'))
+          when nullif(coalesce({alias}.config->>'shortcode', {alias}.metadata->>'shortcode', ''), '') is not null
+          then 1
+          else 0
+        end
+    """
+
+
+def _instagram_social_account_comments_coverage_diagnostics(
+    account_handle: str,
+    *,
+    conn: Any | None = None,
+) -> dict[str, Any]:
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    owner_match_clause = _social_account_profile_owner_match_sql("instagram", alias="p")
+    lifecycle_supported = _call_profile_summary_loader_with_conn(
+        _comment_lifecycle_supported,
+        "instagram_comments",
+        conn=conn,
+    )
+    active_comment_condition = "c.is_missing is not true" if lifecycle_supported else "true"
+    missing_comment_condition = "c.is_missing is true" if lifecycle_supported else "false"
+    reported_comments_expr = _instagram_reported_comments_sql("p")
+    media_urls_expr = "coalesce(to_jsonb(c) -> 'media_urls', '[]'::jsonb)"
+    parent_external_expr = "nullif(coalesce(to_jsonb(c) ->> 'parent_comment_external_id', ''), '')"
+    reply_depth_expr = """
+        case
+          when coalesce(to_jsonb(c) ->> 'reply_depth', '') ~ '^[0-9]+$'
+          then (to_jsonb(c) ->> 'reply_depth')::int
+          else 0
+        end
+    """
+    reply_condition = f"""
+        coalesce(c.is_reply, false)
+        or c.parent_comment_id is not null
+        or {parent_external_expr} is not null
+        or ({reply_depth_expr}) > 0
+    """
+    job_target_count_expr = _instagram_comments_target_count_expr("j")
+    sql = f"""
+            with posts as materialized (
+              select
+                p.id,
+                {reported_comments_expr}::bigint as reported_comments
+              from social.instagram_posts p
+              where {owner_match_clause}
+                and nullif(p.shortcode, '') is not null
+            ),
+            comment_rows as materialized (
+              select
+                c.id,
+                c.post_id,
+                c.is_missing,
+                c.last_seen_at,
+                c.scraped_at,
+                ({reply_condition}) as is_reply_row,
+                case
+                  when jsonb_typeof({media_urls_expr}) = 'array'
+                  then jsonb_array_length({media_urls_expr})
+                  else 0
+                end as media_url_count
+              from social.instagram_comments c
+              join posts p on p.id = c.post_id
+            ),
+            comment_by_post as (
+              select
+                c.post_id,
+                count(c.id) filter (where {active_comment_condition})::bigint as saved_comments,
+                max(coalesce(c.last_seen_at, c.scraped_at)) as last_seen_at
+              from comment_rows c
+              group by c.post_id
+            ),
+            comment_rollup as (
+              select
+                count(c.id) filter (
+                  where {active_comment_condition}
+                    and not c.is_reply_row
+                )::bigint as saved_top_level_comments,
+                count(c.id) filter (
+                  where {active_comment_condition}
+                    and c.is_reply_row
+                )::bigint as saved_reply_comments,
+                count(c.id) filter (where {active_comment_condition})::bigint as flattened_saved_comments,
+                count(c.id) filter (
+                  where {active_comment_condition}
+                    and c.media_url_count > 0
+                )::bigint as saved_media_comments,
+                count(c.id) filter (where {missing_comment_condition})::bigint as missing_marked_comments,
+                max(coalesce(c.last_seen_at, c.scraped_at)) as last_seen_at
+              from comment_rows c
+            ),
+            post_rollup as (
+              select
+                count(*)::int as available_posts,
+                count(*) filter (where reported_comments > 0)::int as eligible_posts,
+                count(*) filter (
+                  where reported_comments > 0
+                    and coalesce(cbp.saved_comments, 0) = 0
+                )::int as missing_posts,
+                count(*) filter (
+                  where reported_comments > 0
+                    and coalesce(cbp.saved_comments, 0) > 0
+                    and (
+                      coalesce(cbp.saved_comments, 0) < reported_comments
+                      or coalesce(cbp.last_seen_at, to_timestamp(0)) < now() - make_interval(hours => %s)
+                    )
+                )::int as stale_posts,
+                coalesce(sum(reported_comments), 0)::bigint as reported_comments
+              from posts p
+              left join comment_by_post cbp on cbp.post_id = p.id
+            ),
+            comments_jobs as materialized (
+              select
+                j.id,
+                j.run_id,
+                j.status,
+                j.config,
+                j.metadata,
+                j.attempt_count,
+                j.max_attempts,
+                j.last_error_code,
+                j.error_message,
+                j.created_at as job_created_at,
+                j.started_at as job_started_at,
+                j.completed_at as job_completed_at,
+                r.status as run_status,
+                r.created_at as run_created_at,
+                r.started_at as run_started_at,
+                r.completed_at as run_completed_at,
+                {job_target_count_expr}::int as target_count,
+                lower(coalesce(j.last_error_code, j.metadata->>'error_code', '')) as error_code
+              from social.scrape_jobs j
+              left join social.scrape_runs r on r.id = j.run_id
+              where j.platform = 'instagram'
+                and coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
+                and ltrim(lower(coalesce(j.config->>'account', j.metadata->>'account', '')), '@') = %s
+            ),
+            job_rollup as (
+              select
+                coalesce(
+                  sum(
+                    case
+                      when coalesce(
+                        metadata->'fetcher_runtime'->'hidden_comments'->>'merged_comments',
+                        metadata->'runtime_metadata'->'hidden_comments'->>'merged_comments',
+                        ''
+                      ) ~ '^[0-9]+$'
+                      then coalesce(
+                        metadata->'fetcher_runtime'->'hidden_comments'->>'merged_comments',
+                        metadata->'runtime_metadata'->'hidden_comments'->>'merged_comments'
+                      )::int
+                      else 0
+                    end
+                  ),
+                  0
+                )::int as hidden_recovered_comments,
+                count(*) filter (where status in ('queued', 'pending', 'running', 'retrying'))::int
+                  as retryable_jobs,
+                coalesce(
+                  sum(target_count) filter (where status in ('queued', 'pending', 'running', 'retrying')),
+                  0
+                )::int as retryable_targets,
+                count(*) filter (
+                  where status in ('failed', 'cancelled')
+                    and (
+                      error_code = any(%s)
+                      or error_code like '%%unavailable%%'
+                      or error_code like '%%blocked%%'
+                    )
+                )::int as terminal_unavailable_jobs,
+                coalesce(
+                  sum(target_count) filter (
+                    where status in ('failed', 'cancelled')
+                      and (
+                        error_code = any(%s)
+                        or error_code like '%%unavailable%%'
+                        or error_code like '%%blocked%%'
+                      )
+                  ),
+                  0
+                )::int as terminal_unavailable_targets
+              from comments_jobs
+            ),
+            latest_job as (
+              select *
+              from comments_jobs
+              order by coalesce(run_started_at, run_created_at, job_started_at, job_created_at) desc, id desc
+              limit 1
+            )
+            select
+              pr.available_posts,
+              pr.eligible_posts,
+              pr.missing_posts,
+              pr.stale_posts,
+              pr.reported_comments,
+              coalesce(cr.saved_top_level_comments, 0)::bigint as saved_top_level_comments,
+              coalesce(cr.saved_reply_comments, 0)::bigint as saved_reply_comments,
+              coalesce(cr.flattened_saved_comments, 0)::bigint as flattened_saved_comments,
+              coalesce(cr.saved_media_comments, 0)::bigint as saved_media_comments,
+              coalesce(cr.missing_marked_comments, 0)::bigint as missing_marked_comments,
+              coalesce(jr.hidden_recovered_comments, 0)::int as hidden_recovered_comments,
+              coalesce(jr.retryable_jobs, 0)::int as retryable_jobs,
+              coalesce(jr.retryable_targets, 0)::int as retryable_targets,
+              coalesce(jr.terminal_unavailable_jobs, 0)::int as terminal_unavailable_jobs,
+              coalesce(jr.terminal_unavailable_targets, 0)::int as terminal_unavailable_targets,
+              lj.run_id::text as last_run_id,
+              lj.id::text as last_run_job_id,
+              coalesce(lj.run_status, lj.status) as last_run_status,
+              lj.status as last_job_status,
+              lj.run_created_at as last_run_created_at,
+              lj.run_started_at as last_run_started_at,
+              lj.run_completed_at as last_run_completed_at,
+              lj.job_created_at as last_job_created_at,
+              lj.job_started_at as last_job_started_at,
+              lj.job_completed_at as last_job_completed_at,
+              lj.error_code as last_error_code,
+              lj.error_message as last_error_message
+            from post_rollup pr
+            cross join comment_rollup cr
+            cross join job_rollup jr
+            left join latest_job lj on true
+            """
+    terminal_codes = list(_INSTAGRAM_COMMENTS_TERMINAL_UNAVAILABLE_ERROR_CODES)
+    params = [
+        normalized_account,
+        _instagram_comments_stale_after_hours(),
+        INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+        normalized_account,
+        terminal_codes,
+        terminal_codes,
+    ]
+    if conn is None:
+        row = pg.fetch_one(sql, params) or {}
+    else:
+        with pg.db_cursor(conn=conn, label="instagram_comments_coverage_diagnostics") as cur:
+            row = pg.fetch_one_with_cursor(cur, sql, params) or {}
+    last_run_metadata = {
+        "run_id": str(row.get("last_run_id") or "").strip() or None,
+        "job_id": str(row.get("last_run_job_id") or "").strip() or None,
+        "status": str(row.get("last_run_status") or "").strip().lower() or None,
+        "job_status": str(row.get("last_job_status") or "").strip().lower() or None,
+        "created_at": row.get("last_run_created_at") or row.get("last_job_created_at"),
+        "started_at": row.get("last_run_started_at") or row.get("last_job_started_at"),
+        "completed_at": row.get("last_run_completed_at") or row.get("last_job_completed_at"),
+        "last_error_code": str(row.get("last_error_code") or "").strip().lower() or None,
+        "error_message": str(row.get("last_error_message") or "").strip() or None,
+    }
+    if not last_run_metadata["run_id"] and not last_run_metadata["job_id"]:
+        last_run_metadata = {}
+    return {
+        "available_posts": _normalize_non_negative_int(row.get("available_posts")),
+        "eligible_posts": _normalize_non_negative_int(row.get("eligible_posts")),
+        "missing_posts": _normalize_non_negative_int(row.get("missing_posts")),
+        "stale_posts": _normalize_non_negative_int(row.get("stale_posts")),
+        "reported_comments": _normalize_non_negative_int(row.get("reported_comments")),
+        "saved_top_level_comments": _normalize_non_negative_int(row.get("saved_top_level_comments")),
+        "saved_reply_comments": _normalize_non_negative_int(row.get("saved_reply_comments")),
+        "flattened_saved_comments": _normalize_non_negative_int(row.get("flattened_saved_comments")),
+        "saved_media_comments": _normalize_non_negative_int(row.get("saved_media_comments")),
+        "hidden_recovered_comments": _normalize_non_negative_int(row.get("hidden_recovered_comments")),
+        "missing_marked_comments": _normalize_non_negative_int(row.get("missing_marked_comments")),
+        "retryable": _normalize_non_negative_int(row.get("retryable_targets")),
+        "retryable_jobs": _normalize_non_negative_int(row.get("retryable_jobs")),
+        "retryable_targets": _normalize_non_negative_int(row.get("retryable_targets")),
+        "terminal_unavailable": _normalize_non_negative_int(row.get("terminal_unavailable_targets")),
+        "terminal_unavailable_jobs": _normalize_non_negative_int(row.get("terminal_unavailable_jobs")),
+        "terminal_unavailable_targets": _normalize_non_negative_int(row.get("terminal_unavailable_targets")),
+        "last_run_metadata": last_run_metadata,
+    }
+
+
 def _instagram_social_account_comments_target_counts(
     account_handle: str,
     *,
@@ -57083,6 +57651,13 @@ def _instagram_social_account_comments_target_counts(
         "missing_posts": _normalize_non_negative_int(row.get("missing_posts")),
         "stale_posts": _normalize_non_negative_int(row.get("stale_posts")),
     }
+
+
+def get_social_account_comments_coverage_diagnostics(platform: str, account_handle: str) -> dict[str, Any]:
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    if normalized_platform != "instagram":
+        raise ValueError("Comments coverage diagnostics are currently supported for Instagram profiles.")
+    return _instagram_social_account_comments_coverage_diagnostics(account_handle)
 
 
 def _instagram_comments_target_priority(refresh_policy: str) -> str:
@@ -58126,6 +58701,44 @@ def _instagram_social_account_incomplete_comment_target_shortcodes(
     return targets
 
 
+def _instagram_comments_reported_gap_is_tolerable(*, reported_comments: int, saved_comments: int) -> bool:
+    reported = max(0, int(reported_comments or 0))
+    saved = max(0, int(saved_comments or 0))
+    unresolved_gap = max(0, reported - saved)
+    if unresolved_gap <= 0:
+        return True
+    if reported <= 0 or saved <= 0:
+        return False
+    max_absolute_gap = _resolve_int_env_with_bounds(
+        "SOCIAL_INSTAGRAM_COMMENTS_PREFILTER_GAP_MAX",
+        _resolve_int_env_with_bounds("SOCIAL_INSTAGRAM_COMMENTS_HIDDEN_UNAVAILABLE_GAP_MAX", 2, minimum=0, maximum=50),
+        minimum=0,
+        maximum=500,
+    )
+    if not os.getenv("SOCIAL_INSTAGRAM_COMMENTS_PREFILTER_GAP_MAX"):
+        max_absolute_gap = _resolve_int_env_with_bounds(
+            "SOCIAL_INSTAGRAM_COMMENTS_RECONCILABLE_GAP_MAX",
+            max_absolute_gap,
+            minimum=0,
+            maximum=500,
+        )
+    ratio_raw = (
+        os.getenv("SOCIAL_INSTAGRAM_COMMENTS_PREFILTER_GAP_RATIO")
+        or os.getenv("SOCIAL_INSTAGRAM_COMMENTS_RECONCILABLE_GAP_RATIO")
+        or os.getenv("SOCIAL_INSTAGRAM_COMMENTS_HIDDEN_UNAVAILABLE_GAP_RATIO")
+        or "0.02"
+    )
+    try:
+        max_ratio = float(ratio_raw)
+    except (TypeError, ValueError):
+        max_ratio = 0.02
+    max_ratio = max(0.0, min(max_ratio, 0.25))
+    ratio_gap = int(reported * max_ratio)
+    if ratio_gap < reported * max_ratio:
+        ratio_gap += 1
+    return unresolved_gap <= max(max_absolute_gap, ratio_gap)
+
+
 def _instagram_filter_incomplete_comment_targets(
     account_handle: str,
     target_source_ids: Sequence[Any],
@@ -58208,7 +58821,10 @@ def _instagram_filter_incomplete_comment_targets(
             continue
         reported = _normalize_non_negative_int(row.get("reported_comments"))
         saved = _normalize_non_negative_int(row.get("saved_comments"))
-        if reported > saved:
+        if reported > saved and not _instagram_comments_reported_gap_is_tolerable(
+            reported_comments=reported,
+            saved_comments=saved,
+        ):
             incomplete.append(shortcode)
     return incomplete
 
@@ -58350,6 +58966,22 @@ def _instagram_comments_profile_shard_count(target_count: int) -> int:
         return recommended
     requested = max(1, min(requested, 24))
     return min(requested, target_count)
+
+
+def _instagram_comments_job_max_attempts(config: Mapping[str, Any] | None = None) -> int:
+    raw_value = None
+    if config is not None:
+        raw_value = config.get("comments_max_attempts")
+    if raw_value is None:
+        raw_value = os.getenv("SOCIAL_INSTAGRAM_COMMENTS_MAX_ATTEMPTS")
+    raw_text = str(raw_value or "").strip()
+    if not raw_text:
+        return SOCIAL_INSTAGRAM_COMMENTS_MAX_ATTEMPTS_DEFAULT
+    try:
+        requested = int(raw_text)
+    except ValueError:
+        return SOCIAL_INSTAGRAM_COMMENTS_MAX_ATTEMPTS_DEFAULT
+    return max(1, min(requested, 12))
 
 
 def _instagram_comments_recommended_shard_count(
@@ -58546,6 +59178,7 @@ def start_social_account_comments_scrape(
             recommended_comments_shard_count = _instagram_comments_recommended_shard_count(
                 target_count=target_source_ids_count
             )
+            comments_max_attempts = _instagram_comments_job_max_attempts()
             run_status = "queued" if queue_enabled else "pending"
             run_config = {
                 "platform": normalized_platform,
@@ -58576,6 +59209,7 @@ def start_social_account_comments_scrape(
                     in {"1", "true", "yes", "on"}
                 ),
                 "recommended_comments_shard_count": recommended_comments_shard_count,
+                "comments_max_attempts": comments_max_attempts,
                 "timing": {
                     "target_enumeration_ms": target_enumeration_ms,
                     "target_source_ids_count": target_source_ids_count,
@@ -58624,6 +59258,7 @@ def start_social_account_comments_scrape(
                         initiated_by=initiated_by,
                         status=run_status,
                         priority=105,
+                        max_attempts=comments_max_attempts,
                         worker_id=inline_worker_id if comments_shard_count == 1 else None,
                         preclaim=bool(inline_worker_id and comments_shard_count == 1),
                         conn=lock_conn,
@@ -58859,6 +59494,7 @@ def rebalance_failed_instagram_comments_shard(
                 initiated_by=str(row.get("initiated_by") or "") or None,
                 status="queued",
                 priority=110,
+                max_attempts=_instagram_comments_job_max_attempts(retry_config),
             )
         )
     return {"created_job_ids": created_job_ids, "retry_group_id": retry_group_id}
@@ -58958,6 +59594,7 @@ def repair_instagram_comments_scrape_run_target_gaps(
                 initiated_by=str(run_row.get("initiated_by") or "") or None,
                 status="queued",
                 priority=108,
+                max_attempts=_instagram_comments_job_max_attempts(repair_config),
             )
         )
     if dispatch_immediately and created_job_ids:
@@ -60753,18 +61390,25 @@ def get_social_account_catalog_post_detail(
     merged_row["source_id"] = normalized_source_id
     merged_row["posted_at"] = merged_row.get("posted_at") or (catalog_row or {}).get("posted_at")
     season_id = str(merged_row.get("season_id") or "").strip() or None
+    post_id = str(merged_row.get("id") or "").strip()
     detail_payload: dict[str, Any] | None = None
     if season_id:
         try:
             detail_payload = get_post_comments(season_id, platform=normalized_platform, source_id=normalized_source_id)
         except ValueError:
             detail_payload = None
+    if detail_payload is None and normalized_platform == "instagram" and post_id:
+        detail_payload = _fetch_instagram_post_comment_detail_payload(
+            post_id,
+            source_id=normalized_source_id,
+            conn=conn,
+        )
 
     detail_discussion_items = (
         _social_discussion_items_from_post_detail(
             normalized_platform,
             detail_payload,
-            post_id=str(merged_row.get("id") or "").strip() or None,
+            post_id=post_id or None,
             post_source_id=normalized_source_id,
             post_url=_social_account_profile_post_url(
                 normalized_platform, merged_row, account_handle=normalized_account
@@ -60924,7 +61568,6 @@ def get_social_account_catalog_post_detail(
     media_urls = hosted_media_urls or source_media_urls
 
     metrics = _social_account_profile_metric_payload("instagram", merged_row)
-    post_id = str(merged_row.get("id") or "").strip()
     saved_comments = (
         _normalize_non_negative_int((detail_payload or {}).get("total_comments_in_db"))
         if detail_payload is not None
@@ -62924,8 +63567,17 @@ def launch_social_account_catalog_backfill(
         if catalog_result is not None:
             comments_deferred_until_catalog_complete = True
             catalog_run_id = str((catalog_result or {}).get("run_id") or "").strip()
-            catalog_run_row = _load_catalog_run_row_by_id(catalog_run_id) if catalog_run_id else {}
-            catalog_run_config = _metadata_dict(catalog_run_row.get("config"))
+            catalog_run_config = _metadata_dict((catalog_result or {}).get("config"))
+            if catalog_run_id and not catalog_run_config:
+                try:
+                    catalog_run_row = _load_catalog_run_row_by_id(catalog_run_id)
+                    catalog_run_config = _metadata_dict(catalog_run_row.get("config"))
+                except pg.DatabaseServiceUnavailableError as exc:
+                    logger.warning(
+                        "Continuing catalog comments followup without loaded catalog run config: run_id=%s error=%s",
+                        catalog_run_id,
+                        exc,
+                    )
             deferred_comments_followup = {
                 "state": "pending",
                 "platform": normalized_platform,
@@ -62947,17 +63599,15 @@ def launch_social_account_catalog_backfill(
                 state="pending",
             )
             if catalog_run_id and deferred_comments_followup:
-                with pg.db_connection(label="catalog-followup-merge") as conn:
-                    _merge_catalog_run_config_with_conn(
-                        conn=conn,
-                        run_id=catalog_run_id,
-                        metadata_updates={
-                            "selected_tasks": normalized_selected_tasks,
-                            "effective_selected_tasks": effective_selected_tasks,
-                            "deferred_comments_followup": deferred_comments_followup,
-                            "attached_followups": attached_followups,
-                        },
-                    )
+                _merge_catalog_run_config(
+                    run_id=catalog_run_id,
+                    metadata_updates={
+                        "selected_tasks": normalized_selected_tasks,
+                        "effective_selected_tasks": effective_selected_tasks,
+                        "deferred_comments_followup": deferred_comments_followup,
+                        "attached_followups": attached_followups,
+                    },
+                )
         else:
             comments_source = "new_run"
             try:

--- a/trr_backend/repositories/social_season_analytics.py
+++ b/trr_backend/repositories/social_season_analytics.py
@@ -19098,6 +19098,22 @@ def _upsert_instagram_comment_tree(
         payload["media_mirror_status"] = "pending"
     if media_urls and _column_exists("social", "instagram_comments", "media_mirror_error"):
         payload["media_mirror_error"] = None
+    # Phase 2: Apify-source owner-metadata columns (migration
+    # 20260501210512_instagram_comments_owner_metadata.sql).
+    if _column_exists("social", "instagram_comments", "comment_url"):
+        payload["comment_url"] = str(getattr(comment, "comment_url", "") or "").strip() or None
+    if _column_exists("social", "instagram_comments", "author_fbid_v2"):
+        payload["author_fbid_v2"] = str(getattr(comment, "owner_fbid_v2", "") or "").strip() or None
+    if _column_exists("social", "instagram_comments", "author_is_mentionable"):
+        payload["author_is_mentionable"] = getattr(comment, "owner_is_mentionable", None)
+    if _column_exists("social", "instagram_comments", "author_is_private"):
+        payload["author_is_private"] = getattr(comment, "owner_is_private", None)
+    if _column_exists("social", "instagram_comments", "author_latest_reel_media"):
+        payload["author_latest_reel_media"] = getattr(comment, "owner_latest_reel_media", None)
+    if _column_exists("social", "instagram_comments", "author_profile_pic_id"):
+        payload["author_profile_pic_id"] = (
+            str(getattr(comment, "owner_profile_pic_id", "") or "").strip() or None
+        )
     effective_reply_depth = _instagram_comment_effective_reply_depth(
         comment,
         parent_external_id=parent_comment_external_id,
@@ -19187,6 +19203,14 @@ _instagram_comment_has_media: bool | None = None
 _instagram_comment_has_hosted_media: bool | None = None
 _instagram_comment_has_media_mirror_status: bool | None = None
 _instagram_comment_has_media_mirror_error: bool | None = None
+# Phase 2: Apify-source owner-metadata column flags
+# (migration 20260501210512_instagram_comments_owner_metadata.sql).
+_instagram_comment_has_comment_url: bool | None = None
+_instagram_comment_has_author_fbid_v2: bool | None = None
+_instagram_comment_has_author_is_mentionable: bool | None = None
+_instagram_comment_has_author_is_private: bool | None = None
+_instagram_comment_has_author_latest_reel_media: bool | None = None
+_instagram_comment_has_author_profile_pic_id: bool | None = None
 
 
 def _instagram_comment_effective_reply_depth(comment: Any, *, parent_external_id: str | None, fallback: int) -> int:
@@ -19224,6 +19248,12 @@ def _batch_upsert_instagram_comments(
     global _instagram_comment_has_media_mirror_status  # noqa: PLW0603
     global _instagram_comment_has_profile_pic  # noqa: PLW0603
     global _instagram_comment_has_verified  # noqa: PLW0603
+    global _instagram_comment_has_comment_url  # noqa: PLW0603
+    global _instagram_comment_has_author_fbid_v2  # noqa: PLW0603
+    global _instagram_comment_has_author_is_mentionable  # noqa: PLW0603
+    global _instagram_comment_has_author_is_private  # noqa: PLW0603
+    global _instagram_comment_has_author_latest_reel_media  # noqa: PLW0603
+    global _instagram_comment_has_author_profile_pic_id  # noqa: PLW0603
 
     if not comments:
         return 0
@@ -19244,6 +19274,28 @@ def _batch_upsert_instagram_comments(
     if _instagram_comment_has_media_mirror_error is None:
         _instagram_comment_has_media_mirror_error = _column_exists(
             "social", "instagram_comments", "media_mirror_error"
+        )
+    if _instagram_comment_has_comment_url is None:
+        _instagram_comment_has_comment_url = _column_exists("social", "instagram_comments", "comment_url")
+    if _instagram_comment_has_author_fbid_v2 is None:
+        _instagram_comment_has_author_fbid_v2 = _column_exists(
+            "social", "instagram_comments", "author_fbid_v2"
+        )
+    if _instagram_comment_has_author_is_mentionable is None:
+        _instagram_comment_has_author_is_mentionable = _column_exists(
+            "social", "instagram_comments", "author_is_mentionable"
+        )
+    if _instagram_comment_has_author_is_private is None:
+        _instagram_comment_has_author_is_private = _column_exists(
+            "social", "instagram_comments", "author_is_private"
+        )
+    if _instagram_comment_has_author_latest_reel_media is None:
+        _instagram_comment_has_author_latest_reel_media = _column_exists(
+            "social", "instagram_comments", "author_latest_reel_media"
+        )
+    if _instagram_comment_has_author_profile_pic_id is None:
+        _instagram_comment_has_author_profile_pic_id = _column_exists(
+            "social", "instagram_comments", "author_profile_pic_id"
         )
     has_lifecycle = _comment_lifecycle_supported("instagram_comments")
 
@@ -19313,6 +19365,25 @@ def _batch_upsert_instagram_comments(
             payload["media_mirror_status"] = "pending" if media_urls else None
         if _instagram_comment_has_media_mirror_error:
             payload["media_mirror_error"] = None
+        # Phase 2: Apify-source owner-metadata column writes.
+        if _instagram_comment_has_comment_url:
+            payload["comment_url"] = (
+                str(getattr(comment_obj, "comment_url", "") or "").strip() or None
+            )
+        if _instagram_comment_has_author_fbid_v2:
+            payload["author_fbid_v2"] = (
+                str(getattr(comment_obj, "owner_fbid_v2", "") or "").strip() or None
+            )
+        if _instagram_comment_has_author_is_mentionable:
+            payload["author_is_mentionable"] = getattr(comment_obj, "owner_is_mentionable", None)
+        if _instagram_comment_has_author_is_private:
+            payload["author_is_private"] = getattr(comment_obj, "owner_is_private", None)
+        if _instagram_comment_has_author_latest_reel_media:
+            payload["author_latest_reel_media"] = getattr(comment_obj, "owner_latest_reel_media", None)
+        if _instagram_comment_has_author_profile_pic_id:
+            payload["author_profile_pic_id"] = (
+                str(getattr(comment_obj, "owner_profile_pic_id", "") or "").strip() or None
+            )
         effective_reply_depth = _instagram_comment_effective_reply_depth(
             comment_obj,
             parent_external_id=parent_ext_id,

--- a/trr_backend/socials/control_plane/run_lifecycle.py
+++ b/trr_backend/socials/control_plane/run_lifecycle.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from psycopg2 import InterfaceError, OperationalError
+from psycopg2.pool import PoolError
+
 import trr_backend.repositories.social_season_analytics as legacy
 
 SOCIAL_CONTROL_POOL_NAME = "social_control"
@@ -548,26 +551,50 @@ def _recompute_run_summary_from_jobs(run_id: str) -> dict[str, Any]:
     summary_row = (
         legacy.pg.fetch_one(
             """
-        with stats as (
+        with job_rows as (
+          select
+            j.*,
+            coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type, 'unknown') as effective_stage,
+            (
+              j.status = 'failed'
+              and j.platform = 'instagram'
+              and coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
+              and exists (
+                select 1
+                from social.scrape_jobs child
+                where child.run_id = j.run_id
+                  and child.id <> j.id
+                  and coalesce(child.config->>'stage', child.metadata->>'stage', child.job_type) =
+                    coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type)
+                  and child.config->>'comments_retry_rebalance_source_job_id' = j.id::text
+              )
+            ) as superseded_by_comments_rebalance
+          from social.scrape_jobs j
+          where j.run_id = %s
+        ),
+        effective_jobs as (
+          select *
+          from job_rows
+          where not superseded_by_comments_rebalance
+        ),
+        stats as (
           select
             count(*)::int as total_jobs,
             count(*) filter (where status = 'completed')::int as completed_jobs,
             count(*) filter (where status = 'failed')::int as failed_jobs,
             count(*) filter (where status in ('queued', 'pending', 'retrying', 'running'))::int as active_jobs,
             coalesce(sum(items_found), 0)::int as items_found_total
-          from social.scrape_jobs
-          where run_id = %s
+          from effective_jobs
         ),
         stage_stats as (
           select
-            coalesce(config->>'stage', metadata->>'stage', job_type, 'unknown') as stage,
+            effective_stage as stage,
             count(*)::int as total,
             count(*) filter (where status = 'completed')::int as completed,
             count(*) filter (where status = 'failed')::int as failed,
             count(*) filter (where status in ('queued', 'pending', 'retrying', 'running'))::int as active
-          from social.scrape_jobs
-          where run_id = %s
-          group by coalesce(config->>'stage', metadata->>'stage', job_type, 'unknown')
+          from effective_jobs
+          group by effective_stage
         )
         select
           (select row_to_json(stats) from stats) as stats,
@@ -578,7 +605,7 @@ def _recompute_run_summary_from_jobs(run_id: str) -> dict[str, Any]:
             'active', active
           )) from stage_stats), '{}'::jsonb) as stage_counts
         """,
-            [run_id, run_id],
+            [legacy.INSTAGRAM_COMMENTS_SCRAPLING_STAGE, run_id],
         )
         or {}
     )
@@ -762,6 +789,18 @@ def _finalize_run_status(run_id: str, *, force_recompute: bool = False) -> dict[
             or {}
         )
         return {"status": current.get("status", "running")}
+    except (
+        legacy.pg.DatabaseServiceUnavailableError,
+        InterfaceError,
+        OperationalError,
+        PoolError,
+    ) as exc:
+        legacy.logger.warning(
+            "[finalize_run_status] deferred after database connection failure run=%s error=%s",
+            run_id[:8],
+            exc,
+        )
+        return {"status": "finalize_deferred", "finalize_deferred": True, "error": str(exc)}
 
 
 def _finalize_run_status_locked(
@@ -796,6 +835,10 @@ def _finalize_run_status_locked(
             conn=lock_conn,
         )
     if classify_jobs_created > 0:
+        summary = _update_run_summary(run_id, force_recompute=True, conn=lock_conn)
+        active_jobs = int(summary.get("active_jobs") or 0)
+        failed_jobs = int(summary.get("failed_jobs") or 0)
+    if active_jobs <= 0 and failed_jobs > 0 and not force_recompute:
         summary = _update_run_summary(run_id, force_recompute=True, conn=lock_conn)
         active_jobs = int(summary.get("active_jobs") or 0)
         failed_jobs = int(summary.get("failed_jobs") or 0)

--- a/trr_backend/socials/instagram/comments_scrapling/counts.py
+++ b/trr_backend/socials/instagram/comments_scrapling/counts.py
@@ -1,0 +1,114 @@
+"""Comment tree helpers for the Instagram comments Scrapling lane."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+
+def _comment_id(comment: Any) -> str:
+    return str(getattr(comment, "comment_id", "") or "").strip()
+
+
+def _comment_replies(comment: Any) -> list[Any]:
+    replies = getattr(comment, "replies", None)
+    return replies if isinstance(replies, list) else []
+
+
+def _unique_count(comments: Iterable[Any]) -> int:
+    count = 0
+    seen_ids: set[str] = set()
+    for comment in comments:
+        comment_id = _comment_id(comment)
+        if not comment_id:
+            continue
+        if comment_id in seen_ids:
+            continue
+        seen_ids.add(comment_id)
+        count += 1
+    return count
+
+
+def iter_flattened_comments(comments: Iterable[Any]) -> Iterator[Any]:
+    """Yield top-level comments and all nested replies in tree order."""
+    for comment in comments:
+        yield comment
+        yield from iter_flattened_comments(_comment_replies(comment))
+
+
+def iter_reply_comments(comments: Iterable[Any]) -> Iterator[Any]:
+    """Yield all replies nested under top-level comments."""
+    for comment in comments:
+        for reply in _comment_replies(comment):
+            yield reply
+            yield from iter_flattened_comments(_comment_replies(reply))
+
+
+def top_level_count(comments: Iterable[Any]) -> int:
+    return _unique_count(comments)
+
+
+def reply_count_observed(comment: Any) -> int:
+    return _unique_count(iter_flattened_comments(_comment_replies(comment)))
+
+
+def reply_count_observed_for_tree(comments: Iterable[Any]) -> int:
+    return _unique_count(iter_reply_comments(comments))
+
+
+def flattened_comment_count(comments: Iterable[Any]) -> int:
+    return _unique_count(iter_flattened_comments(comments))
+
+
+def media_comment_count(comments: Iterable[Any]) -> int:
+    return _unique_count(
+        comment
+        for comment in iter_flattened_comments(comments)
+        if getattr(comment, "media_urls", None) or getattr(comment, "hosted_media_urls", None)
+    )
+
+
+def missing_reply_count_for_parent(comment: Any) -> int:
+    try:
+        expected = int(getattr(comment, "reply_count", 0) or 0)
+    except (TypeError, ValueError):
+        expected = 0
+    if expected <= 0:
+        return 0
+    return max(0, expected - reply_count_observed(comment))
+
+
+def missing_reply_count(comments: Iterable[Any]) -> int:
+    return sum(missing_reply_count_for_parent(comment) for comment in comments)
+
+
+def missing_parent_reply_count(comments: Iterable[Any]) -> int:
+    return sum(1 for comment in comments if missing_reply_count_for_parent(comment) > 0)
+
+
+def merge_comment_replies(
+    existing_replies: Iterable[Any],
+    fetched_replies: Iterable[Any],
+    *,
+    parent_comment_id: str | None = None,
+) -> list[Any]:
+    """Merge preview replies with fetched pages while preserving first-seen rows."""
+    merged: list[Any] = []
+    seen_ids: set[str] = set()
+    for reply in [*list(existing_replies or []), *list(fetched_replies or [])]:
+        comment_id = _comment_id(reply)
+        if comment_id:
+            if comment_id in seen_ids:
+                continue
+            seen_ids.add(comment_id)
+        if parent_comment_id and not getattr(reply, "parent_comment_id", None):
+            try:
+                reply.parent_comment_id = parent_comment_id
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            reply.is_reply = True
+        except Exception:  # noqa: BLE001
+            pass
+        merged.append(reply)
+    return merged

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -701,6 +701,56 @@ class InstagramCommentsWarmupError(RuntimeError):
 # ---------------------------------------------------------------------------
 
 
+def _failed_comment_entries_from_checkpoints(
+    *,
+    shortcode: str,
+    reply_checkpoints: list[dict[str, Any]],
+    top_level_checkpoint: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Phase 1.7: derive per-comment failure attribution from checkpoint data.
+
+    Each entry carries the parent comment id (or empty for top-level pagination
+    failures), stage, last error code and message. This is operational metadata
+    that the job runner persists into ``social.scrape_jobs.metadata.comment_failures``.
+    No new comments-table column is required.
+    """
+    entries: list[dict[str, Any]] = []
+    normalized_shortcode = str(shortcode or "").strip() or None
+    for checkpoint in reply_checkpoints or []:
+        if not isinstance(checkpoint, dict):
+            continue
+        parent_comment_id = str(checkpoint.get("parent_comment_id") or "").strip()
+        stop_reason = str(checkpoint.get("stop_reason") or checkpoint.get("last_error_code") or "").strip()
+        error_code = str(checkpoint.get("last_error_code") or stop_reason or "").strip() or None
+        if not parent_comment_id and not error_code:
+            continue
+        entries.append(
+            {
+                "comment_id": parent_comment_id or None,
+                "stage": "reply",
+                "error_code": error_code,
+                "error_message": stop_reason or None,
+                "shortcode": normalized_shortcode,
+            }
+        )
+    if isinstance(top_level_checkpoint, dict):
+        stop_reason = str(
+            top_level_checkpoint.get("stop_reason") or top_level_checkpoint.get("last_error_code") or ""
+        ).strip()
+        error_code = str(top_level_checkpoint.get("last_error_code") or stop_reason or "").strip() or None
+        if error_code:
+            entries.append(
+                {
+                    "comment_id": None,
+                    "stage": "top_level",
+                    "error_code": error_code,
+                    "error_message": stop_reason or None,
+                    "shortcode": normalized_shortcode,
+                }
+            )
+    return entries
+
+
 @dataclass(slots=True)
 class InstagramCommentsFetchResult:
     comments: list[InstagramComment] = field(default_factory=list)
@@ -712,6 +762,12 @@ class InstagramCommentsFetchResult:
     retryable: bool = False
     reply_checkpoints: list[dict[str, Any]] = field(default_factory=list)
     top_level_checkpoint: dict[str, Any] | None = None
+    # Phase 1.7: per-comment failure attribution. Each entry is
+    # {"comment_id": str, "stage": "top_level" | "reply", "error_code": str,
+    #  "error_message": str, "shortcode": str | None}. Persisted into
+    # social.scrape_jobs.metadata.comment_failures by the job runner.
+    # Operational metadata only; not promoted to a comments-table column.
+    failed_comment_ids: list[dict[str, Any]] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -1356,6 +1412,15 @@ class InstagramCommentsScraplingFetcher:
                             else "hidden_comments_unresolved"
                         )
 
+        # Phase 1.7: derive failed_comment_ids from accumulated checkpoints so
+        # the job runner can persist per-comment failure attribution into
+        # social.scrape_jobs.metadata.comment_failures without each call site
+        # having to track failures separately.
+        failed_comment_ids = _failed_comment_entries_from_checkpoints(
+            shortcode=shortcode,
+            reply_checkpoints=reply_checkpoints,
+            top_level_checkpoint=top_level_checkpoint,
+        )
         return InstagramCommentsFetchResult(
             comments=comments,
             fetch_failed=fetch_failed,
@@ -1366,6 +1431,7 @@ class InstagramCommentsScraplingFetcher:
             retryable=retryable,
             reply_checkpoints=reply_checkpoints,
             top_level_checkpoint=top_level_checkpoint,
+            failed_comment_ids=failed_comment_ids,
         )
 
     async def _fetch_persisted_reply_tails(

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -20,6 +20,7 @@ import os
 import re
 import tempfile
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -54,8 +55,14 @@ from trr_backend.socials._scrapling_http_utils import (
 from trr_backend.socials._scrapling_http_utils import (
     transport_failure_reason as _transport_failure_reason,
 )
+from trr_backend.socials.instagram.comments_scrapling.counts import (
+    flattened_comment_count,
+    merge_comment_replies,
+    missing_reply_count,
+    reply_count_observed,
+)
 from trr_backend.socials.instagram.comments_scrapling.proxy import CommentsProxyConfig
-from trr_backend.socials.instagram.constants import COMMENT_REPLIES_URL, COMMENTS_URL
+from trr_backend.socials.instagram.constants import COMMENT_REPLIES_URL, COMMENTS_URL, resolve_comment_sort_order
 from trr_backend.socials.instagram.permalink_metadata import _shortcode_to_media_id
 from trr_backend.socials.instagram.scraper import InstagramComment, InstagramScraper
 
@@ -65,13 +72,20 @@ _COMMENT_PAGINATION_MAX_PAGES_DEFAULT = 250
 _REPLY_PAGINATION_MAX_PAGES_DEFAULT = 100
 _COMMENT_PAGINATION_MAX_SECONDS_DEFAULT = 600.0
 _REPLY_PAGINATION_MAX_SECONDS_DEFAULT = 180.0
+_REPLY_TAIL_TOTAL_MAX_SECONDS_PER_POST_DEFAULT = 90.0
 _COMMENT_REQUEST_DELAY_DEFAULT = 0.25
+_COMMENT_RATE_LIMIT_COOLDOWN_MIN_SECONDS_DEFAULT = 15.0
+_COMMENT_RATE_LIMIT_COOLDOWN_MULTIPLIER_DEFAULT = 2.0
 _REPLY_CHECKPOINT_MAX_ITEMS_DEFAULT = 25
 _REPLY_CHECKPOINT_STRING_MAX_LENGTH = 256
 _BROWSER_API_FALLBACK_ENV = "SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK"
+_BROWSER_API_FALLBACK_ON_429_ENV = "SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK_ON_429"
+_BROWSER_API_FALLBACK_ON_429_ATTEMPT_ENV = "SOCIAL_INSTAGRAM_COMMENTS_BROWSER_API_FALLBACK_ON_429_ATTEMPT"
 _REVEAL_HIDDEN_COMMENTS_ENV = "SOCIAL_INSTAGRAM_COMMENTS_REVEAL_HIDDEN"
 _REVEAL_HIDDEN_COMMENTS_WITHOUT_EXPECTED_ENV = "SOCIAL_INSTAGRAM_COMMENTS_REVEAL_HIDDEN_WITHOUT_EXPECTED"
 _HIDDEN_COMMENTS_CLICK_LIMIT_DEFAULT = 4
+_HIDDEN_UNAVAILABLE_GAP_MAX_DEFAULT = 2
+_HIDDEN_UNAVAILABLE_GAP_RATIO_DEFAULT = 0.02
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -92,6 +106,45 @@ _SPAN_TEXT_RE = re.compile(r"<span\b[^>]*\bdir=[\"']auto[\"'][^>]*>(.*?)</span>"
 _TIME_DATETIME_RE = re.compile(r"<time\b[^>]*\bdatetime=[\"']([^\"']+)[\"']", re.IGNORECASE)
 _PROFILE_HREF_RE = re.compile(r"href=[\"']/([^/\"?#]+)/[\"']", re.IGNORECASE)
 _LIKE_COUNT_RE = re.compile(r"\b(\d[\d,]*)\s+likes?\b", re.IGNORECASE)
+_MEDIA_SRC_RE = re.compile(r"<(?:img|video)\b[^>]*\b(?:src|poster)=[\"']([^\"']+)[\"']", re.IGNORECASE)
+
+
+class _PaginationDeadlineExceededError(Exception):
+    """Raised when request pacing/backoff would overrun a post-level deadline."""
+
+
+def _deadline_remaining_seconds(deadline: float | None) -> float | None:
+    if deadline is None:
+        return None
+    try:
+        return max(0.0, float(deadline) - time.monotonic())
+    except (TypeError, ValueError):
+        return None
+
+
+def _deadline_response(attempt_count: int) -> dict[str, Any]:
+    return {
+        "failed": True,
+        "auth_failed": False,
+        "reason": "pagination_deadline_exceeded",
+        "retryable": True,
+        "payload": None,
+        "attempt_count": max(0, int(attempt_count or 0)),
+    }
+
+
+async def _sleep_before_deadline(seconds: float, deadline: float | None) -> bool:
+    delay = max(0.0, float(seconds or 0.0))
+    remaining = _deadline_remaining_seconds(deadline)
+    if remaining is not None:
+        if remaining <= 0:
+            return False
+        if delay > remaining:
+            await asyncio.sleep(remaining)
+            return False
+    if delay > 0:
+        await asyncio.sleep(delay)
+    return _deadline_remaining_seconds(deadline) != 0.0
 
 
 def _safe_non_negative_int(value: Any) -> int | None:
@@ -126,16 +179,24 @@ def _rendered_text_is_comment_body(value: str, *, username: str | None = None) -
     return True
 
 
-def _extract_rendered_comment_username(before_permalink_html: str) -> str:
-    ignored = {
-        "accounts",
-        "explore",
-        "p",
-        "reel",
-        "reels",
-        "stories",
-        "thetraitorsus",
-    }
+_INSTAGRAM_RESERVED_PROFILE_PATHS = frozenset({"accounts", "explore", "p", "reel", "reels", "stories"})
+
+
+def _normalize_rendered_ignored_username(value: str | None) -> str:
+    return str(value or "").strip().strip("/").lower().lstrip("@")
+
+
+def _extract_rendered_comment_username(
+    before_permalink_html: str,
+    *,
+    ignored_usernames: Iterable[str] | None = None,
+) -> str:
+    ignored = set(_INSTAGRAM_RESERVED_PROFILE_PATHS)
+    ignored.update(
+        normalized
+        for normalized in (_normalize_rendered_ignored_username(value) for value in (ignored_usernames or []))
+        if normalized
+    )
     for match in reversed(list(_PROFILE_HREF_RE.finditer(str(before_permalink_html or "")))):
         username = html_lib.unescape(match.group(1)).strip().strip("/")
         if username and username.lower() not in ignored:
@@ -174,11 +235,35 @@ def _extract_rendered_comment_like_count(after_permalink_html: str) -> int:
     return int(match.group(1).replace(",", "") or 0)
 
 
+def _extract_rendered_comment_media_urls(after_permalink_html: str) -> list[str]:
+    urls: list[str] = []
+    seen: set[str] = set()
+    for match in _MEDIA_SRC_RE.finditer(str(after_permalink_html or "")[:5000]):
+        url = html_lib.unescape(str(match.group(1) or "").strip())
+        if not url:
+            continue
+        if url.startswith("//"):
+            url = f"https:{url}"
+        lowered = url.lower()
+        if not lowered.startswith(("http://", "https://")):
+            continue
+        if not any(marker in lowered for marker in ("scontent", "cdninstagram", "fbcdn", "instagram")):
+            continue
+        if url in seen:
+            continue
+        seen.add(url)
+        urls.append(url)
+        if len(urls) >= 4:
+            break
+    return urls
+
+
 def _extract_rendered_permalink_comments(
     html_text: str,
     *,
     shortcode: str,
     post_url: str,
+    ignored_usernames: Iterable[str] | None = None,
 ) -> list[InstagramComment]:
     """Extract comments visible in the rendered post DOM.
 
@@ -206,9 +291,10 @@ def _extract_rendered_permalink_comments(
         context_end = min(len(text), match.end() + 5000)
         before_permalink = text[context_start : match.start()]
         after_permalink = text[match.end() : context_end]
-        username = _extract_rendered_comment_username(before_permalink)
+        username = _extract_rendered_comment_username(before_permalink, ignored_usernames=ignored_usernames)
         comment_text = _extract_rendered_comment_text(after_permalink, username=username)
-        if not username or not comment_text:
+        media_urls = _extract_rendered_comment_media_urls(after_permalink)
+        if not username or (not comment_text and not media_urls):
             continue
         created_at = _extract_rendered_comment_created_at(after_permalink)
         seen_comment_ids.add(comment_id)
@@ -228,6 +314,9 @@ def _extract_rendered_permalink_comments(
                 reply_count=0,
                 post_shortcode=normalized_shortcode,
                 post_url=post_url,
+                media_urls=media_urls,
+                is_hidden_by_instagram=True,
+                source_snapshot_type="rendered_hidden_comments",
             )
         )
     return comments
@@ -253,6 +342,169 @@ def _merge_unique_comments(
     return appended
 
 
+def _hidden_unavailable_gap_is_tolerable(*, unresolved_gap: int, target_count: int) -> bool:
+    gap = max(0, int(unresolved_gap or 0))
+    target = max(0, int(target_count or 0))
+    if gap <= 0:
+        return True
+    if target <= 0:
+        return False
+    max_absolute_gap = _resolve_positive_int_env(
+        "SOCIAL_INSTAGRAM_COMMENTS_HIDDEN_UNAVAILABLE_GAP_MAX",
+        _HIDDEN_UNAVAILABLE_GAP_MAX_DEFAULT,
+        minimum=0,
+        maximum=50,
+    )
+    max_ratio = _resolve_positive_float_env(
+        "SOCIAL_INSTAGRAM_COMMENTS_HIDDEN_UNAVAILABLE_GAP_RATIO",
+        _HIDDEN_UNAVAILABLE_GAP_RATIO_DEFAULT,
+        minimum=0.0,
+        maximum=0.25,
+    )
+    ratio_gap = int(target * max_ratio)
+    if ratio_gap < target * max_ratio:
+        ratio_gap += 1
+    return gap <= max(max_absolute_gap, ratio_gap)
+
+
+_TOP_LEVEL_PAGINATION_KEYS = frozenset(
+    {
+        "has_more_comments",
+        "has_more_headload_comments",
+        "next_min_id",
+        "next_max_id",
+    }
+)
+_REPLY_PAGINATION_KEYS = frozenset(
+    {
+        "has_more_tail_child_comments",
+        "has_more_head_child_comments",
+        "next_min_child_cursor",
+        "next_max_child_cursor",
+    }
+)
+
+
+def _pagination_only_row(row: Any, *, keys: frozenset[str]) -> bool:
+    if not isinstance(row, dict):
+        return False
+    if not keys.intersection(row):
+        return False
+    return not any(row.get(key) for key in ("id", "pk", "text", "user", "owner"))
+
+
+def _extract_page_metadata(
+    payload: Any,
+    response: dict[str, Any],
+    *,
+    keys: frozenset[str],
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    sources: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        sources.append(payload)
+    elif isinstance(payload, list):
+        sources.extend(item for item in payload if isinstance(item, dict))
+    sources.append(response)
+    for source in sources:
+        for key in keys:
+            if key in source and source.get(key) is not None:
+                metadata[key] = source.get(key)
+    return metadata
+
+
+def _extract_top_level_page(
+    payload: Any,
+    response: dict[str, Any],
+) -> tuple[list[dict[str, Any]], bool, str | None, str | None]:
+    rows: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        raw_rows = payload.get("comments") or []
+        rows = [row for row in raw_rows if isinstance(row, dict)] if isinstance(raw_rows, list) else []
+    elif isinstance(payload, list):
+        for item in payload:
+            if not isinstance(item, dict) or _pagination_only_row(item, keys=_TOP_LEVEL_PAGINATION_KEYS):
+                continue
+            nested_rows = item.get("comments")
+            if isinstance(nested_rows, list):
+                rows.extend(row for row in nested_rows if isinstance(row, dict))
+            else:
+                rows.append(item)
+
+    metadata = _extract_page_metadata(payload, response, keys=_TOP_LEVEL_PAGINATION_KEYS)
+    has_more_comments = bool(metadata.get("has_more_comments"))
+    has_more_headload = bool(metadata.get("has_more_headload_comments"))
+    next_max = metadata.get("next_max_id")
+    next_min = metadata.get("next_min_id")
+    if has_more_comments and next_max:
+        return rows, True, str(next_max), "max_id"
+    if has_more_headload and next_min:
+        return rows, True, str(next_min), "min_id"
+    if has_more_comments and next_min:
+        return rows, True, str(next_min), "min_id"
+    if has_more_headload and next_max:
+        return rows, True, str(next_max), "max_id"
+    return rows, has_more_comments or has_more_headload, None, None
+
+
+def _extract_reply_page(
+    payload: Any,
+    response: dict[str, Any],
+) -> tuple[list[dict[str, Any]], str | None, str | None]:
+    rows: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        raw_rows = payload.get("child_comments")
+        if not isinstance(raw_rows, list):
+            raw_rows = payload.get("replies")
+        rows = [row for row in raw_rows if isinstance(row, dict)] if isinstance(raw_rows, list) else []
+    elif isinstance(payload, list):
+        for item in payload:
+            if not isinstance(item, dict) or _pagination_only_row(item, keys=_REPLY_PAGINATION_KEYS):
+                continue
+            nested_rows = item.get("child_comments")
+            if not isinstance(nested_rows, list):
+                nested_rows = item.get("replies")
+            if isinstance(nested_rows, list):
+                rows.extend(row for row in nested_rows if isinstance(row, dict))
+            else:
+                rows.append(item)
+
+    metadata = _extract_page_metadata(payload, response, keys=_REPLY_PAGINATION_KEYS)
+    has_more_tail = bool(metadata.get("has_more_tail_child_comments"))
+    has_more_head = bool(metadata.get("has_more_head_child_comments"))
+    next_min = metadata.get("next_min_child_cursor")
+    next_max = metadata.get("next_max_child_cursor")
+    if (has_more_tail or has_more_head) and next_min:
+        return rows, str(next_min), "min_id"
+    if (has_more_head or has_more_tail) and next_max:
+        return rows, str(next_max), "max_id"
+    return rows, None, None
+
+
+def _expected_target_count(expected_comment_count: int | None, max_comments: int) -> int | None:
+    if expected_comment_count is None:
+        return None
+    return min(expected_comment_count, max_comments) if max_comments > 0 else expected_comment_count
+
+
+def _normalized_cursor_key(cursor_param_name: str | None, cursor: str | None) -> str | None:
+    normalized_cursor = str(cursor or "").strip()
+    if not normalized_cursor:
+        return None
+    normalized_param = str(cursor_param_name or "min_id").strip() or "min_id"
+    return f"{normalized_param}:{normalized_cursor}"
+
+
+def _has_expected_gap(
+    *,
+    expected_comment_count: int | None,
+    max_comments: int,
+    current_comment_count: int,
+) -> bool:
+    target_count = _expected_target_count(expected_comment_count, max_comments)
+    return target_count is not None and current_comment_count < target_count
+
+
 def _auth_failure_text(text: str) -> bool:
     normalized = str(text or "").strip().lower()
     return any(token in normalized for token in ("login", "checkpoint", "challenge", "accounts/login"))
@@ -272,25 +524,86 @@ def _global_rate_limit_path(key: str) -> str:
     return os.path.join(directory, f"{safe_key}.lock")
 
 
-def _pace_global_api_request(*, key: str, delay_seconds: float) -> None:
+def _global_rate_cooldown_path(key: str) -> str:
+    safe_key = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in str(key or "instagram"))
+    directory = os.path.join(tempfile.gettempdir(), "trr-instagram-comments-rate")
+    os.makedirs(directory, exist_ok=True)
+    return os.path.join(directory, f"{safe_key}.cooldown")
+
+
+def _read_monotonic_timestamp(handle: Any) -> float:
+    handle.seek(0)
+    raw_value = handle.read().strip()
+    try:
+        timestamp = float(raw_value)
+    except (TypeError, ValueError):
+        return 0.0
+    now = time.monotonic()
+    if timestamp > now + 3_600:
+        return 0.0
+    return max(0.0, timestamp)
+
+
+def _record_global_api_cooldown(*, key: str, delay_seconds: float) -> None:
     delay = max(0.0, float(delay_seconds or 0))
     if delay <= 0:
         return
+    path = _global_rate_cooldown_path(key)
+    cooldown_until = time.monotonic() + delay
+    with open(path, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            existing_until = _read_monotonic_timestamp(handle)
+            handle.seek(0)
+            handle.truncate()
+            handle.write(f"{max(existing_until, cooldown_until):.6f}")
+            handle.flush()
+            os.fsync(handle.fileno())
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _pace_global_api_request(*, key: str, delay_seconds: float, deadline: float | None = None) -> bool:
+    delay = max(0.0, float(delay_seconds or 0))
+    cooldown_path = _global_rate_cooldown_path(key)
+    with open(cooldown_path, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            cooldown_until = _read_monotonic_timestamp(handle)
+            now = time.monotonic()
+            remaining = cooldown_until - now
+            if remaining > 0:
+                deadline_remaining = _deadline_remaining_seconds(deadline)
+                if deadline_remaining is not None:
+                    if deadline_remaining <= 0:
+                        return False
+                    if remaining > deadline_remaining:
+                        time.sleep(deadline_remaining)
+                        return False
+                time.sleep(remaining)
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+    if delay <= 0:
+        return _deadline_remaining_seconds(deadline) != 0.0
+
     path = _global_rate_limit_path(key)
     with open(path, "a+", encoding="utf-8") as handle:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         try:
-            handle.seek(0)
-            raw_last_started_at = handle.read().strip()
-            try:
-                last_started_at = float(raw_last_started_at)
-            except (TypeError, ValueError):
-                last_started_at = 0.0
-            now = time.time()
+            last_started_at = _read_monotonic_timestamp(handle)
+            now = time.monotonic()
             remaining = (last_started_at + delay) - now
             if remaining > 0:
+                deadline_remaining = _deadline_remaining_seconds(deadline)
+                if deadline_remaining is not None:
+                    if deadline_remaining <= 0:
+                        return False
+                    if remaining > deadline_remaining:
+                        time.sleep(deadline_remaining)
+                        return False
                 time.sleep(remaining)
-                now = time.time()
+                now = time.monotonic()
             handle.seek(0)
             handle.truncate()
             handle.write(f"{now:.6f}")
@@ -298,6 +611,7 @@ def _pace_global_api_request(*, key: str, delay_seconds: float) -> None:
             os.fsync(handle.fileno())
         finally:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    return _deadline_remaining_seconds(deadline) != 0.0
 
 
 def _cookies_to_scrapling(cookies: dict[str, str]) -> list[dict[str, Any]]:
@@ -340,6 +654,7 @@ _TRANSPORT_FAILURE_MARKERS = (
     "wrong version number",
     "ssl:",
     "ssl connection",
+    "record layer failure",
     "closed unexpectedly",
     "proxy error",
     "proxyerror",
@@ -396,6 +711,7 @@ class InstagramCommentsFetchResult:
     request_count: int = 0
     retryable: bool = False
     reply_checkpoints: list[dict[str, Any]] = field(default_factory=list)
+    top_level_checkpoint: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +765,19 @@ class InstagramCommentsScraplingFetcher:
             if _env_truthy("SOCIAL_INSTAGRAM_COMMENT_GLOBAL_THROTTLE", True)
             else 0.0
         )
+        self._comment_sort_order = resolve_comment_sort_order()
+        self._rate_limit_cooldown_min_seconds = _resolve_positive_float_env(
+            "SOCIAL_INSTAGRAM_COMMENT_429_COOLDOWN_MIN_SEC",
+            _COMMENT_RATE_LIMIT_COOLDOWN_MIN_SECONDS_DEFAULT,
+            minimum=0.0,
+            maximum=300.0,
+        )
+        self._rate_limit_cooldown_multiplier = _resolve_positive_float_env(
+            "SOCIAL_INSTAGRAM_COMMENT_429_COOLDOWN_MULTIPLIER",
+            _COMMENT_RATE_LIMIT_COOLDOWN_MULTIPLIER_DEFAULT,
+            minimum=1.0,
+            maximum=10.0,
+        )
         self._global_rate_limit_key = _global_rate_limit_key(
             self._browser_account_id,
             self._selected_proxy_fingerprint,
@@ -461,12 +790,21 @@ class InstagramCommentsScraplingFetcher:
         )
         self._reply_max_transient_retries = _resolve_positive_int_env(
             "SOCIAL_INSTAGRAM_COMMENT_REPLY_TRANSIENT_RETRIES",
-            min(self._max_transient_retries, 3),
+            self._max_transient_retries,
             minimum=0,
             maximum=20,
         )
+        self._reply_tail_total_budget_seconds = _resolve_positive_float_env(
+            "SOCIAL_INSTAGRAM_REPLY_TAIL_TOTAL_MAX_SECONDS_PER_POST",
+            _REPLY_TAIL_TOTAL_MAX_SECONDS_PER_POST_DEFAULT,
+            minimum=0.0,
+            maximum=1_800.0,
+        )
         self._last_api_request_started_at = 0.0
         self._retry_reason_counts: dict[str, int] = {}
+        self._top_level_checkpoints: list[dict[str, Any]] = []
+        self._top_level_checkpoint_total_count = 0
+        self._top_level_checkpoint_dropped_count = 0
         self._reply_checkpoints: list[dict[str, Any]] = []
         self._reply_checkpoint_total_count = 0
         self._reply_checkpoint_dropped_count = 0
@@ -475,6 +813,12 @@ class InstagramCommentsScraplingFetcher:
         self._hidden_comments_merged = 0
         self._reply_checkpoint_max_items = _resolve_positive_int_env(
             "SOCIAL_INSTAGRAM_REPLY_CHECKPOINT_MAX_ITEMS",
+            _REPLY_CHECKPOINT_MAX_ITEMS_DEFAULT,
+            minimum=0,
+            maximum=500,
+        )
+        self._top_level_checkpoint_max_items = _resolve_positive_int_env(
+            "SOCIAL_INSTAGRAM_TOP_LEVEL_CHECKPOINT_MAX_ITEMS",
             _REPLY_CHECKPOINT_MAX_ITEMS_DEFAULT,
             minimum=0,
             maximum=500,
@@ -505,9 +849,13 @@ class InstagramCommentsScraplingFetcher:
             "proxy_session_mode": self._proxy_session_mode,
             "api_delay_seconds": self._api_delay_seconds,
             "global_api_delay_seconds": self._global_api_delay_seconds,
+            "comment_sort_order": self._comment_sort_order,
             "global_rate_limit_key": self._global_rate_limit_key,
+            "rate_limit_cooldown_min_seconds": self._rate_limit_cooldown_min_seconds,
+            "rate_limit_cooldown_multiplier": self._rate_limit_cooldown_multiplier,
             "max_transient_retries": self._max_transient_retries,
             "reply_max_transient_retries": self._reply_max_transient_retries,
+            "reply_tail_total_budget_seconds": self._reply_tail_total_budget_seconds,
             "transport": "httpx_after_browser_warmup",
             "request_count": self._request_count,
             "retry_reason_counts": dict(sorted(self._retry_reason_counts.items())),
@@ -515,6 +863,13 @@ class InstagramCommentsScraplingFetcher:
                 "render_attempts": self._hidden_comments_render_attempts,
                 "rendered_comments": self._hidden_comments_rendered_comments,
                 "merged_comments": self._hidden_comments_merged,
+            },
+            "top_level_checkpoint_metadata": {
+                "items": list(self._top_level_checkpoints),
+                "total_count": self._top_level_checkpoint_total_count,
+                "max_items": self._top_level_checkpoint_max_items,
+                "dropped_count": self._top_level_checkpoint_dropped_count,
+                "truncated": self._top_level_checkpoint_dropped_count > 0,
             },
             "reply_checkpoint_metadata": {
                 "items": list(self._reply_checkpoints),
@@ -567,6 +922,13 @@ class InstagramCommentsScraplingFetcher:
         max_comments: int,
         fetch_replies: bool,
         expected_comment_count: int | None = None,
+        top_level_cursor: str | None = None,
+        top_level_cursor_param: str | None = None,
+        reply_resume_cursors: dict[str, str] | None = None,
+        reply_resume_cursor_params: dict[str, str] | None = None,
+        persisted_replies_by_parent: dict[str, list[InstagramComment]] | None = None,
+        persisted_top_level_comments: list[InstagramComment] | None = None,
+        reply_only: bool = False,
     ) -> InstagramCommentsFetchResult:
         try:
             media_id = _shortcode_to_media_id(shortcode)
@@ -583,22 +945,49 @@ class InstagramCommentsScraplingFetcher:
         expected_comments = _safe_non_negative_int(expected_comment_count)
         post_url = f"https://www.instagram.com/p/{shortcode}/"
         comments: list[InstagramComment] = []
-        cursor: str | None = None
+        cursor: str | None = str(top_level_cursor or "").strip() or None
+        cursor_param_name = str(top_level_cursor_param or "min_id").strip() or "min_id"
+        if cursor_param_name not in {"min_id", "max_id"}:
+            cursor_param_name = "min_id"
         comments_fetched = 0
         fetch_failed = False
         auth_failed = False
         fetch_reason: str | None = None
         retryable = False
         reply_checkpoints: list[dict[str, Any]] = []
+        reply_resume_cursors_by_parent = {
+            str(parent_id or "").strip(): str(cursor_value or "").strip()
+            for parent_id, cursor_value in (reply_resume_cursors or {}).items()
+            if str(parent_id or "").strip() and str(cursor_value or "").strip()
+        }
+        reply_resume_cursor_params_by_parent = {
+            str(parent_id or "").strip(): str(cursor_param or "").strip()
+            for parent_id, cursor_param in (reply_resume_cursor_params or {}).items()
+            if str(parent_id or "").strip() and str(cursor_param or "").strip() in {"min_id", "max_id"}
+        }
+        persisted_replies_by_parent_id = {
+            str(parent_id or "").strip(): list(replies or [])
+            for parent_id, replies in (persisted_replies_by_parent or {}).items()
+            if str(parent_id or "").strip()
+        }
+        top_level_checkpoint: dict[str, Any] | None = None
         pages_seen = 0
         seen_cursors: set[str] = set()
-        reply_fetch_disabled_for_post = False
+        seen_top_level_comment_ids: set[str] = set()
+        api_top_level_complete = False
+        api_top_level_reveal_candidate = False
+        hidden_reveal_attempted = False
+        post_deadline_reached = False
         deadline = time.monotonic() + _resolve_positive_float_env(
             "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_SECONDS",
             _COMMENT_PAGINATION_MAX_SECONDS_DEFAULT,
             minimum=1.0,
             maximum=1_800.0,
         )
+        reply_tail_deadline: float | None = None
+        if fetch_replies:
+            if self._reply_tail_total_budget_seconds > 0:
+                reply_tail_deadline = min(deadline, time.monotonic() + self._reply_tail_total_budget_seconds)
         page_cap = _resolve_positive_int_env(
             "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_PAGES",
             _COMMENT_PAGINATION_MAX_PAGES_DEFAULT,
@@ -606,11 +995,40 @@ class InstagramCommentsScraplingFetcher:
             maximum=250,
         )
 
+        if reply_only and persisted_top_level_comments:
+            return await self._fetch_persisted_reply_tails(
+                shortcode=shortcode,
+                media_id=media_id,
+                post_url=post_url,
+                max_comments=max_comments,
+                fetch_replies=fetch_replies,
+                expected_comment_count=expected_comments,
+                persisted_top_level_comments=list(persisted_top_level_comments),
+                persisted_replies_by_parent_id=persisted_replies_by_parent_id,
+                reply_resume_cursors_by_parent=reply_resume_cursors_by_parent,
+                reply_resume_cursor_params_by_parent=reply_resume_cursor_params_by_parent,
+                deadline=deadline,
+                reply_tail_deadline=reply_tail_deadline,
+            )
+
         while True:
             if time.monotonic() >= deadline:
                 fetch_failed = True
                 fetch_reason = "pagination_deadline_exceeded"
                 retryable = True
+                top_level_checkpoint = self._record_top_level_checkpoint(
+                    shortcode=shortcode,
+                    media_id=media_id,
+                    stop_reason=fetch_reason,
+                    last_error_code=fetch_reason,
+                    last_top_level_cursor=cursor,
+                    next_top_level_cursor=cursor,
+                    last_top_level_cursor_param=cursor_param_name,
+                    next_top_level_cursor_param=cursor_param_name,
+                    observed_comment_count=flattened_comment_count(comments),
+                    expected_comment_count=expected_comments,
+                    pages_seen=pages_seen,
+                )
                 logger.warning("Instagram comments pagination deadline exceeded for shortcode=%s", shortcode)
                 break
             response = await self._fetch_json_response(
@@ -619,8 +1037,10 @@ class InstagramCommentsScraplingFetcher:
                 params={
                     "can_support_threading": "true",
                     "permalink_enabled": "false",
-                    **({"min_id": cursor} if cursor else {}),
+                    **({"sort_order": self._comment_sort_order} if self._comment_sort_order else {}),
+                    **({cursor_param_name: cursor} if cursor else {}),
                 },
+                deadline=deadline,
             )
             payload = response.get("payload")
             page_fetch_reason = response.get("reason")
@@ -633,40 +1053,144 @@ class InstagramCommentsScraplingFetcher:
             if page_fetch_reason and not fetch_reason:
                 fetch_reason = page_fetch_reason
             if page_fetch_failed or not isinstance(payload, (dict, list)):
+                if page_retryable:
+                    top_level_checkpoint = self._record_top_level_checkpoint(
+                        shortcode=shortcode,
+                        media_id=media_id,
+                        stop_reason=page_fetch_reason or "top_level_pagination_retryable_stop",
+                        last_error_code=page_fetch_reason,
+                        last_top_level_cursor=cursor,
+                        next_top_level_cursor=cursor,
+                        last_top_level_cursor_param=cursor_param_name,
+                        next_top_level_cursor_param=cursor_param_name,
+                        observed_comment_count=flattened_comment_count(comments),
+                        expected_comment_count=expected_comments,
+                        pages_seen=pages_seen,
+                    )
                 break
             pages_seen += 1
 
-            comment_rows = payload if isinstance(payload, list) else list(payload.get("comments") or [])
+            comment_rows, has_more, next_cursor, next_cursor_param_name = _extract_top_level_page(payload, response)
             for comment_data in comment_rows:
+                if time.monotonic() >= deadline:
+                    fetch_failed = True
+                    fetch_reason = fetch_reason or "pagination_deadline_exceeded"
+                    retryable = True
+                    post_deadline_reached = True
+                    top_level_checkpoint = self._record_top_level_checkpoint(
+                        shortcode=shortcode,
+                        media_id=media_id,
+                        stop_reason=fetch_reason,
+                        last_error_code=fetch_reason,
+                        last_top_level_cursor=cursor,
+                        next_top_level_cursor=cursor,
+                        last_top_level_cursor_param=cursor_param_name,
+                        next_top_level_cursor_param=cursor_param_name,
+                        observed_comment_count=flattened_comment_count(comments),
+                        expected_comment_count=expected_comments,
+                        pages_seen=pages_seen,
+                    )
+                    logger.warning("Instagram comments pagination deadline exceeded for shortcode=%s", shortcode)
+                    break
                 if not isinstance(comment_data, dict):
                     continue
-                comment = self._parser._parse_comment(comment_data, shortcode, post_url)
-                if (
-                    fetch_replies
-                    and not reply_fetch_disabled_for_post
-                    and comment.reply_count > 0
-                    and not comment.replies
-                ):
+                comment = self._parser.parse_comment(comment_data, shortcode, post_url)
+                comment_id = str(comment.comment_id or "").strip()
+                if comment_id:
+                    if comment_id in seen_top_level_comment_ids:
+                        continue
+                    seen_top_level_comment_ids.add(comment_id)
+                persisted_replies = persisted_replies_by_parent_id.get(comment_id)
+                if persisted_replies:
+                    comment.replies = merge_comment_replies(
+                        comment.replies,
+                        persisted_replies,
+                        parent_comment_id=comment.comment_id,
+                    )
+                observed_replies = reply_count_observed(comment)
+                if fetch_replies and comment.reply_count > observed_replies:
+                    reply_fetch_deadline = deadline
+                    if reply_tail_deadline is not None:
+                        if _deadline_remaining_seconds(reply_tail_deadline) == 0.0:
+                            checkpoint = self._record_reply_checkpoint(
+                                shortcode=shortcode,
+                                media_id=media_id,
+                                parent_comment_id=comment.comment_id,
+                                stop_reason="reply_tail_budget_exhausted",
+                                attempt_count=None,
+                                last_error_code="reply_tail_budget_exhausted",
+                                last_reply_cursor=None,
+                                next_reply_cursor=None,
+                                saved_reply_count=observed_replies,
+                                expected_reply_count=comment.reply_count,
+                                pages_seen=0,
+                            )
+                            if checkpoint:
+                                reply_checkpoints.append(checkpoint)
+                            fetch_failed = True
+                            retryable = True
+                            if not fetch_reason:
+                                fetch_reason = "reply_tail_budget_exhausted"
+                            comments.append(comment)
+                            comments_fetched += 1
+                            if max_comments > 0 and comments_fetched >= max_comments:
+                                break
+                            continue
+                        reply_fetch_deadline = min(deadline, reply_tail_deadline)
                     replies_result = await self._fetch_comment_replies(
                         media_id=media_id,
                         comment_id=comment.comment_id,
                         shortcode=shortcode,
                         post_url=post_url,
                         expected_reply_count=comment.reply_count,
+                        existing_replies=comment.replies,
+                        resume_cursor=reply_resume_cursors_by_parent.get(str(comment.comment_id or "").strip()),
+                        resume_cursor_param=reply_resume_cursor_params_by_parent.get(
+                            str(comment.comment_id or "").strip()
+                        ),
+                        deadline=reply_fetch_deadline,
                     )
-                    comment.replies = replies_result.comments
+                    if (
+                        reply_tail_deadline is not None
+                        and replies_result.fetch_reason == "pagination_deadline_exceeded"
+                        and _deadline_remaining_seconds(reply_tail_deadline) == 0.0
+                    ):
+                        replies_result.fetch_reason = "reply_tail_budget_exhausted"
+                    comment.replies = merge_comment_replies(
+                        comment.replies,
+                        replies_result.comments,
+                        parent_comment_id=comment.comment_id,
+                    )
                     reply_checkpoints.extend(replies_result.reply_checkpoints)
                     fetch_failed = fetch_failed or replies_result.fetch_failed
                     auth_failed = auth_failed or replies_result.auth_failed
                     retryable = retryable or replies_result.retryable
                     if replies_result.fetch_reason and not fetch_reason:
                         fetch_reason = replies_result.fetch_reason
-                    if replies_result.fetch_failed and replies_result.retryable:
-                        reply_fetch_disabled_for_post = True
-                        self._record_retry_reason("reply_fetch_circuit_open")
+                    if (
+                        replies_result.fetch_failed
+                        and replies_result.retryable
+                        and not replies_result.reply_checkpoints
+                    ):
+                        checkpoint = self._record_reply_checkpoint(
+                            shortcode=shortcode,
+                            media_id=media_id,
+                            parent_comment_id=comment.comment_id,
+                            stop_reason=replies_result.fetch_reason or "reply_pagination_retryable_stop",
+                            attempt_count=None,
+                            last_error_code=replies_result.fetch_reason,
+                            last_reply_cursor=None,
+                            next_reply_cursor=None,
+                            saved_reply_count=reply_count_observed(comment),
+                            expected_reply_count=comment.reply_count,
+                            pages_seen=0,
+                        )
+                        if checkpoint:
+                            reply_checkpoints.append(checkpoint)
                         logger.warning(
-                            "Instagram comments reply fetch circuit opened for shortcode=%s reason=%s",
+                            "Instagram comments reply fetch stopped for shortcode=%s parent_comment_id=%s reason=%s",
                             shortcode,
+                            comment.comment_id,
                             replies_result.fetch_reason,
                         )
                 comments.append(comment)
@@ -674,19 +1198,51 @@ class InstagramCommentsScraplingFetcher:
                 if max_comments > 0 and comments_fetched >= max_comments:
                     break
 
+            if post_deadline_reached:
+                break
             if max_comments > 0 and comments_fetched >= max_comments:
                 break
             if not isinstance(payload, dict):
-                break
-            has_more = bool(payload.get("has_more_comments", False)) or bool(payload.get("has_more_headload_comments"))
-            next_cursor = payload.get("next_min_id") or payload.get("next_max_id")
+                if has_more and next_cursor:
+                    pass
+                else:
+                    api_top_level_complete = True
+                    break
             if not has_more or not next_cursor:
+                api_top_level_complete = True
                 break
             next_cursor = str(next_cursor)
-            if next_cursor == cursor or next_cursor in seen_cursors:
-                fetch_failed = True
+            next_cursor_param_name = str(next_cursor_param_name or "min_id").strip() or "min_id"
+            if next_cursor_param_name not in {"min_id", "max_id"}:
+                next_cursor_param_name = "min_id"
+            next_cursor_key = _normalized_cursor_key(next_cursor_param_name, next_cursor)
+            current_cursor_key = _normalized_cursor_key(cursor_param_name, cursor)
+            if next_cursor_key == current_cursor_key or (next_cursor_key and next_cursor_key in seen_cursors):
+                has_gap = _has_expected_gap(
+                    expected_comment_count=expected_comments,
+                    max_comments=max_comments,
+                    current_comment_count=flattened_comment_count(comments),
+                )
+                if expected_comments is None:
+                    has_gap = True
+                fetch_failed = fetch_failed or has_gap
                 fetch_reason = "pagination_repeated_cursor"
-                retryable = True
+                retryable = retryable or has_gap
+                api_top_level_reveal_candidate = api_top_level_reveal_candidate or has_gap
+                if has_gap:
+                    top_level_checkpoint = self._record_top_level_checkpoint(
+                        shortcode=shortcode,
+                        media_id=media_id,
+                        stop_reason=fetch_reason,
+                        last_error_code=fetch_reason,
+                        last_top_level_cursor=cursor,
+                        next_top_level_cursor=None,
+                        last_top_level_cursor_param=cursor_param_name,
+                        next_top_level_cursor_param=None,
+                        observed_comment_count=flattened_comment_count(comments),
+                        expected_comment_count=expected_comments,
+                        pages_seen=pages_seen,
+                    )
                 logger.warning(
                     "Instagram comments pagination repeated cursor for shortcode=%s cursor=%s",
                     shortcode,
@@ -694,24 +1250,51 @@ class InstagramCommentsScraplingFetcher:
                 )
                 break
             if pages_seen >= page_cap:
-                fetch_failed = True
+                has_gap = _has_expected_gap(
+                    expected_comment_count=expected_comments,
+                    max_comments=max_comments,
+                    current_comment_count=flattened_comment_count(comments),
+                )
+                if expected_comments is None:
+                    has_gap = True
+                fetch_failed = fetch_failed or has_gap
                 fetch_reason = "pagination_page_cap_reached"
-                retryable = True
+                retryable = retryable or has_gap
+                api_top_level_reveal_candidate = api_top_level_reveal_candidate or has_gap
+                if has_gap:
+                    top_level_checkpoint = self._record_top_level_checkpoint(
+                        shortcode=shortcode,
+                        media_id=media_id,
+                        stop_reason=fetch_reason,
+                        last_error_code=fetch_reason,
+                        last_top_level_cursor=cursor,
+                        next_top_level_cursor=next_cursor,
+                        last_top_level_cursor_param=cursor_param_name,
+                        next_top_level_cursor_param=next_cursor_param_name,
+                        observed_comment_count=flattened_comment_count(comments),
+                        expected_comment_count=expected_comments,
+                        pages_seen=pages_seen,
+                    )
                 logger.warning(
                     "Instagram comments pagination page cap reached for shortcode=%s page_cap=%d",
                     shortcode,
                     page_cap,
                 )
                 break
-            seen_cursors.add(next_cursor)
+            if next_cursor_key:
+                seen_cursors.add(next_cursor_key)
             cursor = next_cursor
+            cursor_param_name = next_cursor_param_name
 
         if self._should_reveal_hidden_comments(
             expected_comment_count=expected_comments,
-            current_comment_count=len(comments),
+            current_comment_count=flattened_comment_count(comments),
+            missing_reply_count=missing_reply_count(comments),
             max_comments=max_comments,
             auth_failed=auth_failed,
+            api_top_level_complete=api_top_level_complete or api_top_level_reveal_candidate,
         ):
+            hidden_reveal_attempted = True
             hidden_comments = await self._fetch_rendered_comments_after_revealing_hidden(shortcode, post_url)
             merged_count = _merge_unique_comments(comments, hidden_comments, max_comments=max_comments)
             self._hidden_comments_merged += merged_count
@@ -719,15 +1302,59 @@ class InstagramCommentsScraplingFetcher:
                 logger.info(
                     "Merged %d rendered hidden Instagram comment(s) for shortcode=%s",
                     merged_count,
-                    shortcode,
-                )
+                        shortcode,
+                    )
+            if api_top_level_reveal_candidate and fetch_reason in {
+                "pagination_repeated_cursor",
+                "pagination_page_cap_reached",
+            }:
+                target_count = _expected_target_count(expected_comments, max_comments)
+                current_flattened_count = flattened_comment_count(comments)
+                if target_count is not None and current_flattened_count >= target_count and not missing_reply_count(
+                    comments
+                ):
+                    fetch_failed = False
+                    retryable = False
+                    fetch_reason = "hidden_comments_recovered"
 
-        if expected_comments is not None and (max_comments <= 0 or expected_comments <= max_comments):
-            if not auth_failed and len(comments) < expected_comments:
-                fetch_failed = True
-                retryable = True
-                if not fetch_reason:
-                    fetch_reason = "hidden_comments_unresolved"
+        target_count = _expected_target_count(expected_comments, max_comments)
+        if target_count is not None and (max_comments <= 0 or expected_comments <= max_comments):
+            current_flattened_count = flattened_comment_count(comments)
+            current_missing_reply_count = missing_reply_count(comments)
+            if not auth_failed and current_flattened_count >= target_count and current_missing_reply_count == 0:
+                fetch_failed = False
+                retryable = False
+                if fetch_reason in {
+                    "hidden_comments_unresolved",
+                    "pagination_deadline_exceeded",
+                    "pagination_page_cap_reached",
+                    "pagination_repeated_cursor",
+                    "reply_tail_incomplete",
+                }:
+                    fetch_reason = "coverage_target_met"
+            elif not auth_failed and current_flattened_count < target_count:
+                unresolved_gap = target_count - current_flattened_count
+                if (
+                    hidden_reveal_attempted
+                    and api_top_level_complete
+                    and current_missing_reply_count == 0
+                    and _hidden_unavailable_gap_is_tolerable(
+                        unresolved_gap=unresolved_gap,
+                        target_count=target_count,
+                    )
+                ):
+                    fetch_failed = False
+                    retryable = False
+                    fetch_reason = "hidden_comments_unavailable_reconciled"
+                else:
+                    fetch_failed = True
+                    retryable = True
+                    if not fetch_reason:
+                        fetch_reason = (
+                            "reply_tail_incomplete"
+                            if current_missing_reply_count > 0
+                            else "hidden_comments_unresolved"
+                        )
 
         return InstagramCommentsFetchResult(
             comments=comments,
@@ -738,6 +1365,156 @@ class InstagramCommentsScraplingFetcher:
             request_count=self._request_count,
             retryable=retryable,
             reply_checkpoints=reply_checkpoints,
+            top_level_checkpoint=top_level_checkpoint,
+        )
+
+    async def _fetch_persisted_reply_tails(
+        self,
+        *,
+        shortcode: str,
+        media_id: str,
+        post_url: str,
+        max_comments: int,
+        fetch_replies: bool,
+        expected_comment_count: int | None,
+        persisted_top_level_comments: list[InstagramComment],
+        persisted_replies_by_parent_id: dict[str, list[InstagramComment]],
+        reply_resume_cursors_by_parent: dict[str, str],
+        reply_resume_cursor_params_by_parent: dict[str, str],
+        deadline: float,
+        reply_tail_deadline: float | None,
+    ) -> InstagramCommentsFetchResult:
+        comments: list[InstagramComment] = []
+        fetch_failed = False
+        auth_failed = False
+        fetch_reason: str | None = None
+        retryable = False
+        reply_checkpoints: list[dict[str, Any]] = []
+        comments_fetched = 0
+
+        for comment in persisted_top_level_comments:
+            if time.monotonic() >= deadline:
+                fetch_failed = True
+                retryable = True
+                fetch_reason = fetch_reason or "pagination_deadline_exceeded"
+                break
+            comment.post_shortcode = comment.post_shortcode or shortcode
+            comment.post_url = comment.post_url or post_url
+            comment_id = str(comment.comment_id or "").strip()
+            persisted_replies = persisted_replies_by_parent_id.get(comment_id)
+            if persisted_replies:
+                comment.replies = merge_comment_replies(
+                    comment.replies,
+                    persisted_replies,
+                    parent_comment_id=comment.comment_id,
+                )
+            observed_replies = reply_count_observed(comment)
+            if fetch_replies and comment.reply_count > observed_replies:
+                reply_fetch_deadline = deadline
+                if reply_tail_deadline is not None:
+                    if _deadline_remaining_seconds(reply_tail_deadline) == 0.0:
+                        checkpoint = self._record_reply_checkpoint(
+                            shortcode=shortcode,
+                            media_id=media_id,
+                            parent_comment_id=comment.comment_id,
+                            stop_reason="reply_tail_budget_exhausted",
+                            attempt_count=None,
+                            last_error_code="reply_tail_budget_exhausted",
+                            last_reply_cursor=None,
+                            next_reply_cursor=None,
+                            saved_reply_count=observed_replies,
+                            expected_reply_count=comment.reply_count,
+                            pages_seen=0,
+                        )
+                        if checkpoint:
+                            reply_checkpoints.append(checkpoint)
+                        fetch_failed = True
+                        retryable = True
+                        fetch_reason = fetch_reason or "reply_tail_budget_exhausted"
+                        comments.append(comment)
+                        comments_fetched += 1
+                        if max_comments > 0 and comments_fetched >= max_comments:
+                            break
+                        continue
+                    reply_fetch_deadline = min(deadline, reply_tail_deadline)
+                replies_result = await self._fetch_comment_replies(
+                    media_id=media_id,
+                    comment_id=comment.comment_id,
+                    shortcode=shortcode,
+                    post_url=post_url,
+                    expected_reply_count=comment.reply_count,
+                    existing_replies=comment.replies,
+                    resume_cursor=reply_resume_cursors_by_parent.get(comment_id),
+                    resume_cursor_param=reply_resume_cursor_params_by_parent.get(comment_id),
+                    deadline=reply_fetch_deadline,
+                )
+                if (
+                    reply_tail_deadline is not None
+                    and replies_result.fetch_reason == "pagination_deadline_exceeded"
+                    and _deadline_remaining_seconds(reply_tail_deadline) == 0.0
+                ):
+                    replies_result.fetch_reason = "reply_tail_budget_exhausted"
+                comment.replies = merge_comment_replies(
+                    comment.replies,
+                    replies_result.comments,
+                    parent_comment_id=comment.comment_id,
+                )
+                reply_checkpoints.extend(replies_result.reply_checkpoints)
+                fetch_failed = fetch_failed or replies_result.fetch_failed
+                auth_failed = auth_failed or replies_result.auth_failed
+                retryable = retryable or replies_result.retryable
+                if replies_result.fetch_reason and not fetch_reason:
+                    fetch_reason = replies_result.fetch_reason
+                if (
+                    replies_result.fetch_failed
+                    and replies_result.retryable
+                    and not replies_result.reply_checkpoints
+                ):
+                    checkpoint = self._record_reply_checkpoint(
+                        shortcode=shortcode,
+                        media_id=media_id,
+                        parent_comment_id=comment.comment_id,
+                        stop_reason=replies_result.fetch_reason or "reply_pagination_retryable_stop",
+                        attempt_count=None,
+                        last_error_code=replies_result.fetch_reason,
+                        last_reply_cursor=None,
+                        next_reply_cursor=None,
+                        saved_reply_count=reply_count_observed(comment),
+                        expected_reply_count=comment.reply_count,
+                        pages_seen=0,
+                    )
+                    if checkpoint:
+                        reply_checkpoints.append(checkpoint)
+            comments.append(comment)
+            comments_fetched += 1
+            if max_comments > 0 and comments_fetched >= max_comments:
+                break
+
+        if missing_reply_count(comments) > 0:
+            fetch_failed = True
+            retryable = True
+            fetch_reason = fetch_reason or "reply_tail_incomplete"
+        elif fetch_reason in {
+            "pagination_deadline_exceeded",
+            "reply_tail_budget_exhausted",
+            "reply_tail_incomplete",
+        }:
+            fetch_failed = False
+            retryable = False
+            fetch_reason = "reply_tail_coverage_complete"
+        elif expected_comment_count is not None and flattened_comment_count(comments) < expected_comment_count:
+            fetch_reason = "reply_tail_coverage_complete"
+
+        return InstagramCommentsFetchResult(
+            comments=comments,
+            fetch_failed=fetch_failed,
+            auth_failed=auth_failed,
+            fetch_reason=fetch_reason,
+            reported_comment_count=expected_comment_count,
+            request_count=self._request_count,
+            retryable=retryable,
+            reply_checkpoints=reply_checkpoints,
+            top_level_checkpoint=None,
         )
 
     def _should_reveal_hidden_comments(
@@ -745,15 +1522,22 @@ class InstagramCommentsScraplingFetcher:
         *,
         expected_comment_count: int | None,
         current_comment_count: int,
+        missing_reply_count: int,
         max_comments: int,
         auth_failed: bool,
+        api_top_level_complete: bool,
     ) -> bool:
         if auth_failed or not _env_truthy(_REVEAL_HIDDEN_COMMENTS_ENV, True):
+            return False
+        if not api_top_level_complete:
             return False
         if max_comments > 0 and current_comment_count >= max_comments:
             return False
         if expected_comment_count is not None:
             target_count = min(expected_comment_count, max_comments) if max_comments > 0 else expected_comment_count
+            unresolved_gap = max(0, target_count - current_comment_count)
+            if missing_reply_count > 0 and unresolved_gap <= missing_reply_count:
+                return False
             return current_comment_count < target_count
         return _env_truthy(_REVEAL_HIDDEN_COMMENTS_WITHOUT_EXPECTED_ENV, False)
 
@@ -810,7 +1594,7 @@ class InstagramCommentsScraplingFetcher:
 
         self._hidden_comments_render_attempts += 1
         self._request_count += 1
-        all_headers = self._parser._get_headers(post_url)
+        all_headers = self._parser.get_headers(post_url)
         nav_headers = {k: v for k, v in all_headers.items() if k.lower() not in _API_HEADER_KEYS_TO_STRIP}
         try:
             response = await self._fetcher.async_fetch(
@@ -839,7 +1623,12 @@ class InstagramCommentsScraplingFetcher:
 
         self._sync_response_cookies(response)
         html_text = _response_text(response)
-        comments = _extract_rendered_permalink_comments(html_text, shortcode=shortcode, post_url=post_url)
+        comments = _extract_rendered_permalink_comments(
+            html_text,
+            shortcode=shortcode,
+            post_url=post_url,
+            ignored_usernames=[self._browser_account_id or ""],
+        )
         self._hidden_comments_rendered_comments += len(comments)
         if comments:
             logger.info(
@@ -870,9 +1659,18 @@ class InstagramCommentsScraplingFetcher:
         shortcode: str,
         post_url: str,
         expected_reply_count: int | None = None,
+        existing_replies: list[InstagramComment] | None = None,
+        resume_cursor: str | None = None,
+        resume_cursor_param: str | None = None,
+        deadline: float | None = None,
     ) -> InstagramCommentsFetchResult:
+        preview_replies = list(existing_replies or [])
         replies: list[InstagramComment] = []
-        cursor: str | None = None
+        cursor: str | None = str(resume_cursor or "").strip() or None
+        normalized_resume_cursor_param = str(resume_cursor_param or "").strip()
+        if normalized_resume_cursor_param not in {"min_id", "max_id"}:
+            normalized_resume_cursor_param = "min_id"
+        cursor_param_name: str | None = normalized_resume_cursor_param if cursor else None
         fetch_failed = False
         auth_failed = False
         fetch_reason: str | None = None
@@ -881,13 +1679,17 @@ class InstagramCommentsScraplingFetcher:
         seen_cursors: set[str] = set()
         last_attempt_count = 0
         last_reply_cursor: str | None = None
+        last_reply_cursor_param: str | None = None
         next_reply_cursor: str | None = None
-        deadline = time.monotonic() + _resolve_positive_float_env(
+        next_reply_cursor_param: str | None = None
+        reply_deadline = time.monotonic() + _resolve_positive_float_env(
             "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_SECONDS",
             _REPLY_PAGINATION_MAX_SECONDS_DEFAULT,
             minimum=1.0,
             maximum=1_800.0,
         )
+        if deadline is not None:
+            reply_deadline = min(reply_deadline, float(deadline))
         page_cap = _resolve_positive_int_env(
             "SOCIAL_INSTAGRAM_REPLY_PAGINATION_MAX_PAGES",
             _REPLY_PAGINATION_MAX_PAGES_DEFAULT,
@@ -896,7 +1698,7 @@ class InstagramCommentsScraplingFetcher:
         )
 
         while True:
-            if time.monotonic() >= deadline:
+            if time.monotonic() >= reply_deadline:
                 fetch_failed = True
                 fetch_reason = "pagination_deadline_exceeded"
                 retryable = True
@@ -905,11 +1707,13 @@ class InstagramCommentsScraplingFetcher:
             response = await self._fetch_json_response(
                 COMMENT_REPLIES_URL.format(media_id=media_id, comment_id=comment_id),
                 referer=post_url,
-                params={"min_id": cursor} if cursor else None,
+                params={cursor_param_name or "min_id": cursor} if cursor else None,
                 max_retries=self._reply_max_transient_retries,
+                deadline=reply_deadline,
             )
             last_attempt_count = int(response.get("attempt_count") or 0)
             last_reply_cursor = cursor
+            last_reply_cursor_param = cursor_param_name
             payload = response.get("payload")
             fetch_reason = response.get("reason")
             fetch_failed = bool(response.get("failed"))
@@ -919,36 +1723,46 @@ class InstagramCommentsScraplingFetcher:
                 break
             pages_seen += 1
 
-            if isinstance(payload, dict):
-                reply_rows = payload.get("child_comments") or payload.get("replies") or []
-            else:
-                reply_rows = payload
+            reply_rows, next_cursor, next_cursor_param_name = _extract_reply_page(payload, response)
             for reply_data in reply_rows:
                 if not isinstance(reply_data, dict):
                     continue
-                replies.append(
-                    self._parser._parse_comment(
-                        reply_data,
-                        shortcode,
-                        post_url,
-                        is_reply=True,
-                        parent_id=comment_id,
-                    )
+                parsed_reply = self._parser.parse_comment(
+                    reply_data,
+                    shortcode,
+                    post_url,
+                    is_reply=True,
+                    parent_id=comment_id,
+                )
+                replies = merge_comment_replies(
+                    replies,
+                    [parsed_reply],
+                    parent_comment_id=comment_id,
                 )
 
             if not isinstance(payload, dict):
+                if next_cursor and next_cursor_param_name:
+                    pass
+                else:
+                    break
+            if not next_cursor or not next_cursor_param_name:
                 break
-            if not bool(payload.get("has_more_tail_child_comments", False)):
-                break
-            next_cursor = payload.get("next_min_child_cursor")
-            if not next_cursor:
-                break
-            next_cursor = str(next_cursor)
             next_reply_cursor = next_cursor
-            if next_cursor == cursor or next_cursor in seen_cursors:
-                fetch_failed = True
+            next_reply_cursor_param = next_cursor_param_name
+            next_cursor_key = f"{next_cursor_param_name}:{next_cursor}"
+            current_cursor_key = f"{cursor_param_name}:{cursor}" if cursor and cursor_param_name else None
+            if next_cursor_key == current_cursor_key or next_cursor_key in seen_cursors:
+                observed_reply_total = len(
+                    merge_comment_replies(
+                        preview_replies,
+                        replies,
+                        parent_comment_id=comment_id,
+                    )
+                )
+                has_gap = expected_reply_count is None or observed_reply_total < expected_reply_count
+                fetch_failed = fetch_failed or has_gap
                 fetch_reason = "pagination_repeated_cursor"
-                retryable = True
+                retryable = retryable or has_gap
                 logger.warning(
                     "Instagram reply pagination repeated cursor for comment_id=%s cursor=%s",
                     comment_id,
@@ -956,20 +1770,36 @@ class InstagramCommentsScraplingFetcher:
                 )
                 break
             if pages_seen >= page_cap:
-                fetch_failed = True
+                observed_reply_total = len(
+                    merge_comment_replies(
+                        preview_replies,
+                        replies,
+                        parent_comment_id=comment_id,
+                    )
+                )
+                has_gap = expected_reply_count is None or observed_reply_total < expected_reply_count
+                fetch_failed = fetch_failed or has_gap
                 fetch_reason = "pagination_page_cap_reached"
-                retryable = True
+                retryable = retryable or has_gap
                 logger.warning(
                     "Instagram reply pagination page cap reached for comment_id=%s page_cap=%d",
                     comment_id,
                     page_cap,
                 )
                 break
-            seen_cursors.add(next_cursor)
+            seen_cursors.add(next_cursor_key)
             cursor = next_cursor
+            cursor_param_name = next_cursor_param_name
 
         reply_checkpoints: list[dict[str, Any]] = []
         if fetch_failed and retryable:
+            observed_reply_total = len(
+                merge_comment_replies(
+                    preview_replies,
+                    replies,
+                    parent_comment_id=comment_id,
+                )
+            )
             checkpoint = self._record_reply_checkpoint(
                 shortcode=shortcode,
                 media_id=media_id,
@@ -979,7 +1809,9 @@ class InstagramCommentsScraplingFetcher:
                 last_error_code=fetch_reason,
                 last_reply_cursor=last_reply_cursor,
                 next_reply_cursor=next_reply_cursor,
-                saved_reply_count=len(replies),
+                last_reply_cursor_param=last_reply_cursor_param,
+                next_reply_cursor_param=next_reply_cursor_param,
+                saved_reply_count=observed_reply_total,
                 expected_reply_count=expected_reply_count,
                 pages_seen=pages_seen,
             )
@@ -1057,7 +1889,7 @@ class InstagramCommentsScraplingFetcher:
         that don't belong on document navigation.
         """
         self._request_count += 1
-        all_headers = self._parser._get_headers(referer)
+        all_headers = self._parser.get_headers(referer)
         nav_headers = {k: v for k, v in all_headers.items() if k.lower() not in _API_HEADER_KEYS_TO_STRIP}
         return await self._fetcher.async_fetch(
             url,
@@ -1082,13 +1914,15 @@ class InstagramCommentsScraplingFetcher:
         *,
         referer: str,
         params: dict[str, Any] | None = None,
+        deadline: float | None = None,
     ) -> httpx.Response:
         """Plain HTTP GET via httpx. Used for comments/replies JSON API calls."""
         if self._http_client is None:
             await self._rebuild_http_client()
-        await self._pace_api_requests()
+        if not await self._pace_api_requests(deadline=deadline):
+            raise _PaginationDeadlineExceededError
         self._request_count += 1
-        headers = self._parser._get_headers(referer)
+        headers = self._parser.get_headers(referer)
         clean_params = {k: v for k, v in (params or {}).items() if v is not None} or None
         response = await self._http_client.get(url, params=clean_params, headers=headers)  # type: ignore[union-attr]
         self._sync_response_cookies(response)
@@ -1100,6 +1934,7 @@ class InstagramCommentsScraplingFetcher:
         *,
         referer: str,
         params: dict[str, Any] | None = None,
+        deadline: float | None = None,
     ) -> Any:
         """Fetch a JSON API URL through the same browser transport as warmup.
 
@@ -1114,36 +1949,48 @@ class InstagramCommentsScraplingFetcher:
         if clean_params:
             separator = "&" if "?" in request_url else "?"
             request_url = f"{request_url}{separator}{urlencode(clean_params, doseq=True)}"
+        remaining = _deadline_remaining_seconds(deadline)
+        if remaining is not None and remaining <= 0:
+            raise _PaginationDeadlineExceededError
         self._request_count += 1
-        response = await self._fetcher.async_fetch(
+        fetch_timeout_ms = self._timeout_ms
+        if remaining is not None:
+            fetch_timeout_ms = max(1_000, min(fetch_timeout_ms, int(remaining * 1_000)))
+        fetch_task = self._fetcher.async_fetch(
             request_url,
             headless=self._headless,
             network_idle=False,
             load_dom=False,
             cookies=_cookies_to_scrapling(self._raw_cookies),
             proxy_rotator=self._proxy_rotator,
-            extra_headers=self._parser._get_headers(referer),
-            timeout=self._timeout_ms,
+            extra_headers=self._parser.get_headers(referer),
+            timeout=fetch_timeout_ms,
             retries=1,
             retry_delay=1.0,
         )
+        response = await asyncio.wait_for(fetch_task, timeout=remaining) if remaining is not None else await fetch_task
         self._sync_response_cookies(response)
         await self._rebuild_http_client()
         return response
 
-    async def _pace_api_requests(self) -> None:
+    async def _pace_api_requests(self, *, deadline: float | None = None) -> bool:
         if self._global_api_delay_seconds > 0:
-            await asyncio.to_thread(
+            paced = await asyncio.to_thread(
                 _pace_global_api_request,
                 key=self._global_rate_limit_key,
                 delay_seconds=self._global_api_delay_seconds,
+                deadline=deadline,
             )
+            if not paced:
+                return False
         if self._api_delay_seconds <= 0:
-            return
+            return _deadline_remaining_seconds(deadline) != 0.0
         remaining = (self._last_api_request_started_at + self._api_delay_seconds) - time.monotonic()
         if remaining > 0:
-            await asyncio.sleep(remaining)
+            if not await _sleep_before_deadline(remaining, deadline):
+                return False
         self._last_api_request_started_at = time.monotonic()
+        return _deadline_remaining_seconds(deadline) != 0.0
 
     async def _recover_homepage_redirect(self, *, referer: str) -> bool:
         recovery_url = str(referer or "").strip() or "https://www.instagram.com/"
@@ -1290,6 +2137,8 @@ class InstagramCommentsScraplingFetcher:
         last_error_code: str | None,
         last_reply_cursor: str | None,
         next_reply_cursor: str | None,
+        last_reply_cursor_param: str | None = None,
+        next_reply_cursor_param: str | None = None,
         saved_reply_count: int,
         expected_reply_count: int | None,
         pages_seen: int,
@@ -1310,6 +2159,8 @@ class InstagramCommentsScraplingFetcher:
             "last_error_code": self._compact_checkpoint_text(last_error_code or stop_reason),
             "last_reply_cursor": self._compact_checkpoint_text(last_reply_cursor),
             "next_reply_cursor": self._compact_checkpoint_text(next_reply_cursor),
+            "last_reply_cursor_param": self._compact_checkpoint_text(last_reply_cursor_param),
+            "next_reply_cursor_param": self._compact_checkpoint_text(next_reply_cursor_param),
             "saved_reply_count_observed": self._non_negative_int(saved_reply_count),
             "expected_reply_count": self._non_negative_int(expected_reply_count),
             "pages_seen": self._non_negative_int(pages_seen),
@@ -1321,6 +2172,50 @@ class InstagramCommentsScraplingFetcher:
             self._reply_checkpoints.pop(0)
             self._reply_checkpoint_dropped_count += 1
         self._reply_checkpoints.append(compact_checkpoint)
+        return compact_checkpoint
+
+    def _record_top_level_checkpoint(
+        self,
+        *,
+        shortcode: str,
+        media_id: str,
+        stop_reason: str,
+        last_error_code: str | None,
+        last_top_level_cursor: str | None,
+        next_top_level_cursor: str | None,
+        last_top_level_cursor_param: str | None,
+        next_top_level_cursor_param: str | None,
+        observed_comment_count: int,
+        expected_comment_count: int | None,
+        pages_seen: int,
+    ) -> dict[str, Any] | None:
+        self._top_level_checkpoint_total_count += 1
+        if self._top_level_checkpoint_max_items <= 0:
+            self._top_level_checkpoint_dropped_count += 1
+            return None
+
+        checkpoint = {
+            "platform": "instagram",
+            "target_shortcode": self._compact_checkpoint_text(shortcode),
+            "source_id": self._compact_checkpoint_text(shortcode),
+            "media_id": self._compact_checkpoint_text(media_id),
+            "stop_reason": self._compact_checkpoint_text(stop_reason),
+            "last_error_code": self._compact_checkpoint_text(last_error_code or stop_reason),
+            "last_top_level_cursor": self._compact_checkpoint_text(last_top_level_cursor),
+            "next_top_level_cursor": self._compact_checkpoint_text(next_top_level_cursor),
+            "last_top_level_cursor_param": self._compact_checkpoint_text(last_top_level_cursor_param),
+            "next_top_level_cursor_param": self._compact_checkpoint_text(next_top_level_cursor_param),
+            "observed_comment_count": self._non_negative_int(observed_comment_count),
+            "expected_comment_count": self._non_negative_int(expected_comment_count),
+            "pages_seen": self._non_negative_int(pages_seen),
+            "retryable": True,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        compact_checkpoint = {key: value for key, value in checkpoint.items() if value is not None}
+        while len(self._top_level_checkpoints) >= self._top_level_checkpoint_max_items:
+            self._top_level_checkpoints.pop(0)
+            self._top_level_checkpoint_dropped_count += 1
+        self._top_level_checkpoints.append(compact_checkpoint)
         return compact_checkpoint
 
     # -------------------------------------------------------------------
@@ -1353,6 +2248,7 @@ class InstagramCommentsScraplingFetcher:
         referer: str,
         params: dict[str, Any] | None = None,
         max_retries: int | None = None,
+        deadline: float | None = None,
     ) -> dict[str, Any]:
         """JSON fetch via httpx with bounded exponential backoff on transient
         failures (429 / 5xx / transport timeout).
@@ -1363,9 +2259,13 @@ class InstagramCommentsScraplingFetcher:
         browser_api_fallback_attempted = False
         last_transient_reason: str | None = None
         while True:
+            if _deadline_remaining_seconds(deadline) == 0.0:
+                return _deadline_response(attempt)
             attempt += 1
             try:
-                response = await self._fetch_api(url, referer=referer, params=params)
+                response = await self._fetch_api(url, referer=referer, params=params, deadline=deadline)
+            except _PaginationDeadlineExceededError:
+                return _deadline_response(attempt)
             except (TimeoutError, httpx.TimeoutException, httpx.TransportError, OSError) as exc:
                 if not _api_transport_failure(exc):
                     raise
@@ -1386,7 +2286,11 @@ class InstagramCommentsScraplingFetcher:
                     logger.debug(
                         "Failed to rebuild Instagram comments HTTP client after transport error", exc_info=True
                     )
-                await asyncio.sleep(_transient_backoff_seconds(attempt, self._BASE_BACKOFF_SECONDS))
+                if not await _sleep_before_deadline(
+                    _transient_backoff_seconds(attempt, self._BASE_BACKOFF_SECONDS),
+                    deadline,
+                ):
+                    return _deadline_response(attempt)
                 continue
 
             status_code = _status_code(response)
@@ -1425,7 +2329,12 @@ class InstagramCommentsScraplingFetcher:
                                 url,
                                 referer=referer,
                                 params=params,
+                                deadline=deadline,
                             )
+                        except _PaginationDeadlineExceededError:
+                            return _deadline_response(attempt)
+                        except TimeoutError:
+                            return _deadline_response(attempt)
                         except Exception as exc:  # noqa: BLE001
                             if not _warmup_transport_failure(exc):
                                 raise
@@ -1468,13 +2377,67 @@ class InstagramCommentsScraplingFetcher:
                         "payload": None,
                         "attempt_count": attempt,
                     }
+                try:
+                    await self._rebuild_http_client()
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "Failed to rebuild Instagram comments HTTP client after transient HTTP status",
+                        exc_info=True,
+                    )
+                fallback_attempt = _resolve_positive_int_env(
+                    _BROWSER_API_FALLBACK_ON_429_ATTEMPT_ENV,
+                    3,
+                    minimum=1,
+                    maximum=20,
+                )
+                if (
+                    status_code == 429
+                    and not browser_api_fallback_attempted
+                    and attempt >= fallback_attempt
+                    and _env_truthy(_BROWSER_API_FALLBACK_ON_429_ENV, True)
+                    and _env_truthy(_BROWSER_API_FALLBACK_ENV, True)
+                ):
+                    browser_api_fallback_attempted = True
+                    self._record_retry_reason("browser_api_fallback_after_429")
+                    try:
+                        browser_response = await self._fetch_api_with_browser(
+                            url,
+                            referer=referer,
+                            params=params,
+                            deadline=deadline,
+                        )
+                    except _PaginationDeadlineExceededError:
+                        return _deadline_response(attempt)
+                    except TimeoutError:
+                        return _deadline_response(attempt)
+                    except Exception as exc:  # noqa: BLE001
+                        if not _warmup_transport_failure(exc):
+                            raise
+                        self._record_retry_reason(_transport_failure_reason(exc))
+                    else:
+                        browser_result = self._decode_json_response_result(browser_response, attempt=attempt)
+                        if not (
+                            browser_result.get("failed")
+                            and browser_result.get("reason") == "http_429"
+                        ):
+                            return browser_result
                 retry_after = self._retry_after_seconds(response)
                 sleep_seconds = _transient_backoff_seconds(
                     attempt,
                     self._BASE_BACKOFF_SECONDS,
                     retry_after=retry_after,
                 )
-                await asyncio.sleep(sleep_seconds)
+                if status_code == 429:
+                    cooldown_seconds = max(
+                        sleep_seconds * self._rate_limit_cooldown_multiplier,
+                        self._rate_limit_cooldown_min_seconds,
+                    )
+                    _record_global_api_cooldown(
+                        key=self._global_rate_limit_key,
+                        delay_seconds=cooldown_seconds,
+                    )
+                if not await _sleep_before_deadline(sleep_seconds, deadline):
+                    return _deadline_response(attempt)
                 continue
 
             # Permanent 4xx.

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -563,6 +563,70 @@ def _record_global_api_cooldown(*, key: str, delay_seconds: float) -> None:
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+_RATE_LIMIT_ADVISORY_LOCK_NAMESPACE = 0x49_47_43_4D  # "IGCM" — IG comments lane.
+_RATE_LIMIT_MODE_ENV = "SOCIAL_INSTAGRAM_COMMENTS_GLOBAL_RATE_LIMIT_MODE"
+_RATE_LIMIT_MODE_DEFAULT = "advisory"
+_RATE_LIMIT_VALID_MODES = frozenset({"advisory", "file_lock"})
+
+
+def _resolve_rate_limit_mode(raw_value: str | None = None) -> str:
+    """Phase 5.2: choose between Postgres-advisory-lock + file-lock fallback
+    (default, cross-container) and pure file-lock (legacy, per-container)."""
+    raw = raw_value if raw_value is not None else os.getenv(_RATE_LIMIT_MODE_ENV)
+    value = str(raw or _RATE_LIMIT_MODE_DEFAULT).strip().lower()
+    return value if value in _RATE_LIMIT_VALID_MODES else _RATE_LIMIT_MODE_DEFAULT
+
+
+def _advisory_lock_keys_for(key: str) -> tuple[int, int]:
+    """Derive a deterministic (namespace, key) pair from the rate-limit key.
+
+    pg_advisory_lock takes two int4 args. The namespace is fixed so this
+    lane never collides with other advisory-lock users; the key is a
+    sha256-derived 32-bit slice so two containers using the same
+    ``_global_rate_limit_key`` serialize.
+    """
+    digest = hashlib.sha256(str(key or "instagram").encode("utf-8")).digest()
+    key_int = int.from_bytes(digest[:4], byteorder="big", signed=True)
+    return _RATE_LIMIT_ADVISORY_LOCK_NAMESPACE, key_int
+
+
+def _try_advisory_lock_pace(*, key: str, delay_seconds: float, deadline: float | None) -> dict[str, Any]:
+    """Phase 5.2: try cross-container advisory-lock pacing first.
+
+    Returns ``{"acquired": bool, "paced": bool, "wait_ms": int, "error": str|None}``.
+    On any DB-side error, ``acquired`` is False and the caller falls back to
+    the per-container file-lock path. Wall-clock waits are still respected
+    inside the lock so the rate-limit semantics stay identical.
+    """
+    delay = max(0.0, float(delay_seconds or 0))
+    namespace, lock_key = _advisory_lock_keys_for(key)
+    started_at = time.monotonic()
+    try:
+        from trr_backend.db import pg
+    except Exception as exc:  # noqa: BLE001
+        return {"acquired": False, "paced": True, "wait_ms": 0, "error": f"pg_import_failed:{exc}"}
+    try:
+        with pg.db_connection(label="instagram-comments-rate-limit-advisory") as conn:
+            with pg.db_cursor(conn=conn) as cur:
+                cur.execute("select pg_advisory_lock(%s::int, %s::int)", (namespace, lock_key))
+                wait_ms = int((time.monotonic() - started_at) * 1000)
+                try:
+                    if delay > 0:
+                        deadline_remaining = _deadline_remaining_seconds(deadline)
+                        if deadline_remaining is not None and deadline_remaining <= 0:
+                            return {"acquired": True, "paced": False, "wait_ms": wait_ms, "error": None}
+                        sleep_for = delay
+                        if deadline_remaining is not None:
+                            sleep_for = min(sleep_for, deadline_remaining)
+                        if sleep_for > 0:
+                            time.sleep(sleep_for)
+                    return {"acquired": True, "paced": True, "wait_ms": wait_ms, "error": None}
+                finally:
+                    cur.execute("select pg_advisory_unlock(%s::int, %s::int)", (namespace, lock_key))
+    except Exception as exc:  # noqa: BLE001
+        return {"acquired": False, "paced": True, "wait_ms": 0, "error": str(exc)}
+
+
 def _pace_global_api_request(*, key: str, delay_seconds: float, deadline: float | None = None) -> bool:
     delay = max(0.0, float(delay_seconds or 0))
     cooldown_path = _global_rate_cooldown_path(key)
@@ -838,6 +902,18 @@ class InstagramCommentsScraplingFetcher:
             self._browser_account_id,
             self._selected_proxy_fingerprint,
         )
+        # Phase 5.2: cross-container Postgres-advisory-lock pacing with
+        # per-container fcntl fallback. Operators can pin to ``file_lock`` via
+        # SOCIAL_INSTAGRAM_COMMENTS_GLOBAL_RATE_LIMIT_MODE for environments
+        # without DB connectivity. Counters surface in runtime_metadata so
+        # silent slowdowns are visible in job metadata.
+        self._global_rate_limit_mode_configured = _resolve_rate_limit_mode()
+        self._global_rate_limit_mode_last: str | None = None
+        self._global_rate_limit_advisory_attempts = 0
+        self._global_rate_limit_advisory_acquires = 0
+        self._global_rate_limit_advisory_fallback_count = 0
+        self._global_rate_limit_advisory_total_wait_ms = 0
+        self._global_rate_limit_advisory_last_error: str | None = None
         self._max_transient_retries = _resolve_positive_int_env(
             "SOCIAL_INSTAGRAM_COMMENT_TRANSIENT_RETRIES",
             self._MAX_TRANSIENT_RETRIES,
@@ -907,6 +983,15 @@ class InstagramCommentsScraplingFetcher:
             "global_api_delay_seconds": self._global_api_delay_seconds,
             "comment_sort_order": self._comment_sort_order,
             "global_rate_limit_key": self._global_rate_limit_key,
+            "global_rate_limit": {
+                "mode_configured": self._global_rate_limit_mode_configured,
+                "mode_last_used": self._global_rate_limit_mode_last,
+                "advisory_attempts": self._global_rate_limit_advisory_attempts,
+                "advisory_acquires": self._global_rate_limit_advisory_acquires,
+                "advisory_fallback_count": self._global_rate_limit_advisory_fallback_count,
+                "advisory_total_wait_ms": self._global_rate_limit_advisory_total_wait_ms,
+                "advisory_last_error": self._global_rate_limit_advisory_last_error,
+            },
             "rate_limit_cooldown_min_seconds": self._rate_limit_cooldown_min_seconds,
             "rate_limit_cooldown_multiplier": self._rate_limit_cooldown_multiplier,
             "max_transient_retries": self._max_transient_retries,
@@ -2041,12 +2126,40 @@ class InstagramCommentsScraplingFetcher:
 
     async def _pace_api_requests(self, *, deadline: float | None = None) -> bool:
         if self._global_api_delay_seconds > 0:
-            paced = await asyncio.to_thread(
-                _pace_global_api_request,
-                key=self._global_rate_limit_key,
-                delay_seconds=self._global_api_delay_seconds,
-                deadline=deadline,
-            )
+            # Phase 5.2: try Postgres advisory lock for cross-container coordination
+            # when configured; fall through to per-container file lock otherwise.
+            paced: bool
+            if self._global_rate_limit_mode_configured == "advisory":
+                self._global_rate_limit_advisory_attempts += 1
+                advisory_result = await asyncio.to_thread(
+                    _try_advisory_lock_pace,
+                    key=self._global_rate_limit_key,
+                    delay_seconds=self._global_api_delay_seconds,
+                    deadline=deadline,
+                )
+                self._global_rate_limit_advisory_total_wait_ms += int(advisory_result.get("wait_ms") or 0)
+                if advisory_result.get("acquired"):
+                    self._global_rate_limit_advisory_acquires += 1
+                    self._global_rate_limit_mode_last = "advisory"
+                    paced = bool(advisory_result.get("paced", True))
+                else:
+                    self._global_rate_limit_advisory_fallback_count += 1
+                    self._global_rate_limit_advisory_last_error = advisory_result.get("error")
+                    self._global_rate_limit_mode_last = "file_lock_fallback"
+                    paced = await asyncio.to_thread(
+                        _pace_global_api_request,
+                        key=self._global_rate_limit_key,
+                        delay_seconds=self._global_api_delay_seconds,
+                        deadline=deadline,
+                    )
+            else:
+                self._global_rate_limit_mode_last = "file_lock"
+                paced = await asyncio.to_thread(
+                    _pace_global_api_request,
+                    key=self._global_rate_limit_key,
+                    delay_seconds=self._global_api_delay_seconds,
+                    deadline=deadline,
+                )
             if not paced:
                 return False
         if self._api_delay_seconds <= 0:

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -35,6 +35,22 @@ _QUEUE_DEFAULT_ATTEMPT_COUNT = 1
 _QUEUE_DEFAULT_MAX_ATTEMPTS = 12
 _DEFAULT_CANCEL_CHECK_EVERY_POSTS = 5
 _DEFAULT_JOB_HEARTBEAT_INTERVAL_SECONDS = 30
+# Phase 1.5: mid-run warmup refresh defaults. Triggered when the runner sees
+# >= _DEFAULT_MID_RUN_WARMUP_AUTH_THRESHOLD consecutive auth-failed posts OR
+# every _DEFAULT_MID_RUN_WARMUP_EVERY_POSTS successful posts (whichever first).
+# Both are env-overridable through the job config so tests can flip them.
+_DEFAULT_MID_RUN_WARMUP_AUTH_THRESHOLD = 3
+_DEFAULT_MID_RUN_WARMUP_EVERY_POSTS = 50
+# Phase 1.4: incomplete-run raise threshold. The shard only raises
+# instagram_comments_incomplete_retryable when at least this fraction of the
+# target list is incomplete, so a single bad post does not force the whole
+# shard into retrying.
+_DEFAULT_INCOMPLETE_RAISE_RATIO = 4  # raise when ratio is >= 1/_RAISE_RATIO
+_MIN_INCOMPLETE_RAISE_TARGETS = 1
+# Phase 1.7: cap on per-comment failure entries persisted in
+# social.scrape_jobs.metadata.comment_failures so a runaway shard cannot bloat
+# the job-metadata column.
+_COMMENT_FAILURE_METADATA_MAX_ENTRIES = 200
 _RECONCILABLE_REPORTED_GAP_MAX_DEFAULT = 2
 _RECONCILABLE_REPORTED_GAP_RATIO_DEFAULT = 0.02
 _RECONCILABLE_REPORTED_GAP_REASONS = {
@@ -406,10 +422,14 @@ def _safe_int(value: Any) -> int | None:
 def _job_attempt_state(job: dict[str, Any]) -> tuple[int, int]:
     attempt_count = _safe_int(job.get("attempt_count"))
     max_attempts = _safe_int(job.get("max_attempts"))
-    return (
-        max(1, attempt_count if attempt_count is not None else _QUEUE_DEFAULT_ATTEMPT_COUNT),
-        max(1, max_attempts if max_attempts is not None else _QUEUE_DEFAULT_MAX_ATTEMPTS),
-    )
+    normalized_attempt_count = max(1, attempt_count if attempt_count is not None else _QUEUE_DEFAULT_ATTEMPT_COUNT)
+    normalized_max_attempts = max(1, max_attempts if max_attempts is not None else _QUEUE_DEFAULT_MAX_ATTEMPTS)
+    # Phase 1.3 / audit: enforce max_attempts >= attempt_count + 1 when retryable
+    # state is missing or malformed so transient transport blips actually retry.
+    # Without this, a row carrying attempt_count = max_attempts (e.g. 1 == 1)
+    # would short-circuit can_retry to False on the first transient failure.
+    normalized_max_attempts = max(normalized_max_attempts, normalized_attempt_count + 1)
+    return (normalized_attempt_count, normalized_max_attempts)
 
 
 def _attach_incomplete_activity(
@@ -1272,6 +1292,23 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
     successful_target_fetches = 0
     post_auth_failure_circuit_limit = _safe_int(config.get("post_auth_failure_circuit_limit")) or 3
     post_fetch_failure_circuit_limit = _safe_int(config.get("post_fetch_failure_circuit_limit")) or 3
+    # Phase 1.5: mid-run warmup refresh state.
+    mid_run_warmup_auth_threshold = (
+        _safe_int(config.get("comments_warmup_refresh_auth_threshold"))
+        or _DEFAULT_MID_RUN_WARMUP_AUTH_THRESHOLD
+    )
+    mid_run_warmup_every_posts = (
+        _safe_int(config.get("comments_warmup_refresh_every_posts"))
+        or _DEFAULT_MID_RUN_WARMUP_EVERY_POSTS
+    )
+    posts_since_last_warmup = 0
+    mid_run_warmup_count = 0
+    last_mid_run_warmup_reason: str | None = None
+    # Phase 1.7: accumulator for per-comment failure attribution. Capped via
+    # _COMMENT_FAILURE_METADATA_MAX_ENTRIES so a runaway shard cannot bloat
+    # social.scrape_jobs.metadata. Persisted under metadata.comment_failures.
+    failed_comment_ids: list[dict[str, Any]] = []
+    failed_comment_ids_truncated = False
     warmup_completed_at = None
     first_post_persisted_at = None
     auth_context: dict[str, Any] = {}
@@ -1295,6 +1332,22 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
             "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
             "top_level_checkpoints": list(top_level_checkpoints_by_shortcode.values()),
+            # Phase 1.5: mid-run warmup-refresh telemetry.
+            "mid_run_warmup": {
+                "count": mid_run_warmup_count,
+                "auth_threshold": mid_run_warmup_auth_threshold,
+                "every_posts": mid_run_warmup_every_posts,
+                "last_reason": last_mid_run_warmup_reason,
+                "posts_since_last_warmup": posts_since_last_warmup,
+            },
+            # Phase 1.7: per-comment failure attribution. Operational metadata
+            # only — comments-table column expansion is intentionally deferred.
+            "comment_failures": {
+                "entries": list(failed_comment_ids),
+                "count": len(failed_comment_ids),
+                "truncated": failed_comment_ids_truncated,
+                "max_entries": _COMMENT_FAILURE_METADATA_MAX_ENTRIES,
+            },
         }
 
     def terminal_metadata_common() -> dict[str, Any]:
@@ -1324,6 +1377,11 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         nonlocal activity, fetcher_metadata
         nonlocal consecutive_post_auth_failures, consecutive_post_fetch_failures, successful_target_fetches
         nonlocal warmup_completed_at, first_post_persisted_at, auth_context
+        # Phase 1.5 / 1.7: scope mid-run warmup counters and per-comment failure
+        # truncation flag to the outer function so progress_metadata_common()
+        # reads the live values and _maybe_refresh_warmup() writes propagate.
+        nonlocal posts_since_last_warmup, mid_run_warmup_count, last_mid_run_warmup_reason
+        nonlocal failed_comment_ids_truncated
 
         session = resolve_comments_scrapling_session(
             browser_account_id=account_handle,
@@ -1411,6 +1469,43 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     or (post_index - 1) % cancel_check_every_posts == 0
                 )
 
+            async def _maybe_refresh_warmup(*, reason: str) -> bool:
+                """Phase 1.5: re-run fetcher.warmup() mid-run.
+
+                Returns True when a refresh actually fired so callers can reset
+                their counters. Failures are logged and swallowed — a stale
+                warmup will still pass through the normal auth-failed circuit.
+                """
+                nonlocal posts_since_last_warmup, mid_run_warmup_count, last_mid_run_warmup_reason
+                try:
+                    await fetcher.warmup()
+                except InstagramCommentsWarmupError as exc:
+                    logger.warning(
+                        "Mid-run Instagram comments warmup refresh failed: job_id=%s reason=%s error=%s",
+                        job_id,
+                        reason,
+                        exc,
+                    )
+                    return False
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Mid-run Instagram comments warmup refresh raised unexpectedly: job_id=%s reason=%s",
+                        job_id,
+                        reason,
+                        exc_info=True,
+                    )
+                    return False
+                posts_since_last_warmup = 0
+                mid_run_warmup_count += 1
+                last_mid_run_warmup_reason = reason
+                logger.info(
+                    "Instagram comments warmup refreshed mid-run: job_id=%s reason=%s count=%d",
+                    job_id,
+                    reason,
+                    mid_run_warmup_count,
+                )
+                return True
+
             for index, shortcode in enumerate(target_source_ids, start=1):
                 post_started_at = time.monotonic()
                 if not repo._touch_job_heartbeat(job_id, worker_id=worker_id):
@@ -1430,6 +1525,22 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     worker_id=worker_id,
                     runtime_metadata=dict(fetcher.runtime_metadata),
                 )
+                # Phase 1.5: mid-run warmup refresh trigger. Fires when the
+                # consecutive auth-failure threshold is reached OR when
+                # mid_run_warmup_every_posts successful posts have elapsed
+                # since the last warmup. Skipped for shortcodes pre-classified
+                # as already-complete because no fetch will run for them.
+                if shortcode not in skipped_complete_target_source_ids:
+                    if (
+                        mid_run_warmup_auth_threshold > 0
+                        and consecutive_post_auth_failures >= mid_run_warmup_auth_threshold
+                    ):
+                        await _maybe_refresh_warmup(reason="consecutive_auth_failures")
+                    elif (
+                        mid_run_warmup_every_posts > 0
+                        and posts_since_last_warmup >= mid_run_warmup_every_posts
+                    ):
+                        await _maybe_refresh_warmup(reason="post_count_threshold")
                 if shortcode in skipped_complete_target_source_ids:
                     total_elapsed_ms = int((time.monotonic() - post_started_at) * 1000)
                     post_latency_samples.append(
@@ -1532,6 +1643,16 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 top_level_checkpoint = getattr(result, "top_level_checkpoint", None)
                 if isinstance(top_level_checkpoint, dict):
                     top_level_checkpoints_by_shortcode[shortcode] = dict(top_level_checkpoint)
+                # Phase 1.7: accumulate per-comment failure attribution into the
+                # bounded shard-level list so it lands in scrape_jobs metadata.
+                result_failed_comment_ids = getattr(result, "failed_comment_ids", None) or []
+                for entry in result_failed_comment_ids:
+                    if not isinstance(entry, dict):
+                        continue
+                    if len(failed_comment_ids) >= _COMMENT_FAILURE_METADATA_MAX_ENTRIES:
+                        failed_comment_ids_truncated = True
+                        break
+                    failed_comment_ids.append(entry)
                 _raise_if_job_lease_lost(
                     job_id=job_id,
                     worker_id=worker_id,
@@ -1612,6 +1733,10 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         },
                     )
                 consecutive_post_auth_failures = 0
+                # Phase 1.5: every successful (or non-auth-failed) post advances the
+                # mid-run-warmup post counter. Skip-paths above continued before
+                # this point so they do not advance the counter spuriously.
+                posts_since_last_warmup += 1
                 if result.fetch_failed and not result.comments:
                     normalized_incomplete_shortcode = str(shortcode or "").strip()
                     consecutive_post_fetch_failures += 1
@@ -1838,7 +1963,15 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             retryable_incomplete_targets = list(
                 dict.fromkeys([*incomplete_target_source_ids, *auth_failed_target_source_ids])
             )
-            if retryable_incomplete_targets:
+            # Phase 1.4 / audit: only raise when at least 1/_DEFAULT_INCOMPLETE_RAISE_RATIO
+            # of the target list is incomplete. Single-post failures persist their
+            # retry targets in metadata via _retry_rebalance_metadata(...) without
+            # forcing the whole shard into retrying.
+            incomplete_raise_threshold = max(
+                _MIN_INCOMPLETE_RAISE_TARGETS,
+                len(target_source_ids) // _DEFAULT_INCOMPLETE_RAISE_RATIO,
+            )
+            if retryable_incomplete_targets and len(retryable_incomplete_targets) >= incomplete_raise_threshold:
                 retry_fetch_reasons = {
                     shortcode: incomplete_fetch_reasons.get(shortcode) or auth_failed_fetch_reasons.get(shortcode)
                     for shortcode in retryable_incomplete_targets
@@ -1852,6 +1985,8 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         "incomplete_fetch_reasons": retry_fetch_reasons,
                         "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
                         "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
+                        "incomplete_raise_threshold": incomplete_raise_threshold,
+                        "target_source_ids_count": len(target_source_ids),
                     },
                 )
 

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from collections import Counter
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
@@ -17,6 +19,7 @@ from trr_backend.socials.instagram.comments_scrapling.fetcher import (
 from trr_backend.socials.instagram.comments_scrapling.persistence import persist_instagram_comments_for_post
 from trr_backend.socials.instagram.comments_scrapling.proxy import select_comments_proxy
 from trr_backend.socials.instagram.comments_scrapling.session import resolve_comments_scrapling_session
+from trr_backend.socials.instagram.scraper import InstagramComment
 
 logger = logging.getLogger("socials.instagram.comments_scrapling.job_runner")
 
@@ -24,6 +27,40 @@ _RUN_FATAL_COMMENTS_ERROR_CODES = {
     "instagram_comments_auth_failed",
     "instagram_comments_warmup_auth_failed",
     "instagram_comments_warmup_no_cookies",
+    "instagram_comments_warmup_transport_error",
+    "instagram_comments_cookie_bridge_failed",
+    "instagram_comments_proxy_bridge_failed",
+}
+_QUEUE_DEFAULT_ATTEMPT_COUNT = 1
+_QUEUE_DEFAULT_MAX_ATTEMPTS = 12
+_DEFAULT_CANCEL_CHECK_EVERY_POSTS = 5
+_DEFAULT_JOB_HEARTBEAT_INTERVAL_SECONDS = 30
+_RECONCILABLE_REPORTED_GAP_MAX_DEFAULT = 2
+_RECONCILABLE_REPORTED_GAP_RATIO_DEFAULT = 0.02
+_RECONCILABLE_REPORTED_GAP_REASONS = {
+    "hidden_comments_unavailable_reconciled",
+    "hidden_comments_unresolved",
+    "reply_tail_budget_exhausted",
+    "reply_tail_incomplete",
+}
+_REPLY_ONLY_RETRY_REASONS = {
+    "http_429",
+    "reply_tail_budget_exhausted",
+    "reply_tail_incomplete",
+}
+_TERMINAL_COVERAGE_GAP_MAX_DEFAULT = 150
+_TERMINAL_COVERAGE_GAP_RATIO_DEFAULT = 0.10
+_TERMINAL_COVERAGE_GAP_REASONS = {
+    "http_429",
+    "http_500",
+    "http_502",
+    "http_503",
+    "http_504",
+    "pagination_deadline_exceeded",
+    "pagination_page_cap_reached",
+    "pagination_repeated_cursor",
+    "transport_error",
+    "transport_timeout",
 }
 
 
@@ -51,6 +88,72 @@ class ScraplingJobCancelledError(Exception):
 
 
 ScraplingJobCancelled = ScraplingJobCancelledError
+
+
+@dataclass(slots=True)
+class ScraplingJobLeaseLostError(Exception):
+    message: str
+    job_status: str | None = None
+    job_worker_id: str | None = None
+    claimed_at: Any | None = None
+    runtime_metadata: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def _worker_id_matches_claim(row_worker_id: Any, current_worker_id: str | None) -> bool:
+    row_value = str(row_worker_id or "").strip()
+    current_value = str(current_worker_id or "").strip()
+    if not current_value:
+        return True
+    if not row_value:
+        return False
+    return row_value == current_value or current_value.startswith(f"{row_value}:")
+
+
+def _raise_if_job_lease_lost(
+    *,
+    job_id: str,
+    worker_id: str | None,
+    runtime_metadata: dict[str, Any] | None = None,
+    conn: Any | None = None,
+) -> None:
+    if not job_id:
+        return
+    try:
+        job_state = (
+            pg.fetch_one(
+                """
+                select status, worker_id, claimed_at
+                from social.scrape_jobs
+                where id = %s
+                """,
+                [job_id],
+                conn=conn,
+            )
+            or {}
+        )
+    except pg.DatabaseServiceUnavailableError as exc:
+        logger.warning(
+            "Skipping comments lease check after database saturation: job_id=%s error=%s",
+            job_id,
+            exc,
+        )
+        return
+    job_status = str(job_state.get("status") or "").strip().lower() or None
+    job_worker_id = str(job_state.get("worker_id") or "").strip() or None
+    claimed_at = job_state.get("claimed_at")
+    if job_status == "running" and claimed_at is not None and _worker_id_matches_claim(job_worker_id, worker_id):
+        return
+    metadata = dict(runtime_metadata or {})
+    raise ScraplingJobLeaseLostError(
+        "Instagram comments Scrapling job lost its active queue lease.",
+        job_status=job_status,
+        job_worker_id=job_worker_id,
+        claimed_at=claimed_at,
+        runtime_metadata=metadata,
+    )
 
 
 def _raise_if_cancelled(
@@ -113,6 +216,43 @@ def _raise_if_cancelled(
     )
 
 
+def _resolve_job_heartbeat_interval_seconds() -> int:
+    raw = (
+        os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_JOB_HEARTBEAT_INTERVAL_SEC")
+        or os.environ.get("SOCIAL_JOB_HEARTBEAT_INTERVAL_SEC")
+        or _DEFAULT_JOB_HEARTBEAT_INTERVAL_SECONDS
+    )
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = _DEFAULT_JOB_HEARTBEAT_INTERVAL_SECONDS
+    return max(5, min(value, 300))
+
+
+async def _maintain_comments_job_heartbeat(
+    *,
+    job_id: str,
+    worker_id: str | None,
+    interval_seconds: int,
+) -> None:
+    from trr_backend.repositories import social_season_analytics as repo
+
+    if not job_id:
+        return
+    while True:
+        try:
+            repo._touch_job_heartbeat(job_id, worker_id=worker_id)
+        except pg.DatabaseServiceUnavailableError as exc:
+            logger.warning(
+                "Skipping comments job heartbeat after database saturation: job_id=%s error=%s",
+                job_id,
+                exc,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Comments job heartbeat failed: job_id=%s error=%s", job_id, exc)
+        await asyncio.sleep(interval_seconds)
+
+
 def _comments_scrape_is_complete(
     *,
     result: InstagramCommentsFetchResult,
@@ -121,12 +261,138 @@ def _comments_scrape_is_complete(
     if result.fetch_failed or result.auth_failed:
         return False
     reported_comment_count = _extract_reported_comment_count(result)
-    if reported_comment_count is not None and len(result.comments) < reported_comment_count:
+    observed_comment_count = _extract_observed_comment_count(result)
+    if reported_comment_count is not None and observed_comment_count >= reported_comment_count:
+        return True
+    if str(getattr(result, "fetch_reason", "") or "") == "hidden_comments_unavailable_reconciled":
+        return observed_comment_count > 0
+    if reported_comment_count is not None and observed_comment_count < reported_comment_count:
         if max_comments_per_post <= 0 or reported_comment_count <= max_comments_per_post:
             return False
     if max_comments_per_post <= 0:
         return True
     return len(result.comments) < max_comments_per_post
+
+
+def _persisted_comment_coverage_is_complete(
+    *,
+    result: InstagramCommentsFetchResult,
+    stored_total_comments: int,
+    max_comments_per_post: int,
+) -> bool:
+    if result.auth_failed:
+        return False
+    if not bool(getattr(result, "retryable", False)):
+        return False
+    reported_comment_count = _extract_reported_comment_count(result)
+    if reported_comment_count is None:
+        return False
+    target_count = reported_comment_count
+    if max_comments_per_post > 0:
+        target_count = min(target_count, max_comments_per_post)
+    return int(stored_total_comments or 0) >= target_count
+
+
+def _reported_count_gap_is_tolerable(*, unresolved_gap: int, target_count: int) -> bool:
+    gap = max(0, int(unresolved_gap or 0))
+    target = max(0, int(target_count or 0))
+    if gap <= 0:
+        return True
+    if target <= 0:
+        return False
+    try:
+        max_absolute_gap = int(
+            os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_RECONCILABLE_GAP_MAX")
+            or os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_HIDDEN_UNAVAILABLE_GAP_MAX")
+            or _RECONCILABLE_REPORTED_GAP_MAX_DEFAULT
+        )
+    except (TypeError, ValueError):
+        max_absolute_gap = _RECONCILABLE_REPORTED_GAP_MAX_DEFAULT
+    max_absolute_gap = max(0, min(max_absolute_gap, 50))
+    try:
+        max_ratio = float(
+            os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_RECONCILABLE_GAP_RATIO")
+            or os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_HIDDEN_UNAVAILABLE_GAP_RATIO")
+            or _RECONCILABLE_REPORTED_GAP_RATIO_DEFAULT
+        )
+    except (TypeError, ValueError):
+        max_ratio = _RECONCILABLE_REPORTED_GAP_RATIO_DEFAULT
+    max_ratio = max(0.0, min(max_ratio, 0.25))
+    ratio_gap = int(target * max_ratio)
+    if ratio_gap < target * max_ratio:
+        ratio_gap += 1
+    return gap <= max(max_absolute_gap, ratio_gap)
+
+
+def _persisted_comment_coverage_gap_is_reconcilable(
+    *,
+    result: InstagramCommentsFetchResult,
+    stored_total_comments: int,
+    max_comments_per_post: int,
+) -> bool:
+    if result.auth_failed:
+        return False
+    reason = str(getattr(result, "fetch_reason", "") or "").strip()
+    if reason not in _RECONCILABLE_REPORTED_GAP_REASONS:
+        return False
+    reported_comment_count = _extract_reported_comment_count(result)
+    if reported_comment_count is None:
+        return False
+    target_count = reported_comment_count
+    if max_comments_per_post > 0:
+        target_count = min(target_count, max_comments_per_post)
+    stored_total = int(stored_total_comments or 0)
+    if stored_total <= 0 or stored_total >= target_count:
+        return False
+    return _reported_count_gap_is_tolerable(
+        unresolved_gap=target_count - stored_total,
+        target_count=target_count,
+    )
+
+
+def _terminal_pagination_coverage_gap_is_reconcilable(
+    *,
+    result: InstagramCommentsFetchResult,
+    stored_total_comments: int,
+    max_comments_per_post: int,
+) -> bool:
+    if result.auth_failed:
+        return False
+    if not result.retryable:
+        return False
+    reason = str(getattr(result, "fetch_reason", "") or "").strip()
+    if reason not in _TERMINAL_COVERAGE_GAP_REASONS:
+        return False
+    reported_comment_count = _extract_reported_comment_count(result)
+    if reported_comment_count is None:
+        return False
+    target_count = reported_comment_count
+    if max_comments_per_post > 0:
+        target_count = min(target_count, max_comments_per_post)
+    stored_total = int(stored_total_comments or 0)
+    if stored_total <= 0 or stored_total >= target_count:
+        return False
+    unresolved_gap = target_count - stored_total
+    try:
+        max_absolute_gap = int(
+            os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_TERMINAL_GAP_MAX")
+            or _TERMINAL_COVERAGE_GAP_MAX_DEFAULT
+        )
+    except (TypeError, ValueError):
+        max_absolute_gap = _TERMINAL_COVERAGE_GAP_MAX_DEFAULT
+    max_absolute_gap = max(0, min(max_absolute_gap, 500))
+    try:
+        max_ratio = float(
+            os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_TERMINAL_GAP_RATIO")
+            or _TERMINAL_COVERAGE_GAP_RATIO_DEFAULT
+        )
+    except (TypeError, ValueError):
+        max_ratio = _TERMINAL_COVERAGE_GAP_RATIO_DEFAULT
+    max_ratio = max(0.0, min(max_ratio, 0.25))
+    ratio_gap = int(target_count * max_ratio)
+    if ratio_gap < target_count * max_ratio:
+        ratio_gap += 1
+    return unresolved_gap <= max(max_absolute_gap, ratio_gap)
 
 
 def _safe_int(value: Any) -> int | None:
@@ -135,6 +401,42 @@ def _safe_int(value: Any) -> int | None:
     except (TypeError, ValueError):
         return None
     return parsed if parsed >= 0 else None
+
+
+def _job_attempt_state(job: dict[str, Any]) -> tuple[int, int]:
+    attempt_count = _safe_int(job.get("attempt_count"))
+    max_attempts = _safe_int(job.get("max_attempts"))
+    return (
+        max(1, attempt_count if attempt_count is not None else _QUEUE_DEFAULT_ATTEMPT_COUNT),
+        max(1, max_attempts if max_attempts is not None else _QUEUE_DEFAULT_MAX_ATTEMPTS),
+    )
+
+
+def _attach_incomplete_activity(
+    activity: dict[str, Any],
+    *,
+    incomplete_target_source_ids: list[str],
+    incomplete_fetch_reasons: dict[str, str],
+    auth_failed_target_source_ids: list[str] | None = None,
+    auth_failed_fetch_reasons: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    incomplete_targets = list(
+        dict.fromkeys(str(item or "").strip() for item in incomplete_target_source_ids if str(item or "").strip())
+    )
+    if incomplete_targets:
+        activity["incomplete_target_source_ids"] = incomplete_targets
+    if incomplete_fetch_reasons:
+        activity["incomplete_fetch_reasons"] = dict(incomplete_fetch_reasons)
+    auth_failed_targets = list(
+        dict.fromkeys(
+            str(item or "").strip() for item in (auth_failed_target_source_ids or []) if str(item or "").strip()
+        )
+    )
+    if auth_failed_targets:
+        activity["auth_failed_target_source_ids"] = auth_failed_targets
+    if auth_failed_fetch_reasons:
+        activity["auth_failed_fetch_reasons"] = dict(auth_failed_fetch_reasons)
+    return activity
 
 
 def _config_truthy(value: Any) -> bool:
@@ -170,6 +472,7 @@ def _is_comments_transport_error(exc: BaseException) -> bool:
             "wrong version number",
             "ssl:",
             "ssl connection",
+            "record layer failure",
             "closed unexpectedly",
             "transport error",
             "transporterror",
@@ -187,7 +490,9 @@ def _is_comments_transport_error(exc: BaseException) -> bool:
 
 
 def _extract_reported_comment_count(result: InstagramCommentsFetchResult) -> int | None:
-    reported = getattr(result, "reported_comment_count", None) or getattr(result, "comments_count", None)
+    reported = getattr(result, "reported_comment_count", None)
+    if reported is None:
+        reported = getattr(result, "comments_count", None)
     if reported is not None:
         return _safe_int(reported)
     for attr_name in ("runtime_metadata", "raw_metadata"):
@@ -199,6 +504,55 @@ def _extract_reported_comment_count(result: InstagramCommentsFetchResult) -> int
             if parsed is not None:
                 return parsed
     return None
+
+
+def _extract_observed_comment_count(result: InstagramCommentsFetchResult) -> int:
+    for attr_name in (
+        "flattened_comment_count",
+        "flattened_comments_count",
+        "observed_comment_count",
+        "observed_comments_count",
+        "comments_observed_count",
+        "total_comments_observed",
+    ):
+        parsed = _safe_int(getattr(result, attr_name, None))
+        if parsed is not None:
+            return parsed
+    for attr_name in ("runtime_metadata", "raw_metadata", "metadata"):
+        metadata = getattr(result, attr_name, None)
+        if not isinstance(metadata, dict):
+            continue
+        for key in (
+            "flattened_comment_count",
+            "flattened_comments_count",
+            "observed_comment_count",
+            "observed_comments_count",
+            "comments_observed_count",
+            "total_comments_observed",
+        ):
+            parsed = _safe_int(metadata.get(key))
+            if parsed is not None:
+                return parsed
+    return _count_comment_tree(getattr(result, "comments", None))
+
+
+def _count_comment_tree(comments: Any) -> int:
+    if not isinstance(comments, list):
+        return 0
+    total = 0
+    stack = list(comments)
+    seen: set[int] = set()
+    while stack:
+        comment = stack.pop()
+        marker = id(comment)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        total += 1
+        replies = comment.get("replies") if isinstance(comment, dict) else getattr(comment, "replies", None)
+        if isinstance(replies, list):
+            stack.extend(replies)
+    return total
 
 
 def _load_expected_comment_counts(
@@ -252,6 +606,196 @@ def _load_expected_comment_counts(
     return counts
 
 
+def _coerce_comment_timestamp(value: Any) -> tuple[int, str]:
+    if value is None:
+        return 0, ""
+    if hasattr(value, "timestamp"):
+        try:
+            timestamp = int(value.timestamp())
+        except (TypeError, ValueError, OSError):
+            timestamp = 0
+        iso_value = value.isoformat() if hasattr(value, "isoformat") else str(value)
+        return max(0, timestamp), iso_value
+    raw_value = str(value or "").strip()
+    return 0, raw_value
+
+
+def _json_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item or "").strip()]
+    return []
+
+
+def _load_persisted_replies_by_parent(
+    *,
+    account_handle: str,
+    shortcode: str,
+) -> dict[str, list[InstagramComment]]:
+    normalized_shortcode = str(shortcode or "").strip()
+    if not normalized_shortcode:
+        return {}
+    rows = pg.fetch_all(
+        """
+        select
+          reply.parent_comment_external_id::text as parent_comment_external_id,
+          reply.comment_id::text as comment_id,
+          coalesce(reply.text, '')::text as text,
+          coalesce(reply.username, '')::text as username,
+          coalesce(reply.user_id, '')::text as user_id,
+          coalesce(reply.likes, 0)::int as likes,
+          reply.created_at,
+          coalesce(reply.reply_count, 0)::int as reply_count,
+          coalesce(reply.reply_depth, 1)::int as reply_depth,
+          reply.media_urls,
+          reply.hosted_media_urls,
+          reply.author_full_name,
+          reply.author_profile_pic_url,
+          reply.author_profile_pic_url_hd,
+          reply.author_is_verified,
+          reply.raw_data,
+          reply.source_snapshot_type
+        from social.instagram_comments reply
+        join social.instagram_posts post on post.id = reply.post_id
+        where post.shortcode = %s
+          and coalesce(reply.is_reply, false) = true
+          and coalesce(reply.is_missing, false) = false
+          and reply.deleted_at is null
+          and nullif(reply.comment_id, '') is not null
+          and nullif(reply.parent_comment_external_id, '') is not null
+        order by reply.parent_comment_external_id, reply.created_at asc nulls last, reply.comment_id asc
+        """,
+        [normalized_shortcode],
+    )
+    replies_by_parent: dict[str, list[InstagramComment]] = {}
+    for row in rows:
+        parent_id = str(row.get("parent_comment_external_id") or "").strip()
+        comment_id = str(row.get("comment_id") or "").strip()
+        if not (parent_id and comment_id):
+            continue
+        created_at, date_time = _coerce_comment_timestamp(row.get("created_at"))
+        reply = InstagramComment(
+            comment_id=comment_id,
+            text=str(row.get("text") or ""),
+            username=str(row.get("username") or ""),
+            user_id=str(row.get("user_id") or ""),
+            created_at=created_at,
+            date_time=date_time,
+            likes=int(row.get("likes") or 0),
+            is_reply=True,
+            parent_comment_id=parent_id,
+            reply_count=int(row.get("reply_count") or 0),
+            reply_depth=max(1, int(row.get("reply_depth") or 1)),
+            media_urls=_json_list(row.get("media_urls")),
+            hosted_media_urls=_json_list(row.get("hosted_media_urls")),
+            owner_full_name=str(row.get("author_full_name") or "") or None,
+            owner_profile_pic_url=str(row.get("author_profile_pic_url") or "") or None,
+            owner_profile_pic_url_hd=str(row.get("author_profile_pic_url_hd") or "") or None,
+            owner_is_verified=(
+                bool(row.get("author_is_verified")) if row.get("author_is_verified") is not None else None
+            ),
+            is_hidden_by_instagram=bool((row.get("raw_data") or {}).get("is_hidden_by_instagram"))
+            if isinstance(row.get("raw_data"), dict)
+            else False,
+            source_snapshot_type=str(row.get("source_snapshot_type") or "full_comments_scrape"),
+            post_shortcode=normalized_shortcode,
+            post_url=f"https://www.instagram.com/p/{normalized_shortcode}/",
+        )
+        replies_by_parent.setdefault(parent_id, []).append(reply)
+    return replies_by_parent
+
+
+def _load_persisted_top_level_comments_for_reply_retry(
+    *,
+    account_handle: str,
+    shortcode: str,
+) -> list[InstagramComment]:
+    del account_handle
+    normalized_shortcode = str(shortcode or "").strip()
+    if not normalized_shortcode:
+        return []
+    rows = pg.fetch_all(
+        """
+        select
+          top.comment_id::text as comment_id,
+          coalesce(top.text, '')::text as text,
+          coalesce(top.username, '')::text as username,
+          coalesce(top.user_id, '')::text as user_id,
+          coalesce(top.likes, 0)::int as likes,
+          top.created_at,
+          coalesce(top.reply_count, 0)::int as reply_count,
+          top.media_urls,
+          top.hosted_media_urls,
+          top.author_full_name,
+          top.author_profile_pic_url,
+          top.author_profile_pic_url_hd,
+          top.author_is_verified,
+          top.raw_data,
+          top.source_snapshot_type,
+          coalesce(reply_counts.saved_reply_count, 0)::int as saved_reply_count
+        from social.instagram_comments top
+        join social.instagram_posts post on post.id = top.post_id
+        left join lateral (
+          select count(*)::int as saved_reply_count
+          from social.instagram_comments reply
+          where reply.post_id = top.post_id
+            and reply.parent_comment_external_id = top.comment_id
+            and coalesce(reply.is_reply, false) = true
+            and coalesce(reply.is_missing, false) = false
+            and reply.deleted_at is null
+            and nullif(reply.comment_id, '') is not null
+        ) reply_counts on true
+        where post.shortcode = %s
+          and coalesce(top.is_reply, false) = false
+          and top.parent_comment_external_id is null
+          and coalesce(top.is_missing, false) = false
+          and top.deleted_at is null
+          and nullif(top.comment_id, '') is not null
+          and coalesce(top.reply_count, 0) > coalesce(reply_counts.saved_reply_count, 0)
+        order by
+          (coalesce(top.reply_count, 0) - coalesce(reply_counts.saved_reply_count, 0)) desc,
+          top.created_at asc nulls last,
+          top.comment_id asc
+        """,
+        [normalized_shortcode],
+    )
+    comments: list[InstagramComment] = []
+    for row in rows:
+        comment_id = str(row.get("comment_id") or "").strip()
+        if not comment_id:
+            continue
+        created_at, date_time = _coerce_comment_timestamp(row.get("created_at"))
+        comments.append(
+            InstagramComment(
+                comment_id=comment_id,
+                text=str(row.get("text") or ""),
+                username=str(row.get("username") or ""),
+                user_id=str(row.get("user_id") or ""),
+                created_at=created_at,
+                date_time=date_time,
+                likes=int(row.get("likes") or 0),
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=int(row.get("reply_count") or 0),
+                reply_depth=0,
+                media_urls=_json_list(row.get("media_urls")),
+                hosted_media_urls=_json_list(row.get("hosted_media_urls")),
+                owner_full_name=str(row.get("author_full_name") or "") or None,
+                owner_profile_pic_url=str(row.get("author_profile_pic_url") or "") or None,
+                owner_profile_pic_url_hd=str(row.get("author_profile_pic_url_hd") or "") or None,
+                owner_is_verified=(
+                    bool(row.get("author_is_verified")) if row.get("author_is_verified") is not None else None
+                ),
+                is_hidden_by_instagram=bool((row.get("raw_data") or {}).get("is_hidden_by_instagram"))
+                if isinstance(row.get("raw_data"), dict)
+                else False,
+                source_snapshot_type=str(row.get("source_snapshot_type") or "full_comments_scrape"),
+                post_shortcode=normalized_shortcode,
+                post_url=f"https://www.instagram.com/p/{normalized_shortcode}/",
+            )
+        )
+    return comments
+
+
 def _post_latency_metadata(samples: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "samples": samples[-25:],
@@ -278,12 +822,18 @@ def _retry_rebalance_metadata(
     target_source_ids: list[str],
     processed_posts: int,
     incomplete_target_source_ids: list[str] | None = None,
+    auth_failed_target_source_ids: list[str] | None = None,
 ) -> dict[str, Any] | None:
     retry_targets = [
         str(item or "").strip()
         for item in (incomplete_target_source_ids or [])
         if str(item or "").strip()
     ]
+    retry_targets.extend(
+        str(item or "").strip()
+        for item in (auth_failed_target_source_ids or [])
+        if str(item or "").strip()
+    )
     retry_targets.extend(target_source_ids[max(0, processed_posts) :])
     remaining_targets = list(dict.fromkeys(retry_targets))
     if comments_shard_count <= 1 and not remaining_targets:
@@ -318,6 +868,204 @@ def _reply_checkpoint_summary(fetcher_metadata: dict[str, Any]) -> dict[str, Any
         "stop_reasons": dict(Counter(str(item.get("stop_reason") or "unknown") for item in items)),
         "latest": items[-1] if items else None,
     }
+
+
+def _top_level_checkpoint_summary(
+    fetcher_metadata: dict[str, Any],
+    top_level_checkpoints: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    checkpoint_metadata = fetcher_metadata.get("top_level_checkpoint_metadata")
+    runtime_items: list[dict[str, Any]] = []
+    if isinstance(checkpoint_metadata, dict):
+        runtime_items = [
+            item for item in (checkpoint_metadata.get("items") or []) if isinstance(item, dict)
+        ]
+    merged_by_shortcode: dict[str, dict[str, Any]] = {}
+    for checkpoint in [*runtime_items, *top_level_checkpoints.values()]:
+        shortcode = str(
+            checkpoint.get("target_shortcode")
+            or checkpoint.get("source_id")
+            or checkpoint.get("shortcode")
+            or ""
+        ).strip()
+        if shortcode:
+            merged_by_shortcode[shortcode] = dict(checkpoint)
+    items = list(merged_by_shortcode.values())
+    return {
+        "total_count": int(
+            checkpoint_metadata.get("total_count") if isinstance(checkpoint_metadata, dict) else len(items)
+            or len(items)
+        ),
+        "retained_count": len(items),
+        "dropped_count": int(
+            checkpoint_metadata.get("dropped_count") if isinstance(checkpoint_metadata, dict) else 0
+            or 0
+        ),
+        "truncated": bool(checkpoint_metadata.get("truncated")) if isinstance(checkpoint_metadata, dict) else False,
+        "stop_reasons": dict(Counter(str(item.get("stop_reason") or "unknown") for item in items)),
+        "items": items,
+        "latest": items[-1] if items else None,
+    }
+
+
+def _top_level_resume_cursors_from_job(job: dict[str, Any]) -> dict[str, str]:
+    metadata = job.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    candidates: list[Any] = []
+    for key in ("top_level_checkpoints", "instagram_comments_top_level_checkpoints"):
+        value = metadata.get(key)
+        if isinstance(value, list):
+            candidates.extend(value)
+    summary = metadata.get("top_level_checkpoint_summary")
+    if isinstance(summary, dict) and isinstance(summary.get("items"), list):
+        candidates.extend(summary.get("items") or [])
+    runtime = metadata.get("fetcher_runtime")
+    if isinstance(runtime, dict):
+        checkpoint_metadata = runtime.get("top_level_checkpoint_metadata")
+        if isinstance(checkpoint_metadata, dict) and isinstance(checkpoint_metadata.get("items"), list):
+            candidates.extend(checkpoint_metadata.get("items") or [])
+
+    cursors: dict[str, str] = {}
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        shortcode = str(
+            item.get("target_shortcode")
+            or item.get("source_id")
+            or item.get("shortcode")
+            or ""
+        ).strip()
+        stop_reason = str(item.get("stop_reason") or "").strip()
+        cursor = str(item.get("next_top_level_cursor") or "").strip()
+        if not cursor and stop_reason != "pagination_repeated_cursor":
+            cursor = str(item.get("last_top_level_cursor") or "").strip()
+        if shortcode and cursor:
+            cursors[shortcode] = cursor
+    return cursors
+
+
+def _top_level_resume_cursor_params_from_job(job: dict[str, Any]) -> dict[str, str]:
+    metadata = job.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    candidates: list[Any] = []
+    for key in ("top_level_checkpoints", "instagram_comments_top_level_checkpoints"):
+        value = metadata.get(key)
+        if isinstance(value, list):
+            candidates.extend(value)
+    summary = metadata.get("top_level_checkpoint_summary")
+    if isinstance(summary, dict) and isinstance(summary.get("items"), list):
+        candidates.extend(summary.get("items") or [])
+    runtime = metadata.get("fetcher_runtime")
+    if isinstance(runtime, dict):
+        checkpoint_metadata = runtime.get("top_level_checkpoint_metadata")
+        if isinstance(checkpoint_metadata, dict) and isinstance(checkpoint_metadata.get("items"), list):
+            candidates.extend(checkpoint_metadata.get("items") or [])
+
+    params: dict[str, str] = {}
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        shortcode = str(
+            item.get("target_shortcode")
+            or item.get("source_id")
+            or item.get("shortcode")
+            or ""
+        ).strip()
+        if not shortcode:
+            continue
+        stop_reason = str(item.get("stop_reason") or "").strip()
+        cursor = str(item.get("next_top_level_cursor") or "").strip()
+        cursor_param = str(item.get("next_top_level_cursor_param") or "").strip()
+        if not cursor and stop_reason != "pagination_repeated_cursor":
+            cursor = str(item.get("last_top_level_cursor") or "").strip()
+            cursor_param = str(item.get("last_top_level_cursor_param") or "").strip()
+        if cursor and cursor_param in {"min_id", "max_id"}:
+            params[shortcode] = cursor_param
+    return params
+
+
+def _reply_resume_cursors_from_job(job: dict[str, Any]) -> dict[str, str]:
+    metadata = job.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    candidates: list[Any] = []
+    summary = metadata.get("reply_checkpoint_summary")
+    if isinstance(summary, dict):
+        latest = summary.get("latest")
+        if isinstance(latest, dict):
+            candidates.append(latest)
+        if isinstance(summary.get("items"), list):
+            candidates.extend(summary.get("items") or [])
+    runtime = metadata.get("fetcher_runtime")
+    if isinstance(runtime, dict):
+        checkpoint_metadata = runtime.get("reply_checkpoint_metadata")
+        if isinstance(checkpoint_metadata, dict) and isinstance(checkpoint_metadata.get("items"), list):
+            candidates.extend(checkpoint_metadata.get("items") or [])
+
+    cursors: dict[str, str] = {}
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        parent_comment_id = str(item.get("parent_comment_id") or "").strip()
+        cursor = str(item.get("next_reply_cursor") or item.get("last_reply_cursor") or "").strip()
+        if parent_comment_id and cursor:
+            cursors[parent_comment_id] = cursor
+    return cursors
+
+
+def _reply_resume_cursor_params_from_job(job: dict[str, Any]) -> dict[str, str]:
+    metadata = job.get("metadata")
+    if not isinstance(metadata, dict):
+        return {}
+    candidates: list[Any] = []
+    summary = metadata.get("reply_checkpoint_summary")
+    if isinstance(summary, dict):
+        latest = summary.get("latest")
+        if isinstance(latest, dict):
+            candidates.append(latest)
+        if isinstance(summary.get("items"), list):
+            candidates.extend(summary.get("items") or [])
+    runtime = metadata.get("fetcher_runtime")
+    if isinstance(runtime, dict):
+        checkpoint_metadata = runtime.get("reply_checkpoint_metadata")
+        if isinstance(checkpoint_metadata, dict) and isinstance(checkpoint_metadata.get("items"), list):
+            candidates.extend(checkpoint_metadata.get("items") or [])
+
+    params: dict[str, str] = {}
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        parent_comment_id = str(item.get("parent_comment_id") or "").strip()
+        cursor_param = str(item.get("next_reply_cursor_param") or item.get("last_reply_cursor_param") or "").strip()
+        if parent_comment_id and cursor_param in {"min_id", "max_id"}:
+            params[parent_comment_id] = cursor_param
+    return params
+
+
+def _prior_incomplete_fetch_reason(job: dict[str, Any], shortcode: str) -> str:
+    metadata = job.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    normalized_shortcode = str(shortcode or "").strip()
+    reason_maps: list[Any] = [
+        metadata.get("incomplete_fetch_reasons"),
+        metadata.get("auth_failed_fetch_reasons"),
+    ]
+    runtime_metadata = metadata.get("runtime_metadata")
+    if isinstance(runtime_metadata, dict):
+        reason_maps.append(runtime_metadata.get("incomplete_fetch_reasons"))
+    post_fetch_failures = metadata.get("post_fetch_failures")
+    if isinstance(post_fetch_failures, dict):
+        reason_maps.append(post_fetch_failures.get("fetch_reasons"))
+    for reason_map in reason_maps:
+        if not isinstance(reason_map, dict):
+            continue
+        reason = str(reason_map.get(normalized_shortcode) or "").strip()
+        if reason:
+            return reason
+    return str(metadata.get("failure_reason_code") or metadata.get("error_code") or "").strip()
 
 
 def _auth_context_metadata(auth_session: Any | None) -> dict[str, Any]:
@@ -427,10 +1175,19 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         for item in (config.get("target_source_ids") or ([config.get("source_id")] if config.get("source_id") else []))
         if str(item or "").strip()
     ]
+    attempt_count, max_attempts = _job_attempt_state(job)
     comments_shard_index = max(1, int(config.get("comments_shard_index") or 1))
     comments_shard_count = max(1, int(config.get("comments_shard_count") or 1))
     comments_shard_target_count = max(0, int(config.get("comments_shard_target_count") or len(target_source_ids)))
+    cancel_check_every_posts = max(
+        1,
+        _safe_int(config.get("comments_cancel_check_every_posts")) or _DEFAULT_CANCEL_CHECK_EVERY_POSTS,
+    )
     skipped_complete_target_source_ids: list[str] = []
+    top_level_resume_cursors_by_shortcode = _top_level_resume_cursors_from_job(job)
+    top_level_resume_cursor_params_by_shortcode = _top_level_resume_cursor_params_from_job(job)
+    reply_resume_cursors_by_parent = _reply_resume_cursors_from_job(job)
+    reply_resume_cursor_params_by_parent = _reply_resume_cursor_params_from_job(job)
     skip_complete_retry_targets = any(
         _config_truthy(config.get(flag))
         for flag in (
@@ -439,7 +1196,9 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             "comments_target_gap_repair",
             "comments_skip_complete_targets",
         )
-    )
+    ) or str(config.get("target_filter") or "").strip().lower() == "incomplete" or _config_truthy(
+        config.get("incomplete_fill")
+    ) or str(job.get("status") or "").strip().lower() == "retrying" or attempt_count > 1
     if skip_complete_retry_targets and target_source_ids:
         try:
             incomplete_targets = repo._instagram_filter_incomplete_comment_targets(account_handle, target_source_ids)
@@ -502,31 +1261,53 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         **shard_metadata,
     }
     fetcher_metadata: dict[str, Any] = {}
+    top_level_checkpoints_by_shortcode: dict[str, dict[str, Any]] = {}
     post_latency_samples: list[dict[str, Any]] = []
     incomplete_target_source_ids: list[str] = []
     incomplete_fetch_reasons: dict[str, str] = {}
     auth_failed_target_source_ids: list[str] = []
     auth_failed_fetch_reasons: dict[str, str] = {}
     consecutive_post_auth_failures = 0
+    consecutive_post_fetch_failures = 0
     successful_target_fetches = 0
     post_auth_failure_circuit_limit = _safe_int(config.get("post_auth_failure_circuit_limit")) or 3
+    post_fetch_failure_circuit_limit = _safe_int(config.get("post_fetch_failure_circuit_limit")) or 3
     warmup_completed_at = None
     first_post_persisted_at = None
     auth_context: dict[str, Any] = {}
     terminal_status = str(job.get("status") or "").strip().lower() or None
     terminal_error_message: str | None = None
 
-    def terminal_metadata_common() -> dict[str, Any]:
+    def progress_metadata_common() -> dict[str, Any]:
         return {
-            **shard_metadata,
-            "post_latency": _post_latency_metadata(post_latency_samples),
-            "comment_completeness": _comment_completeness_metadata(post_latency_samples),
             "post_auth_failures": {
                 "target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
                 "fetch_reasons": dict(auth_failed_fetch_reasons),
                 "circuit_limit": post_auth_failure_circuit_limit,
             },
+            "post_fetch_failures": {
+                "target_source_ids": list(dict.fromkeys(incomplete_target_source_ids)),
+                "fetch_reasons": dict(incomplete_fetch_reasons),
+                "circuit_limit": post_fetch_failure_circuit_limit,
+            },
+            "incomplete_target_source_ids": list(dict.fromkeys(incomplete_target_source_ids)),
+            "incomplete_fetch_reasons": dict(incomplete_fetch_reasons),
+            "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
+            "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
+            "top_level_checkpoints": list(top_level_checkpoints_by_shortcode.values()),
+        }
+
+    def terminal_metadata_common() -> dict[str, Any]:
+        return {
+            **shard_metadata,
+            "post_latency": _post_latency_metadata(post_latency_samples),
+            "comment_completeness": _comment_completeness_metadata(post_latency_samples),
+            **progress_metadata_common(),
             "reply_checkpoint_summary": _reply_checkpoint_summary(fetcher_metadata),
+            "top_level_checkpoint_summary": _top_level_checkpoint_summary(
+                fetcher_metadata,
+                top_level_checkpoints_by_shortcode,
+            ),
             "timing": {
                 "job_runner_started_at": repo._iso(job_runner_started_at),
                 "warmup_completed_at": repo._iso(warmup_completed_at),
@@ -541,7 +1322,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         nonlocal processed_posts, comments_upserted, comments_fetched
         nonlocal comments_marked_missing, mirror_jobs_enqueued, mirror_job_enqueue_errors
         nonlocal activity, fetcher_metadata
-        nonlocal consecutive_post_auth_failures, successful_target_fetches
+        nonlocal consecutive_post_auth_failures, consecutive_post_fetch_failures, successful_target_fetches
         nonlocal warmup_completed_at, first_post_persisted_at, auth_context
 
         session = resolve_comments_scrapling_session(
@@ -562,6 +1343,13 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             browser_account_id=session.browser_account_id,
             proxy_config=proxy_config,
         )
+        heartbeat_task = asyncio.create_task(
+            _maintain_comments_job_heartbeat(
+                job_id=job_id,
+                worker_id=worker_id,
+                interval_seconds=_resolve_job_heartbeat_interval_seconds(),
+            )
+        )
         auth_metadata: dict[str, Any] = {}
         try:
             try:
@@ -574,13 +1362,32 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     retryable=exc.retryable,
                     runtime_metadata=dict(fetcher.runtime_metadata),
                 ) from exc
+            except Exception as exc:  # noqa: BLE001
+                if _is_comments_transport_error(exc):
+                    raise CommentsScraplingRuntimeError(
+                        str(exc),
+                        error_code="instagram_comments_warmup_transport_error",
+                        retryable=True,
+                        runtime_metadata=dict(fetcher.runtime_metadata),
+                    ) from exc
+                raise
             auth_metadata = dict(session.auth_session.metadata or {})
             _raise_if_cancelled(
                 job_id=job_id,
                 run_id=run_id,
                 runtime_metadata=dict(fetcher.runtime_metadata),
             )
-            repo._touch_job_heartbeat(job_id, worker_id=worker_id)
+            _raise_if_job_lease_lost(
+                job_id=job_id,
+                worker_id=worker_id,
+                runtime_metadata=dict(fetcher.runtime_metadata),
+            )
+            if not repo._touch_job_heartbeat(job_id, worker_id=worker_id):
+                _raise_if_job_lease_lost(
+                    job_id=job_id,
+                    worker_id=worker_id,
+                    runtime_metadata=dict(fetcher.runtime_metadata),
+                )
             repo._emit_job_progress(
                 job_id=job_id,
                 stage=stage,
@@ -592,15 +1399,35 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 comments_upserted=0,
                 activity=activity,
                 progress_state=progress_state,
+                worker_id=worker_id,
                 force=True,
+                extra_metadata=progress_metadata_common(),
             )
+
+            def should_poll_cancellation(post_index: int) -> bool:
+                return (
+                    post_index == 1
+                    or post_index == len(target_source_ids)
+                    or (post_index - 1) % cancel_check_every_posts == 0
+                )
 
             for index, shortcode in enumerate(target_source_ids, start=1):
                 post_started_at = time.monotonic()
-                repo._touch_job_heartbeat(job_id, worker_id=worker_id)
-                _raise_if_cancelled(
+                if not repo._touch_job_heartbeat(job_id, worker_id=worker_id):
+                    _raise_if_job_lease_lost(
+                        job_id=job_id,
+                        worker_id=worker_id,
+                        runtime_metadata=dict(fetcher.runtime_metadata),
+                    )
+                if should_poll_cancellation(index):
+                    _raise_if_cancelled(
+                        job_id=job_id,
+                        run_id=run_id,
+                        runtime_metadata=dict(fetcher.runtime_metadata),
+                    )
+                _raise_if_job_lease_lost(
                     job_id=job_id,
-                    run_id=run_id,
+                    worker_id=worker_id,
                     runtime_metadata=dict(fetcher.runtime_metadata),
                 )
                 if shortcode in skipped_complete_target_source_ids:
@@ -640,17 +1467,77 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         comments_upserted=comments_upserted,
                         activity=activity,
                         progress_state=progress_state,
+                        worker_id=worker_id,
                         force=index == len(target_source_ids),
+                        extra_metadata=progress_metadata_common(),
                     )
                     continue
                 fetch_started_at = time.monotonic()
-                result = await fetcher.fetch_comments_for_shortcode(
-                    shortcode,
-                    max_comments=max_comments_per_post,
-                    fetch_replies=fetch_replies,
-                    expected_comment_count=expected_comment_counts_by_shortcode.get(shortcode),
-                )
+                fetch_kwargs: dict[str, Any] = {
+                    "max_comments": max_comments_per_post,
+                    "fetch_replies": fetch_replies,
+                    "expected_comment_count": expected_comment_counts_by_shortcode.get(shortcode),
+                }
+                resume_cursor = top_level_resume_cursors_by_shortcode.get(shortcode)
+                if resume_cursor:
+                    fetch_kwargs["top_level_cursor"] = resume_cursor
+                    resume_cursor_param = top_level_resume_cursor_params_by_shortcode.get(shortcode)
+                    if resume_cursor_param:
+                        fetch_kwargs["top_level_cursor_param"] = resume_cursor_param
+                if fetch_replies:
+                    try:
+                        persisted_replies_by_parent = _load_persisted_replies_by_parent(
+                            account_handle=account_handle,
+                            shortcode=shortcode,
+                        )
+                    except pg.DatabaseServiceUnavailableError as exc:
+                        logger.warning(
+                            "Continuing comments fetch without persisted reply hydration after database saturation: "
+                            "job_id=%s shortcode=%s error=%s",
+                            job_id,
+                            shortcode,
+                            exc,
+                        )
+                        persisted_replies_by_parent = {}
+                    if persisted_replies_by_parent:
+                        fetch_kwargs["persisted_replies_by_parent"] = persisted_replies_by_parent
+                    prior_incomplete_reason = _prior_incomplete_fetch_reason(job, shortcode)
+                    if (
+                        prior_incomplete_reason in _REPLY_ONLY_RETRY_REASONS
+                        and not resume_cursor
+                    ):
+                        try:
+                            persisted_top_level_comments = _load_persisted_top_level_comments_for_reply_retry(
+                                account_handle=account_handle,
+                                shortcode=shortcode,
+                            )
+                        except pg.DatabaseServiceUnavailableError as exc:
+                            logger.warning(
+                                "Continuing comments fetch without persisted top-level reply retry after database "
+                                "saturation: job_id=%s shortcode=%s error=%s",
+                                job_id,
+                                shortcode,
+                                exc,
+                            )
+                            persisted_top_level_comments = []
+                        if persisted_top_level_comments:
+                            fetch_kwargs["persisted_top_level_comments"] = persisted_top_level_comments
+                            fetch_kwargs["reply_only"] = True
+                if reply_resume_cursors_by_parent:
+                    fetch_kwargs["reply_resume_cursors"] = reply_resume_cursors_by_parent
+                if reply_resume_cursor_params_by_parent:
+                    fetch_kwargs["reply_resume_cursor_params"] = reply_resume_cursor_params_by_parent
+                result = await fetcher.fetch_comments_for_shortcode(shortcode, **fetch_kwargs)
                 fetch_elapsed_ms = int((time.monotonic() - fetch_started_at) * 1000)
+                top_level_checkpoint = getattr(result, "top_level_checkpoint", None)
+                if isinstance(top_level_checkpoint, dict):
+                    top_level_checkpoints_by_shortcode[shortcode] = dict(top_level_checkpoint)
+                _raise_if_job_lease_lost(
+                    job_id=job_id,
+                    worker_id=worker_id,
+                    runtime_metadata=dict(fetcher.runtime_metadata),
+                )
+                observed_comment_count = _extract_observed_comment_count(result)
                 if result.auth_failed and not result.comments:
                     normalized_auth_failed_shortcode = str(shortcode or "").strip()
                     if normalized_auth_failed_shortcode:
@@ -689,6 +1576,13 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                             "total_posts": len(target_source_ids),
                             **shard_metadata,
                         }
+                        _attach_incomplete_activity(
+                            activity,
+                            incomplete_target_source_ids=incomplete_target_source_ids,
+                            incomplete_fetch_reasons=incomplete_fetch_reasons,
+                            auth_failed_target_source_ids=auth_failed_target_source_ids,
+                            auth_failed_fetch_reasons=auth_failed_fetch_reasons,
+                        )
                         repo._emit_job_progress(
                             job_id=job_id,
                             stage=stage,
@@ -700,7 +1594,9 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                             comments_upserted=comments_upserted,
                             activity=activity,
                             progress_state=progress_state,
+                            worker_id=worker_id,
                             force=index == len(target_source_ids),
+                            extra_metadata=progress_metadata_common(),
                         )
                         continue
                     raise CommentsScraplingRuntimeError(
@@ -717,28 +1613,108 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     )
                 consecutive_post_auth_failures = 0
                 if result.fetch_failed and not result.comments:
+                    normalized_incomplete_shortcode = str(shortcode or "").strip()
+                    consecutive_post_fetch_failures += 1
+                    should_skip_post_fetch_failure = bool(result.retryable) and (
+                        successful_target_fetches > 0
+                        or consecutive_post_fetch_failures < post_fetch_failure_circuit_limit
+                    )
+                    if should_skip_post_fetch_failure:
+                        if normalized_incomplete_shortcode:
+                            incomplete_target_source_ids.append(normalized_incomplete_shortcode)
+                            incomplete_fetch_reasons[normalized_incomplete_shortcode] = str(
+                                result.fetch_reason or "retryable_post_fetch_failed"
+                            )
+                        total_elapsed_ms = int((time.monotonic() - post_started_at) * 1000)
+                        post_latency_samples.append(
+                            {
+                                "shortcode": shortcode,
+                                "fetch_elapsed_ms": fetch_elapsed_ms,
+                                "persist_elapsed_ms": 0,
+                                "total_elapsed_ms": total_elapsed_ms,
+                                "comments_fetched": 0,
+                                "observed_comment_count": 0,
+                                "top_level_comment_count": 0,
+                                "comments_upserted": 0,
+                                "comments_marked_missing": 0,
+                                "fetch_reason": result.fetch_reason,
+                                "is_complete": False,
+                                "completion_reason": "post_fetch_failed_retryable_skipped",
+                                "reported_comment_count": _extract_reported_comment_count(result),
+                            }
+                        )
+                        processed_posts += 1
+                        activity = {
+                            "phase": "comments_scrapling_running",
+                            "posts_checked": processed_posts,
+                            "matched_posts": processed_posts,
+                            "saved_posts": processed_posts,
+                            "total_posts": len(target_source_ids),
+                            **shard_metadata,
+                        }
+                        _attach_incomplete_activity(
+                            activity,
+                            incomplete_target_source_ids=incomplete_target_source_ids,
+                            incomplete_fetch_reasons=incomplete_fetch_reasons,
+                            auth_failed_target_source_ids=auth_failed_target_source_ids,
+                            auth_failed_fetch_reasons=auth_failed_fetch_reasons,
+                        )
+                        repo._emit_job_progress(
+                            job_id=job_id,
+                            stage=stage,
+                            platform="instagram",
+                            account=account_handle,
+                            scraped_posts=processed_posts,
+                            scraped_comments=comments_fetched,
+                            posts_upserted=processed_posts,
+                            comments_upserted=comments_upserted,
+                            activity=activity,
+                            progress_state=progress_state,
+                            worker_id=worker_id,
+                            force=index == len(target_source_ids),
+                            extra_metadata=progress_metadata_common(),
+                        )
+                        continue
                     raise CommentsScraplingRuntimeError(
                         f"Instagram comments fetch failed for {shortcode}.",
                         error_code=str(result.fetch_reason or "instagram_comments_fetch_failed"),
                         retryable=bool(result.retryable),
-                        runtime_metadata={"shortcode": shortcode, "fetch_reason": result.fetch_reason},
+                        runtime_metadata={
+                            "shortcode": shortcode,
+                            "fetch_reason": result.fetch_reason,
+                            "post_fetch_failure_circuit_limit": post_fetch_failure_circuit_limit,
+                            "consecutive_post_fetch_failures": consecutive_post_fetch_failures,
+                            "incomplete_target_source_ids": list(dict.fromkeys(incomplete_target_source_ids)),
+                            "incomplete_fetch_reasons": dict(incomplete_fetch_reasons),
+                        },
                     )
+                consecutive_post_fetch_failures = 0
                 is_complete = _comments_scrape_is_complete(
                     result=result,
                     max_comments_per_post=max_comments_per_post,
                 )
                 completion_reason = (
-                    "max_comments_cap"
-                    if max_comments_per_post and len(result.comments) >= max_comments_per_post
-                    else "pagination_exhausted"
+                    "pagination_exhausted"
                     if is_complete
+                    else "max_comments_cap"
+                    if max_comments_per_post and len(result.comments) >= max_comments_per_post
                     else "incomplete_fetch"
                 )
                 persist_started_at = time.monotonic()
+                stored_coverage_complete = False
+                stored_coverage_reconciled_gap = False
+                stored_coverage_terminal_gap = False
                 with pg.db_connection(label="instagram-comments-scrapling-persist") as persist_conn:
-                    _raise_if_cancelled(
+                    if should_poll_cancellation(index):
+                        _raise_if_cancelled(
+                            job_id=job_id,
+                            run_id=run_id,
+                            runtime_metadata=dict(fetcher.runtime_metadata),
+                            conn=persist_conn,
+                        )
+                    _raise_if_job_lease_lost(
                         job_id=job_id,
-                        run_id=run_id,
+                        worker_id=worker_id,
                         runtime_metadata=dict(fetcher.runtime_metadata),
                         conn=persist_conn,
                     )
@@ -750,37 +1726,79 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         job_id=job_id,
                         is_complete=is_complete,
                         source_scope=source_scope,
+                        enable_media_followups=_config_truthy(config.get("comments_enable_media_followups")),
                         conn=persist_conn,
                     )
+                    stored_coverage_complete = _persisted_comment_coverage_is_complete(
+                        result=result,
+                        stored_total_comments=persisted.stored_total_comments,
+                        max_comments_per_post=max_comments_per_post,
+                    )
+                    stored_coverage_reconciled_gap = _persisted_comment_coverage_gap_is_reconcilable(
+                        result=result,
+                        stored_total_comments=persisted.stored_total_comments,
+                        max_comments_per_post=max_comments_per_post,
+                    )
+                    stored_coverage_terminal_gap = _terminal_pagination_coverage_gap_is_reconcilable(
+                        result=result,
+                        stored_total_comments=persisted.stored_total_comments,
+                        max_comments_per_post=max_comments_per_post,
+                    )
+                    if stored_coverage_reconciled_gap or stored_coverage_terminal_gap:
+                        repo._reconcile_post_comment_count(
+                            platform="instagram",
+                            post_db_id=persisted.post_id,
+                            conn=persist_conn,
+                        )
                     persist_conn.commit()
+                _raise_if_job_lease_lost(
+                    job_id=job_id,
+                    worker_id=worker_id,
+                    runtime_metadata=dict(fetcher.runtime_metadata),
+                )
                 persist_elapsed_ms = int((time.monotonic() - persist_started_at) * 1000)
                 total_elapsed_ms = int((time.monotonic() - post_started_at) * 1000)
                 if first_post_persisted_at is None:
                     first_post_persisted_at = repo._now_utc()
-                if result.fetch_failed and result.retryable:
+                effective_is_complete = (
+                    is_complete
+                    or stored_coverage_complete
+                    or stored_coverage_reconciled_gap
+                    or stored_coverage_terminal_gap
+                )
+                if result.fetch_failed and result.retryable and not effective_is_complete:
                     normalized_incomplete_shortcode = str(shortcode or "").strip()
                     if normalized_incomplete_shortcode:
                         incomplete_target_source_ids.append(normalized_incomplete_shortcode)
                         incomplete_fetch_reasons[normalized_incomplete_shortcode] = str(
                             result.fetch_reason or "retryable_incomplete_fetch"
                         )
+                if stored_coverage_complete and not is_complete:
+                    completion_reason = "stored_comment_coverage_complete"
+                elif stored_coverage_reconciled_gap and not is_complete:
+                    completion_reason = "stored_comment_coverage_reconciled_gap"
+                elif stored_coverage_terminal_gap and not is_complete:
+                    completion_reason = "stored_comment_coverage_terminal_gap_reconciled"
                 post_latency_samples.append(
                     {
                         "shortcode": shortcode,
                         "fetch_elapsed_ms": fetch_elapsed_ms,
                         "persist_elapsed_ms": persist_elapsed_ms,
                         "total_elapsed_ms": total_elapsed_ms,
-                        "comments_fetched": len(result.comments),
+                        "comments_fetched": observed_comment_count,
+                        "observed_comment_count": observed_comment_count,
+                        "top_level_comment_count": len(result.comments),
                         "comments_upserted": persisted.comments_upserted,
                         "comments_marked_missing": persisted.comments_marked_missing,
                         "fetch_reason": result.fetch_reason,
-                        "is_complete": is_complete,
+                        "stored_total_comments": persisted.stored_total_comments,
+                        "is_complete": effective_is_complete,
                         "completion_reason": completion_reason,
                         "reported_comment_count": _extract_reported_comment_count(result),
                     }
                 )
                 processed_posts += 1
-                comments_fetched += len(result.comments)
+                comments_fetched += observed_comment_count
                 comments_upserted += persisted.comments_upserted
                 successful_target_fetches += 1
                 comments_marked_missing += persisted.comments_marked_missing
@@ -794,6 +1812,13 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     "total_posts": len(target_source_ids),
                     **shard_metadata,
                 }
+                _attach_incomplete_activity(
+                    activity,
+                    incomplete_target_source_ids=incomplete_target_source_ids,
+                    incomplete_fetch_reasons=incomplete_fetch_reasons,
+                    auth_failed_target_source_ids=auth_failed_target_source_ids,
+                    auth_failed_fetch_reasons=auth_failed_fetch_reasons,
+                )
                 repo._emit_job_progress(
                     job_id=job_id,
                     stage=stage,
@@ -805,31 +1830,46 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     comments_upserted=comments_upserted,
                     activity=activity,
                     progress_state=progress_state,
+                    worker_id=worker_id,
                     force=index == len(target_source_ids),
+                    extra_metadata=progress_metadata_common(),
                 )
 
-            retryable_incomplete_targets = list(dict.fromkeys(incomplete_target_source_ids))
+            retryable_incomplete_targets = list(
+                dict.fromkeys([*incomplete_target_source_ids, *auth_failed_target_source_ids])
+            )
             if retryable_incomplete_targets:
+                retry_fetch_reasons = {
+                    shortcode: incomplete_fetch_reasons.get(shortcode) or auth_failed_fetch_reasons.get(shortcode)
+                    for shortcode in retryable_incomplete_targets
+                }
                 raise CommentsScraplingRuntimeError(
                     "Instagram comments Scrapling job had retryable incomplete posts.",
                     error_code="instagram_comments_incomplete_retryable",
                     retryable=True,
                     runtime_metadata={
                         "incomplete_target_source_ids": retryable_incomplete_targets,
-                        "incomplete_fetch_reasons": {
-                            shortcode: incomplete_fetch_reasons.get(shortcode)
-                            for shortcode in retryable_incomplete_targets
-                        },
+                        "incomplete_fetch_reasons": retry_fetch_reasons,
+                        "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
+                        "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
                     },
                 )
 
             return auth_metadata, dict(fetcher.runtime_metadata)
         finally:
+            heartbeat_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await heartbeat_task
             fetcher_metadata = dict(fetcher.runtime_metadata)
             await fetcher.aclose()
 
     try:
         auth_metadata, fetcher_metadata = asyncio.run(_run_job())
+        _raise_if_job_lease_lost(
+            job_id=job_id,
+            worker_id=worker_id,
+            runtime_metadata=dict(fetcher_metadata),
+        )
         metadata = {
             "stage": stage,
             "platform": "instagram",
@@ -837,6 +1877,8 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             "mode": mode,
             "source_scope": source_scope,
             "target_source_ids": target_source_ids,
+            "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
+            "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
             **terminal_metadata_common(),
             "stage_counters": {"posts": processed_posts, "comments": comments_fetched},
             "skipped_complete_target_source_ids": skipped_complete_target_source_ids,
@@ -863,9 +1905,19 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             status="completed",
             items_found=processed_posts + comments_fetched,
             metadata=metadata,
+            expected_worker_id=worker_id,
         )
         terminal_status = "completed"
         terminal_error_message = None
+    except ScraplingJobLeaseLostError as exc:
+        logger.warning(
+            "Instagram comments Scrapling job stopped after losing queue lease: job_id=%s status=%s worker_id=%s",
+            job_id,
+            exc.job_status,
+            exc.job_worker_id,
+        )
+        terminal_status = exc.job_status or "unknown"
+        terminal_error_message = str(exc)
     except ScraplingJobCancelledError as exc:
         repo._finish_job(
             job_id,
@@ -880,8 +1932,10 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 "source_scope": source_scope,
                 "target_source_ids": target_source_ids,
                 "incomplete_target_source_ids": list(dict.fromkeys(incomplete_target_source_ids)),
+                "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
                 "skipped_complete_target_source_ids": skipped_complete_target_source_ids,
                 "incomplete_fetch_reasons": dict(incomplete_fetch_reasons),
+                "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
                 **terminal_metadata_common(),
                 "cancelled": True,
                 "cancel_scope": exc.cancel_scope,
@@ -904,10 +1958,12 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     target_source_ids=target_source_ids,
                     processed_posts=processed_posts,
                     incomplete_target_source_ids=incomplete_target_source_ids,
+                    auth_failed_target_source_ids=auth_failed_target_source_ids,
                 ),
             },
             last_error_code="instagram_comments_scrapling_cancelled",
             last_error_class=exc.__class__.__name__,
+            expected_worker_id=worker_id,
         )
         terminal_status = "cancelled"
         terminal_error_message = str(exc)
@@ -931,14 +1987,13 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         )
         error_class = str(getattr(exc, "error_class", "") or exc.__class__.__name__).strip()
         retryable = bool(getattr(exc, "retryable", False)) or database_capacity_error or transport_error
-        attempt_count = int(job.get("attempt_count") or 1)
-        max_attempts = int(job.get("max_attempts") or 1)
         can_retry = retryable and attempt_count < max_attempts
         retry_rebalance = _retry_rebalance_metadata(
             comments_shard_count=comments_shard_count,
             target_source_ids=target_source_ids,
             processed_posts=processed_posts,
             incomplete_target_source_ids=retry_incomplete_targets or incomplete_target_source_ids,
+            auth_failed_target_source_ids=auth_failed_target_source_ids,
         )
         retry_target_source_ids = retry_incomplete_targets or [
             str(item or "").strip()
@@ -979,11 +2034,18 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 "source_scope": source_scope,
                 "target_source_ids": target_source_ids,
                 "incomplete_target_source_ids": list(dict.fromkeys(incomplete_target_source_ids)),
+                "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
                 "skipped_complete_target_source_ids": skipped_complete_target_source_ids,
                 "incomplete_fetch_reasons": dict(incomplete_fetch_reasons),
+                "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
                 **terminal_metadata_common(),
                 "error_code": error_code,
                 "error_class": error_class,
+                "retryable": retryable,
+                "can_retry": can_retry,
+                "retry_exhausted": bool(retryable and not can_retry),
+                "attempt_count": attempt_count,
+                "max_attempts": max_attempts,
                 "activity": {"phase": "failed", "last_progress_at": repo._iso(repo._now_utc())},
                 "persist_counters": {
                     "posts_upserted": processed_posts,
@@ -997,6 +2059,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             last_error_code=error_code,
             last_error_class=error_class,
             next_available_at=next_available_at,
+            expected_worker_id=worker_id,
         )
         terminal_status = "retrying" if can_retry else "failed"
         terminal_error_message = str(exc)
@@ -1024,7 +2087,15 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
     finally:
         if run_id:
             try:
-                repo._finalize_run_status(run_id)
+                finalize_result = repo._finalize_run_status(run_id)
+                if isinstance(finalize_result, dict) and finalize_result.get("finalize_deferred"):
+                    logger.warning(
+                        "Retrying deferred comments run-status reconciliation: run_id=%s error=%s",
+                        run_id,
+                        finalize_result.get("error"),
+                    )
+                    time.sleep(2.0)
+                    repo._finalize_run_status(run_id, force_recompute=True)
             except pg.DatabaseServiceUnavailableError as exc:
                 logger.warning(
                     "Deferred final comments run-status reconciliation after database saturation: run_id=%s error=%s",

--- a/trr_backend/socials/instagram/comments_scrapling/persistence.py
+++ b/trr_backend/socials/instagram/comments_scrapling/persistence.py
@@ -274,6 +274,14 @@ def _persist_without_season_context(
     has_hosted_media = repo._column_exists("social", "instagram_comments", "hosted_media_urls")
     has_media_mirror_status = repo._column_exists("social", "instagram_comments", "media_mirror_status")
     has_media_mirror_error = repo._column_exists("social", "instagram_comments", "media_mirror_error")
+    # Phase 2: Apify-source owner-metadata columns. Each gated independently so
+    # partial migrations remain safe.
+    has_comment_url = repo._column_exists("social", "instagram_comments", "comment_url")
+    has_author_fbid_v2 = repo._column_exists("social", "instagram_comments", "author_fbid_v2")
+    has_author_is_mentionable = repo._column_exists("social", "instagram_comments", "author_is_mentionable")
+    has_author_is_private = repo._column_exists("social", "instagram_comments", "author_is_private")
+    has_author_latest_reel_media = repo._column_exists("social", "instagram_comments", "author_latest_reel_media")
+    has_author_profile_pic_id = repo._column_exists("social", "instagram_comments", "author_profile_pic_id")
     has_lifecycle = repo._comment_lifecycle_supported("instagram_comments")
     flat: list[tuple[InstagramComment, str | None]] = []
     for comment in comments:
@@ -338,6 +346,25 @@ def _persist_without_season_context(
                 else "season_context_missing"
                 if enable_media_followups
                 else "media_followups_disabled"
+            )
+        # Phase 2: write Apify-source owner-metadata columns when present.
+        if has_comment_url:
+            payload["comment_url"] = (
+                str(getattr(comment_obj, "comment_url", "") or "").strip() or None
+            )
+        if has_author_fbid_v2:
+            payload["author_fbid_v2"] = (
+                str(getattr(comment_obj, "owner_fbid_v2", "") or "").strip() or None
+            )
+        if has_author_is_mentionable:
+            payload["author_is_mentionable"] = getattr(comment_obj, "owner_is_mentionable", None)
+        if has_author_is_private:
+            payload["author_is_private"] = getattr(comment_obj, "owner_is_private", None)
+        if has_author_latest_reel_media:
+            payload["author_latest_reel_media"] = getattr(comment_obj, "owner_latest_reel_media", None)
+        if has_author_profile_pic_id:
+            payload["author_profile_pic_id"] = (
+                str(getattr(comment_obj, "owner_profile_pic_id", "") or "").strip() or None
             )
         reply_depth = _comment_effective_reply_depth(
             comment_obj,

--- a/trr_backend/socials/instagram/comments_scrapling/persistence.py
+++ b/trr_backend/socials/instagram/comments_scrapling/persistence.py
@@ -45,6 +45,16 @@ def _load_repo_helpers():
     return repo
 
 
+def _comment_effective_reply_depth(comment: InstagramComment, parent_external_id: str | None, *, fallback: int) -> int:
+    try:
+        parsed_depth = int(getattr(comment, "reply_depth", 0) or 0)
+    except (TypeError, ValueError):
+        parsed_depth = 0
+    if parsed_depth > 0 or not parent_external_id:
+        return max(0, parsed_depth)
+    return max(0, int(fallback or 0))
+
+
 def find_instagram_post_for_comments(
     *,
     account_handle: str,
@@ -162,6 +172,7 @@ def persist_instagram_comments_for_post(
     job_id: str | None,
     is_complete: bool,
     source_scope: str = "bravo",
+    enable_media_followups: bool = True,
     conn: Any | None = None,
 ) -> PersistedInstagramComments:
     if conn is None:
@@ -174,6 +185,7 @@ def persist_instagram_comments_for_post(
                 job_id=job_id,
                 is_complete=is_complete,
                 source_scope=source_scope,
+                enable_media_followups=enable_media_followups,
                 conn=managed_conn,
             )
 
@@ -203,6 +215,7 @@ def persist_instagram_comments_for_post(
             observed_comment_ids=observed_comment_ids,
             persist_stats=persist_stats,
             source_scope=source_scope,
+            enable_media_followups=enable_media_followups,
             conn=conn,
         )
     else:
@@ -215,9 +228,10 @@ def persist_instagram_comments_for_post(
             job_id=job_id,
             observed_comment_ids=observed_comment_ids,
             persist_stats=persist_stats,
+            enable_media_followups=enable_media_followups,
             conn=conn,
         )
-    if is_complete:
+    if isinstance(is_complete, bool) and is_complete:
         comments_marked_missing = repo._mark_missing_comments_for_anchor(
             platform="instagram",
             anchor_id=post_id,
@@ -251,11 +265,15 @@ def _persist_without_season_context(
     job_id: str | None,
     observed_comment_ids: set[str],
     persist_stats: dict[str, int],
+    enable_media_followups: bool,
     conn: Any,
 ) -> int:
     has_profile_pic = repo._column_exists("social", "instagram_comments", "author_profile_pic_url")
     has_verified = repo._column_exists("social", "instagram_comments", "author_is_verified")
     has_media = repo._column_exists("social", "instagram_comments", "media_urls")
+    has_hosted_media = repo._column_exists("social", "instagram_comments", "hosted_media_urls")
+    has_media_mirror_status = repo._column_exists("social", "instagram_comments", "media_mirror_status")
+    has_media_mirror_error = repo._column_exists("social", "instagram_comments", "media_mirror_error")
     has_lifecycle = repo._comment_lifecycle_supported("instagram_comments")
     flat: list[tuple[InstagramComment, str | None]] = []
     for comment in comments:
@@ -304,15 +322,33 @@ def _persist_without_season_context(
             )
         if has_verified:
             payload["author_is_verified"] = getattr(comment_obj, "owner_is_verified", None)
+        media_urls = [str(url).strip() for url in (getattr(comment_obj, "media_urls", []) or []) if str(url).strip()]
         if has_media:
-            payload["media_urls"] = [
-                str(url).strip() for url in (getattr(comment_obj, "media_urls", []) or []) if str(url).strip()
+            payload["media_urls"] = media_urls
+        if has_hosted_media:
+            payload["hosted_media_urls"] = [
+                str(url).strip() for url in (getattr(comment_obj, "hosted_media_urls", []) or []) if str(url).strip()
             ]
+        if has_media_mirror_status:
+            payload["media_mirror_status"] = "deferred" if media_urls else None
+        if has_media_mirror_error:
+            payload["media_mirror_error"] = (
+                None
+                if not media_urls
+                else "season_context_missing"
+                if enable_media_followups
+                else "media_followups_disabled"
+            )
+        reply_depth = _comment_effective_reply_depth(
+            comment_obj,
+            parent_external_id,
+            fallback=1 if parent_external_id else 0,
+        )
         repo._apply_instagram_comment_queryable_columns(
             payload,
             comment_obj,
             parent_external_id=parent_external_id,
-            reply_depth=1 if parent_external_id else 0,
+            reply_depth=reply_depth,
         )
         if parent_external_id is None:
             top_level.append(payload)

--- a/trr_backend/socials/instagram/comments_scrapling/proxy.py
+++ b/trr_backend/socials/instagram/comments_scrapling/proxy.py
@@ -53,9 +53,20 @@ def _split_proxy_values(raw: str) -> list[str]:
     return values
 
 
-def _build_proxy_rotator(browser_proxy: str | dict[str, str] | None) -> Any | None:
-    """Build a ProxyRotator for the browser warmup path. Accepts both dict
-    (Decodo — bypasses URL-parsing bug) and str (explicit PROXY_URLS).
+def _build_proxy_rotator(
+    browser_proxy: str | dict[str, str] | list[str | dict[str, str]] | None,
+) -> Any | None:
+    """Build a ProxyRotator for the browser warmup path.
+
+    Accepts:
+      * ``None``                                   → returns None (local-dev mode)
+      * ``str`` / ``dict``                         → wrapped in a single-element list
+      * ``list[str | dict[str, str]]``             → passed through unchanged
+
+    Phase 5.1: explicit PROXY_URLS callers can now pass the full env-supplied
+    URL list so the Scrapling ``ProxyRotator`` sees every IP, instead of the
+    previous one-element stub. The Decodo path still passes a single dict
+    because its gateway rotates IPs server-side.
     """
     if browser_proxy is None:
         return None
@@ -63,6 +74,11 @@ def _build_proxy_rotator(browser_proxy: str | dict[str, str] | None) -> Any | No
         from scrapling.fetchers import ProxyRotator
     except Exception as exc:  # noqa: BLE001
         raise RuntimeError("Scrapling proxy rotation is unavailable. Install scrapling[fetchers].") from exc
+    if isinstance(browser_proxy, list):
+        normalized = [value for value in browser_proxy if value]
+        if not normalized:
+            return None
+        return ProxyRotator(normalized)
     return ProxyRotator([browser_proxy])
 
 
@@ -133,7 +149,13 @@ def select_comments_proxy(*, session_key: str | None = None) -> CommentsProxyCon
     explicit_urls = _load_proxy_urls_from_env()
     if explicit_urls:
         selected_url = _explicit_proxy_url_for_session(explicit_urls, session_key)
-        rotator = _build_proxy_rotator(selected_url)
+        # Phase 5.1: hand the full URL list to the rotator so Scrapling can
+        # rotate across IPs during warmup, while keeping browser_proxy and
+        # api_proxy_url pinned to the deterministic per-shard selection so
+        # api-side requests stay on a stable session.
+        rotator = _build_proxy_rotator(list(explicit_urls)) if len(explicit_urls) > 1 else _build_proxy_rotator(
+            selected_url
+        )
         return CommentsProxyConfig(
             browser_proxy=selected_url,
             api_proxy_url=selected_url,

--- a/trr_backend/socials/instagram/comments_scrapling/proxy.py
+++ b/trr_backend/socials/instagram/comments_scrapling/proxy.py
@@ -10,6 +10,7 @@ are private helpers.
 
 from __future__ import annotations
 
+import hashlib
 import os
 from dataclasses import dataclass
 from typing import Any
@@ -78,6 +79,18 @@ def _fingerprint_from_url(url: str) -> str:
     return f"{host}:{port}:explicit"
 
 
+def _explicit_proxy_url_for_session(proxy_urls: list[str], session_key: str | None) -> str:
+    """Pick one explicit proxy URL deterministically for a session/shard key."""
+    urls = [str(url or "").strip() for url in proxy_urls if str(url or "").strip()]
+    if not urls:
+        raise ValueError("proxy_urls must contain at least one URL")
+    normalized_key = str(session_key or "").strip().lower()
+    if not normalized_key or len(urls) == 1:
+        return urls[0]
+    digest = hashlib.sha256(normalized_key.encode("utf-8")).hexdigest()
+    return urls[int(digest[:16], 16) % len(urls)]
+
+
 # ---------------------------------------------------------------------------
 # Internal env readers
 # ---------------------------------------------------------------------------
@@ -119,14 +132,14 @@ def select_comments_proxy(*, session_key: str | None = None) -> CommentsProxyCon
     # 1. Explicit proxy URLs take precedence.
     explicit_urls = _load_proxy_urls_from_env()
     if explicit_urls:
-        first_url = explicit_urls[0]
-        rotator = _build_proxy_rotator(first_url)
+        selected_url = _explicit_proxy_url_for_session(explicit_urls, session_key)
+        rotator = _build_proxy_rotator(selected_url)
         return CommentsProxyConfig(
-            browser_proxy=first_url,
-            api_proxy_url=first_url,
+            browser_proxy=selected_url,
+            api_proxy_url=selected_url,
             proxy_rotator=rotator,
-            fingerprint=_fingerprint_from_url(first_url),
-            session_mode="explicit",
+            fingerprint=_fingerprint_from_url(selected_url),
+            session_mode="explicit_sharded" if len(explicit_urls) > 1 and session_key else "explicit",
         )
 
     # 2. Decodo provider (default when env has credentials).

--- a/trr_backend/socials/instagram/constants.py
+++ b/trr_backend/socials/instagram/constants.py
@@ -37,6 +37,9 @@ COMMENTS_URL = "https://www.instagram.com/api/v1/media/{media_id}/comments/"
 COMMENT_REPLIES_URL = "https://www.instagram.com/api/v1/media/{media_id}/comments/{comment_id}/child_comments/"
 PROFILE_PAGE_URL = "https://www.instagram.com/{username}/"
 PERMALINK_URL = "https://www.instagram.com/p/{shortcode}/"
+COMMENT_SORT_ORDER_ENV = "SOCIAL_INSTAGRAM_COMMENTS_SORT_ORDER"
+DEFAULT_COMMENT_SORT_ORDER = "recent"
+VALID_COMMENT_SORT_ORDERS = frozenset({"popular", "recent"})
 
 PROFILE_POSTS_DOC_IDS = (
     "25645538101792896",
@@ -64,3 +67,19 @@ AUTH_FATAL_MESSAGES = {
     "sentry_block",
 }
 
+
+def resolve_comment_sort_order(raw_value: str | None = None) -> str | None:
+    """Resolve the Instagram comments ordering used for full pagination.
+
+    Instagram's default ranked ordering can cycle through headload cursors on
+    high-volume posts. The `recent` order is the safer default for coverage
+    backfills; operators can set the env var to `popular` for one-off parity
+    checks, or `none` to omit the parameter during upstream debugging.
+    """
+    raw = raw_value if raw_value is not None else os.getenv(COMMENT_SORT_ORDER_ENV)
+    value = str(raw or DEFAULT_COMMENT_SORT_ORDER).strip().lower()
+    if value in {"", "none", "default", "off", "false"}:
+        return None
+    if value in VALID_COMMENT_SORT_ORDERS:
+        return value
+    return DEFAULT_COMMENT_SORT_ORDER

--- a/trr_backend/socials/instagram/constants.py
+++ b/trr_backend/socials/instagram/constants.py
@@ -41,11 +41,40 @@ COMMENT_SORT_ORDER_ENV = "SOCIAL_INSTAGRAM_COMMENTS_SORT_ORDER"
 DEFAULT_COMMENT_SORT_ORDER = "recent"
 VALID_COMMENT_SORT_ORDERS = frozenset({"popular", "recent"})
 
-PROFILE_POSTS_DOC_IDS = (
+PROFILE_POSTS_DOC_IDS_ENV = "SOCIAL_INSTAGRAM_PROFILE_POSTS_DOC_IDS"
+_PROFILE_POSTS_DOC_IDS_FALLBACK = (
     "25645538101792896",
     "26035927152742158",
     "33944389991841132",
 )
+
+
+def resolve_profile_posts_doc_ids(raw_value: str | None = None) -> tuple[str, ...]:
+    """Phase 4.1: env-driven hot rotation for IG profile-posts GraphQL doc IDs.
+
+    Comma-separated values from ``SOCIAL_INSTAGRAM_PROFILE_POSTS_DOC_IDS`` are
+    parsed, whitespace-stripped, deduplicated, and validated as digit-only
+    strings. When the env var is unset, empty, or every entry is invalid, the
+    hardcoded fallback tuple is returned instead. Operators can hot-rotate
+    without a deploy when IG bumps doc IDs.
+    """
+    raw = raw_value if raw_value is not None else os.getenv(PROFILE_POSTS_DOC_IDS_ENV)
+    if not raw:
+        return _PROFILE_POSTS_DOC_IDS_FALLBACK
+    seen: set[str] = set()
+    chosen: list[str] = []
+    for token in str(raw).split(","):
+        candidate = token.strip()
+        if not candidate or not candidate.isdigit():
+            continue
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        chosen.append(candidate)
+    return tuple(chosen) if chosen else _PROFILE_POSTS_DOC_IDS_FALLBACK
+
+
+PROFILE_POSTS_DOC_IDS = resolve_profile_posts_doc_ids()
 
 WEB_X_ASBD_ID = "359341"
 PROFILE_POSTS_PAGE_SIZE = int(os.getenv("SOCIAL_INSTAGRAM_PAGE_SIZE", "33"))

--- a/trr_backend/socials/instagram/post_normalizer.py
+++ b/trr_backend/socials/instagram/post_normalizer.py
@@ -203,8 +203,12 @@ def normalize_instagram_post(payload: dict[str, Any], *, account_handle: str | N
         audio_url=_string_or_none(_first_value(node, "audioUrl", "audio_url")),
         video_duration=_coerce_float(_first_value(node, "videoDuration", "video_duration", "duration")),
         video_play_count=_coerce_int_or_none(_first_value(node, "videoPlayCount", "video_play_count", "play_count")),
+        # Phase 3.3 / audit: original list duplicated "video_view_count"; the
+        # second slot now falls back to "play_count" so reels lacking
+        # videoViewCount but exposing play_count get a real number instead of
+        # None. Keep snake_case + camelCase variants for cross-payload coverage.
         video_view_count=_coerce_int_or_none(
-            _first_value(node, "videoViewCount", "video_view_count", "video_view_count", "view_count")
+            _first_value(node, "videoViewCount", "video_view_count", "play_count", "view_count")
         ),
         context_items=_extract_context_items(node),
         child_posts=child_posts,
@@ -482,13 +486,50 @@ def _extract_tagged_users(node: dict[str, Any]) -> list[InstagramTaggedUser]:
             user = item.get("user") if isinstance(item.get("user"), dict) else item
             add_user(user, _extract_position(item, source_prefix="apify_tagged_users"))
 
+    # Phase 3.4: also read users_in_photo (alt REST shape) and any nested
+    # usertags inside image_versions2.candidates[]. Both are payload variants
+    # IG sometimes returns when the standard usertags / taggedUsers blocks are
+    # absent or sparse.
+    users_in_photo = node.get("users_in_photo")
+    if isinstance(users_in_photo, list):
+        for item in users_in_photo:
+            if not isinstance(item, dict):
+                continue
+            user = item.get("user") if isinstance(item.get("user"), dict) else item
+            add_user(user, _extract_position(item, source_prefix="rest_users_in_photo"))
+
+    image_versions2 = node.get("image_versions2")
+    if isinstance(image_versions2, dict):
+        candidates = image_versions2.get("candidates")
+        if isinstance(candidates, list):
+            for candidate in candidates:
+                if not isinstance(candidate, dict):
+                    continue
+                candidate_usertags = candidate.get("usertags")
+                if not isinstance(candidate_usertags, dict):
+                    continue
+                for item in candidate_usertags.get("in") or []:
+                    if not isinstance(item, dict):
+                        continue
+                    user = item.get("user") if isinstance(item.get("user"), dict) else {}
+                    add_user(user, _extract_position(item, source_prefix="rest_image_versions2_usertags"))
+
     return tagged
 
 
 def _extract_collaborators(node: dict[str, Any]) -> list[InstagramUser]:
     collaborators: list[InstagramUser] = []
     seen: set[str] = set()
-    for key in ("coauthor_producers", "invited_coauthor_producers", "coauthorProducers", "coauthors"):
+    # Phase 3.5: include coauthor_producer_users / coauthor_invited_users which
+    # IG ships on some web GraphQL responses where the original key list misses.
+    for key in (
+        "coauthor_producers",
+        "invited_coauthor_producers",
+        "coauthorProducers",
+        "coauthors",
+        "coauthor_producer_users",
+        "coauthor_invited_users",
+    ):
         values = node.get(key)
         if not isinstance(values, list):
             continue

--- a/trr_backend/socials/instagram/posts_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/posts_scrapling/fetcher.py
@@ -318,6 +318,13 @@ class InstagramPostsScraplingFetcher:
         self._proxy_session_mode: str = proxy_config.session_mode if proxy_config else "none"
         self._page_tokens: dict[str, str] = {}
         self._retry_reason_counts: dict[str, int] = {}
+        # Phase 4.2: doc-ID rotation observability — record which doc IDs were
+        # tried this run and which one ultimately succeeded. Operators can
+        # cross-reference http_400 / non_json_response spikes with rotation
+        # events and decide when to update SOCIAL_INSTAGRAM_PROFILE_POSTS_DOC_IDS.
+        self._doc_ids_configured: tuple[str, ...] = tuple(PROFILE_POSTS_DOC_IDS)
+        self._doc_ids_attempted: list[str] = []
+        self._doc_id_used: str | None = None
         self._api_delay_seconds = _resolve_positive_float_env(
             "SOCIAL_INSTAGRAM_DELAY_SEC",
             _POSTS_REQUEST_DELAY_DEFAULT,
@@ -354,6 +361,12 @@ class InstagramPostsScraplingFetcher:
             "request_count": self._request_count,
             "transport": "httpx_after_browser_warmup",
             "retry_reason_counts": dict(sorted(self._retry_reason_counts.items())),
+            # Phase 4.2: doc-ID rotation telemetry.
+            "profile_posts_doc_ids": {
+                "configured": list(self._doc_ids_configured),
+                "attempted": list(self._doc_ids_attempted),
+                "used": self._doc_id_used,
+            },
         }
 
     async def warmup(self, username: str) -> None:
@@ -417,6 +430,9 @@ class InstagramPostsScraplingFetcher:
         retryable = False
 
         for doc_id in PROFILE_POSTS_DOC_IDS:
+            # Phase 4.2: track every doc_id this run actually tried.
+            if doc_id not in self._doc_ids_attempted:
+                self._doc_ids_attempted.append(doc_id)
             data = _build_graphql_form_data(
                 username=username,
                 cursor=cursor,
@@ -473,6 +489,9 @@ class InstagramPostsScraplingFetcher:
                 if isinstance(node, dict) and node:
                     posts.append(node)
 
+            # Phase 4.2: record the doc_id that produced data so operators can
+            # see which IDs are healthy without grepping logs.
+            self._doc_id_used = doc_id
             return InstagramPostsFetchResult(
                 posts=posts,
                 fetch_failed=False,

--- a/trr_backend/socials/instagram/scraper.py
+++ b/trr_backend/socials/instagram/scraper.py
@@ -56,6 +56,7 @@ from trr_backend.socials.instagram.constants import (
     QUERY_TYPE_GRAPHQL_PROFILE_POSTS,
     QUERY_TYPE_LEGACY,
     QUERY_TYPE_PROFILE_INFO,
+    resolve_comment_sort_order,
 )
 from trr_backend.socials.instagram.constants import (
     WEB_X_ASBD_ID as IG_WEB_X_ASBD_ID,
@@ -216,6 +217,8 @@ class InstagramComment:
     owner_profile_pic_url: str | None = None
     owner_profile_pic_url_hd: str | None = None
     owner_is_verified: bool | None = None
+    is_hidden_by_instagram: bool = False
+    source_snapshot_type: str = "full_comments_scrape"
 
     # Post reference
     post_shortcode: str = ""
@@ -1467,6 +1470,10 @@ class InstagramScraper:
         if request_cookies.get("csrftoken"):
             headers["x-csrftoken"] = request_cookies["csrftoken"]
         return headers
+
+    def get_headers(self, referer: str | None = None) -> dict:
+        """Public header builder for shared Instagram transports."""
+        return self._get_headers(referer)
 
     @staticmethod
     def _graphql_error_response_message(response: requests.Response | None) -> str | None:
@@ -3086,6 +3093,7 @@ class InstagramScraper:
         comments_fetched = 0
         pages_seen = 0
         seen_cursors: set[str] = set()
+        comment_sort_order = resolve_comment_sort_order()
         deadline = time.monotonic() + self._resolve_positive_float_env(
             "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_SECONDS",
             _COMMENT_PAGINATION_MAX_SECONDS_DEFAULT,
@@ -3108,8 +3116,11 @@ class InstagramScraper:
             self._rate_limit_with_lock(delay, fast_mode=fast_mode, rate_lock=rate_lock)
             url = self.COMMENTS_URL.format(media_id=media_id)
             params = {"can_support_threading": "true", "permalink_enabled": "false"}
+            if comment_sort_order:
+                params["sort_order"] = comment_sort_order
             if cursor:
-                params["min_id"] = cursor
+                cursor_param_name, cursor_value = cursor
+                params[cursor_param_name] = cursor_value
 
             headers = self._get_headers(post_url)
 
@@ -3176,8 +3187,8 @@ class InstagramScraper:
                 comments.append(comment)
                 comments_fetched += 1
 
-                # Fetch replies if requested and comment has replies
-                if fetch_replies and comment.reply_count > 0 and not comment.replies:
+                # Fetch reply tails when Instagram only embedded a preview subset.
+                if fetch_replies and comment.reply_count > self._observed_reply_count(comment):
                     replies = self._fetch_comment_replies(
                         media_id,
                         comment.comment_id,
@@ -3187,7 +3198,11 @@ class InstagramScraper:
                         fast_mode=fast_mode,
                         rate_lock=rate_lock,
                     )
-                    comment.replies = replies
+                    comment.replies = self._merge_comment_replies(
+                        comment.replies,
+                        replies,
+                        parent_comment_id=comment.comment_id,
+                    )
                     logger.info(f"  Comment {comment.comment_id}: {comment.reply_count} replies fetched")
 
                 if max_comments and comments_fetched >= max_comments:
@@ -3205,11 +3220,24 @@ class InstagramScraper:
                 has_more = has_more or bool(data.get("has_more_headload_comments", False))
             if not has_more:
                 break
-            next_cursor = (data.get("next_min_id") or data.get("next_max_id")) if isinstance(data, dict) else None
+            next_cursor = None
+            cursor_param_name = "min_id"
+            if isinstance(data, dict):
+                if data.get("has_more_comments") and data.get("next_max_id"):
+                    next_cursor = data.get("next_max_id")
+                    cursor_param_name = "max_id"
+                elif data.get("has_more_headload_comments") and data.get("next_min_id"):
+                    next_cursor = data.get("next_min_id")
+                    cursor_param_name = "min_id"
+                else:
+                    next_cursor = data.get("next_min_id") or data.get("next_max_id")
+                    cursor_param_name = "min_id" if data.get("next_min_id") else "max_id"
             if not next_cursor:
                 break
             next_cursor = str(next_cursor)
-            if next_cursor == cursor or next_cursor in seen_cursors:
+            next_cursor_key = f"{cursor_param_name}:{next_cursor}"
+            current_cursor_key = f"{cursor[0]}:{cursor[1]}" if cursor else None
+            if next_cursor_key == current_cursor_key or next_cursor_key in seen_cursors:
                 self.last_comment_fetch_reason = "pagination_repeated_cursor"
                 logger.warning(
                     "Instagram comments pagination repeated cursor for shortcode=%s cursor=%s",
@@ -3225,11 +3253,45 @@ class InstagramScraper:
                     page_cap,
                 )
                 break
-            seen_cursors.add(next_cursor)
-            cursor = next_cursor
+            seen_cursors.add(next_cursor_key)
+            cursor = (cursor_param_name, next_cursor)
 
         logger.info(f"Total: {len(comments)} comments fetched for {shortcode}")
         return comments
+
+    @staticmethod
+    def _observed_reply_count(comment: InstagramComment) -> int:
+        seen_ids: set[str] = set()
+        count = 0
+        for reply in list(comment.replies or []):
+            reply_id = str(getattr(reply, "comment_id", "") or "").strip()
+            if reply_id:
+                if reply_id in seen_ids:
+                    continue
+                seen_ids.add(reply_id)
+            count += 1
+        return count
+
+    @staticmethod
+    def _merge_comment_replies(
+        existing_replies: list[InstagramComment],
+        fetched_replies: list[InstagramComment],
+        *,
+        parent_comment_id: str | None,
+    ) -> list[InstagramComment]:
+        merged: list[InstagramComment] = []
+        seen_ids: set[str] = set()
+        for reply in [*list(existing_replies or []), *list(fetched_replies or [])]:
+            reply_id = str(getattr(reply, "comment_id", "") or "").strip()
+            if reply_id:
+                if reply_id in seen_ids:
+                    continue
+                seen_ids.add(reply_id)
+            if parent_comment_id and not reply.parent_comment_id:
+                reply.parent_comment_id = parent_comment_id
+            reply.is_reply = True
+            merged.append(reply)
+        return merged
 
     def _fetch_comment_replies(
         self,
@@ -3245,6 +3307,7 @@ class InstagramScraper:
         """Fetch replies to a specific comment."""
         replies = []
         cursor = None
+        cursor_param_name = None
         pages_seen = 0
         seen_cursors: set[str] = set()
         deadline = time.monotonic() + self._resolve_positive_float_env(
@@ -3270,7 +3333,7 @@ class InstagramScraper:
             url = self.COMMENT_REPLIES_URL.format(media_id=media_id, comment_id=comment_id)
             params = {}
             if cursor:
-                params["min_id"] = cursor
+                params[cursor_param_name or "min_id"] = cursor
 
             headers = self._get_headers(post_url)
 
@@ -3333,19 +3396,26 @@ class InstagramScraper:
                 replies.append(reply)
 
             # Check for more pages
-            has_more_tail = bool(data.get("has_more_tail_child_comments", False)) if isinstance(data, dict) else False
-            if not has_more_tail:
+            if not isinstance(data, dict):
                 break
-            cursor = data.get("next_min_child_cursor") if isinstance(data, dict) else None
-            if not cursor:
+            has_more_tail = bool(data.get("has_more_tail_child_comments", False))
+            has_more_head = bool(data.get("has_more_head_child_comments", False))
+            if has_more_tail and data.get("next_min_child_cursor"):
+                next_cursor = str(data["next_min_child_cursor"])
+                next_cursor_param_name = "min_id"
+            elif has_more_head and data.get("next_max_child_cursor"):
+                next_cursor = str(data["next_max_child_cursor"])
+                next_cursor_param_name = "max_id"
+            else:
                 break
-            cursor = str(cursor)
-            if cursor in seen_cursors:
+            next_cursor_key = f"{next_cursor_param_name}:{next_cursor}"
+            current_cursor_key = f"{cursor_param_name}:{cursor}" if cursor and cursor_param_name else None
+            if next_cursor_key == current_cursor_key or next_cursor_key in seen_cursors:
                 self.last_comment_fetch_reason = "pagination_repeated_cursor"
                 logger.warning(
                     "Instagram reply pagination repeated cursor for comment_id=%s cursor=%s",
                     comment_id,
-                    cursor,
+                    next_cursor,
                 )
                 break
             if pages_seen >= page_cap:
@@ -3356,7 +3426,9 @@ class InstagramScraper:
                     page_cap,
                 )
                 break
-            seen_cursors.add(cursor)
+            seen_cursors.add(next_cursor_key)
+            cursor = next_cursor
+            cursor_param_name = next_cursor_param_name
 
         return replies
 
@@ -3570,6 +3642,25 @@ class InstagramScraper:
                 comment.reply_count = len(comment.replies)
         return comment
 
+    def parse_comment(
+        self,
+        data: dict,
+        shortcode: str,
+        post_url: str,
+        is_reply: bool = False,
+        parent_id: str | None = None,
+        reply_depth: int | None = None,
+    ) -> InstagramComment:
+        """Public comment parser for shared comments fetcher integrations."""
+        return self._parse_comment(
+            data,
+            shortcode,
+            post_url,
+            is_reply=is_reply,
+            parent_id=parent_id,
+            reply_depth=reply_depth,
+        )
+
     @staticmethod
     def _extract_hosted_comment_media_urls(data: dict[str, Any]) -> list[str]:
         urls: list[str] = []
@@ -3616,6 +3707,7 @@ class InstagramScraper:
 
             for key in (
                 "url",
+                "uri",
                 "display_url",
                 "displayUrl",
                 "video_url",
@@ -3626,6 +3718,13 @@ class InstagramScraper:
                 "thumbnailUrl",
                 "media_url",
                 "mediaUrl",
+                "animated_image_url",
+                "animatedImageUrl",
+                "fixed_height_url",
+                "fixedHeightUrl",
+                "fixed_width_url",
+                "fixedWidthUrl",
+                "webp",
                 "src",
             ):
                 _append(node.get(key))
@@ -3634,19 +3733,45 @@ class InstagramScraper:
                 "media",
                 "comment_media",
                 "commentMedia",
+                "comment_gif",
+                "commentGif",
                 "media_versions",
                 "attachment",
                 "attachments",
                 "content",
                 "preview",
                 "image",
+                "images",
                 "image_versions2",
                 "video_versions",
                 "carousel_media",
+                "sticker",
+                "stickers",
+                "sticker_asset",
+                "stickerAsset",
+                "static_sticker",
+                "staticSticker",
+                "gift",
+                "gifts",
+                "gift_media",
+                "giftMedia",
+                "gif",
+                "gif_media",
+                "gifMedia",
                 "giphy_media_info",
                 "giphyMediaInfo",
+                "tenor_media_info",
+                "tenorMediaInfo",
+                "visual_media",
+                "visualMedia",
                 "animated_media",
                 "animatedMedia",
+                "original",
+                "downsized",
+                "fixed_height",
+                "fixedHeight",
+                "fixed_width",
+                "fixedWidth",
             ):
                 nested = node.get(nested_key)
                 if isinstance(nested, (dict, list)):
@@ -3661,8 +3786,22 @@ class InstagramScraper:
             "content",
             "preview",
             "clip",
+            "sticker",
+            "stickers",
+            "gift",
+            "gifts",
+            "comment_gif",
+            "commentGif",
+            "gif",
+            "gifMedia",
             "giphy_media_info",
             "giphyMediaInfo",
+            "tenor_media_info",
+            "tenorMediaInfo",
+            "visual_media",
+            "visualMedia",
+            "animated_media",
+            "animatedMedia",
         ):
             nested = data.get(key)
             if isinstance(nested, (dict, list)):

--- a/trr_backend/socials/instagram/scraper.py
+++ b/trr_backend/socials/instagram/scraper.py
@@ -217,12 +217,27 @@ class InstagramComment:
     owner_profile_pic_url: str | None = None
     owner_profile_pic_url_hd: str | None = None
     owner_is_verified: bool | None = None
+    # Phase 2: Apify-source owner-metadata fields the parser now extracts.
+    owner_fbid_v2: str | None = None
+    owner_is_mentionable: bool | None = None
+    owner_is_private: bool | None = None
+    owner_latest_reel_media: int | None = None
+    owner_profile_pic_id: str | None = None
     is_hidden_by_instagram: bool = False
     source_snapshot_type: str = "full_comments_scrape"
 
     # Post reference
     post_shortcode: str = ""
     post_url: str = ""
+
+    # Phase 2: comment URL + ISO-8601 timestamp built at parse time. Optional so
+    # tests/fixtures that construct InstagramComment directly do not break.
+    comment_url: str | None = None
+    created_at_iso: str | None = None
+    # Phase 1.2 / audit: separate observed-nested-reply count from IG's reported
+    # reply_count. Previously _parse_comment overwrote reply_count to
+    # len(replies) when no count was present, masking the gap during pagination.
+    reply_count_observed: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         result = asdict(self)
@@ -3588,8 +3603,60 @@ class InstagramScraper:
         fallback_reply_depth = 1 if is_reply or parent_id else 0
         normalized_reply_depth = max(0, int(reply_depth if reply_depth is not None else fallback_reply_depth))
 
+        # Phase 2: extract Apify-source owner-metadata fields. Each falls back
+        # across data/owner/user payload variants; absent -> None so persistence
+        # can leave the column null.
+        def _first_present(*keys: str) -> Any:
+            for source in (data, owner, user):
+                if not isinstance(source, dict):
+                    continue
+                for key in keys:
+                    if key in source and source.get(key) is not None:
+                        return source.get(key)
+            return None
+
+        def _coerce_optional_bool(value: Any) -> bool | None:
+            if isinstance(value, bool):
+                return value
+            if value is None:
+                return None
+            return bool(value)
+
+        def _coerce_optional_nonneg_int(value: Any) -> int | None:
+            if value is None:
+                return None
+            try:
+                parsed = int(value)
+            except (TypeError, ValueError):
+                return None
+            return parsed if parsed >= 0 else None
+
+        owner_fbid_v2 = _first_present("fbid_v2", "fbidV2")
+        owner_is_mentionable = _coerce_optional_bool(_first_present("is_mentionable", "isMentionable"))
+        owner_is_private = _coerce_optional_bool(_first_present("is_private", "isPrivate"))
+        owner_latest_reel_media = _coerce_optional_nonneg_int(_first_present("latest_reel_media", "latestReelMedia"))
+        owner_profile_pic_id = _first_present("profile_pic_id", "profilePicId")
+
+        comment_id_str = str(data.get("pk") or data.get("id") or "")
+        normalized_shortcode = str(shortcode or "").strip()
+        comment_url = (
+            f"https://www.instagram.com/p/{normalized_shortcode}/c/{comment_id_str}/"
+            if normalized_shortcode and comment_id_str
+            else None
+        )
+        created_at_iso: str | None = None
+        if created_at:
+            try:
+                created_at_iso = (
+                    datetime.fromtimestamp(int(created_at), tz=UTC)
+                    .isoformat(timespec="milliseconds")
+                    .replace("+00:00", "Z")
+                )
+            except (TypeError, ValueError, OSError, OverflowError):
+                created_at_iso = None
+
         comment = InstagramComment(
-            comment_id=str(data.get("pk") or data.get("id") or ""),
+            comment_id=comment_id_str,
             text=str(data.get("text") or ""),
             username=str(username or ""),
             user_id=str(user_id or ""),
@@ -3619,8 +3686,15 @@ class InstagramScraper:
                 if "is_verified" in user
                 else None
             ),
+            owner_fbid_v2=str(owner_fbid_v2).strip() if owner_fbid_v2 else None,
+            owner_is_mentionable=owner_is_mentionable,
+            owner_is_private=owner_is_private,
+            owner_latest_reel_media=owner_latest_reel_media,
+            owner_profile_pic_id=str(owner_profile_pic_id).strip() if owner_profile_pic_id else None,
             post_shortcode=shortcode,
             post_url=post_url,
+            comment_url=comment_url,
+            created_at_iso=created_at_iso,
         )
         nested_replies = data.get("replies")
         if not isinstance(nested_replies, list):
@@ -3638,8 +3712,12 @@ class InstagramScraper:
                 for reply in nested_replies
                 if isinstance(reply, dict)
             ]
-            if comment.reply_count <= 0:
-                comment.reply_count = len(comment.replies)
+            # Phase 1.2 / audit: previously this overwrote reply_count to
+            # len(comment.replies) when no count shipped, hiding tail gaps from
+            # the fetcher's reply guard. Now we record the observed nested-reply
+            # count in a separate field so reply_count keeps representing IG's
+            # reported total (or 0 when IG didn't ship one).
+            comment.reply_count_observed = len(comment.replies)
         return comment
 
     def parse_comment(


### PR DESCRIPTION
## Summary
- Closes the remaining Instagram comment-coverage gaps and persists Apify-source owner metadata that the scraper was reading but discarding.
- Backend-only; no app contract change. Backend stays snake_case; app types unchanged.
- 6 commits split per the audit's commit-boundary recommendation (audit at \`.plan-grader/instagram-comments-post-detail-schema-completeness-20260501-162443/\`).

## Phase changes

### Phase 1 — comment coverage runtime fixes (\`fbfddb9\`)
- **1.2** \`scraper.py:_parse_comment\` no longer overwrites IG-reported \`reply_count\` with \`len(nested_replies)\` when the parsed count is ≤0. Observed nested count moves to a new \`InstagramComment.reply_count_observed\` field so the fetcher's reply guard keeps firing.
- **1.3** \`job_runner.py:_job_attempt_state\` enforces \`max_attempts >= attempt_count + 1\` when retryable state is missing/malformed. Stops \`can_retry\` from short-circuiting to False on the first transient failure.
- **1.4** \`instagram_comments_incomplete_retryable\` raise gated by \`len(retryable_incomplete_targets) >= max(1, total // 4)\` so a single bad post no longer forces the whole shard into retrying.
- **1.5** Mid-run \`fetcher.warmup()\` refresh after 3 consecutive auth-failed posts OR every \`comments_warmup_refresh_every_posts\` (default 50). Telemetry surfaces in progress metadata.
- **1.7** Per-comment failure attribution: \`InstagramCommentsFetchResult.failed_comment_ids\` derives from accumulated reply/top-level checkpoints; persisted into \`social.scrape_jobs.metadata.comment_failures\` (capped at 200 entries).

### Phase 2 — comment field completeness (\`f7e2914\` + \`fbfddb9\`)
- New Supabase migration \`20260501210512_instagram_comments_owner_metadata.sql\` adds nullable columns: \`comment_url\`, \`author_fbid_v2\`, \`author_is_mentionable\`, \`author_is_private\`, \`author_latest_reel_media\`, \`author_profile_pic_id\`.
- \`InstagramComment\` dataclass extended with \`comment_url\`, \`created_at_iso\`, \`owner_fbid_v2\`, \`owner_is_mentionable\`, \`owner_is_private\`, \`owner_latest_reel_media\`, \`owner_profile_pic_id\`.
- \`_parse_comment\` populates new fields from \`data\`/\`owner\`/\`user\` payload variants; builds \`comment_url\` and ISO-8601 \`created_at_iso\` at parse time.
- Both upsert paths (\`_batch_upsert_instagram_comments\` and \`_persist_without_season_context\`) write the new columns behind \`_column_exists()\` gates.

### Phase 3 — post-normalizer fallback widening (\`dac010a\`)
- Fix duplicate \`\"video_view_count\"\` entry in the play-count fallback list — reels lacking \`videoViewCount\` but exposing \`play_count\` now get a real number.
- \`_extract_tagged_users\` reads \`users_in_photo\` and nested \`image_versions2.candidates[].usertags\`.
- \`_extract_collaborators\` reads \`coauthor_producer_users\` and \`coauthor_invited_users\`.

### Phase 4 — env-driven GraphQL doc-ID rotation (\`8bfd5af\`)
- New \`resolve_profile_posts_doc_ids()\` reads \`SOCIAL_INSTAGRAM_PROFILE_POSTS_DOC_IDS\` (comma-separated) with hardcoded fallback. Whitespace-stripped, deduplicated, digit-only.
- \`posts_scrapling/fetcher.py\` records \`_doc_ids_configured\`/\`_doc_ids_attempted\`/\`_doc_id_used\` in \`runtime_metadata.profile_posts_doc_ids\` so \`http_400\` / \`non_json_response\` spikes can be cross-referenced with rotation events.

### Phase 5 — infrastructure reliability (\`e1ccc61\`)
- **5.1** \`comments_scrapling/proxy.py:_build_proxy_rotator\` now accepts \`list[str | dict]\` so multi-URL configurations actually rotate IPs during warmup. \`browser_proxy\`/\`api_proxy_url\` stay deterministic per shard.
- **5.2** Postgres advisory-lock global rate limit with file-lock fallback. \`SOCIAL_INSTAGRAM_COMMENTS_GLOBAL_RATE_LIMIT_MODE=advisory\` (default) tries \`pg_advisory_lock\` first; falls back to the existing \`fcntl\` path on any DB error. Telemetry in \`runtime_metadata.global_rate_limit\`: \`mode_configured\`, \`mode_last_used\`, \`advisory_attempts\`/\`acquires\`, \`advisory_fallback_count\`, \`advisory_total_wait_ms\`, \`advisory_last_error\`.

## Tests added (\`+19\` regressions)
- \`tests/socials/instagram/comments_scrapling/test_job_attempt_state.py\` — Phase 1.3 enforcement edge cases (4 tests).
- \`tests/socials/instagram/test_constants_doc_id_override.py\` — Phase 4.1 env-override parsing (5 tests).
- \`tests/socials/instagram/test_scraper_parse_comment.py\` — Phase 1.2 + Phase 2 dataclass extension and parser fields (5 tests).
- \`tests/socials/instagram/comments_scrapling/test_proxy.py\` — Phase 5.1 full-list rotator + single-URL edge (2 added tests on top of the existing 3).

## Test plan
- [x] Phase 6.1 plan command 1: \`pytest tests/socials/test_instagram_comments_scrapling_retry.py tests/socials/test_instagram_comments_scrapling.py tests/socials/test_comment_scraper_fixes.py -q\` → **239 passed**
- [x] Phase 6.1 plan command 2: \`pytest tests/socials/instagram/test_instagram_normalizers.py tests/socials/instagram/posts_scrapling/test_persistence.py -q\` → **13 passed**
- [x] Phase 6.1 plan command 3: \`pytest tests/repositories/test_social_season_analytics.py -k \"comments_scrape or comments_run_cancel or instagram_post\" -q\` → **42 passed, 697 deselected**
- [x] Modal readiness probe: \`scripts/modal/verify_modal_readiness.py --probe-remote-auth instagram\` → \`ok: true\`, all 13 social/admin Modal functions resolved, IG remote auth ready (sessionid + csrftoken + ds_user_id present)
- [x] Schema preflight (read-only introspection): saved to \`docs/ai/local-status/instagram-comments-schema-preflight-20260501-220456.txt\`. Confirms 38 existing columns; 6 Phase 2 target columns absent — migration will additively add them.
- [x] Ruff clean across all 9 touched modules
- [ ] **Pending operator approval before deploy**: apply migration to dev/staging, run Phase 6.3 5-post canary on a low-volume account, then run the full \`thetraitorsus\` scrape and validate the live coverage diff.

## Pre-existing failure (NOT caused by this PR)
\`tests/socials/instagram/comments_scrapling/test_job_runner_cancellation.py::test_comments_job_runner_reuses_persist_conn_for_loop_cancellation\` was already failing on \`main\` after commit \`e6e1d34\` added \`_load_expected_comment_counts\` to the runner without updating the cancellation-test mocks. The test does not mock \`pg.fetch_all\` and exits via the lease-lost path before the persist-conn cancellation block executes. Fixing it requires a refactor to the lease-lost flow that is intentionally out of scope for this plan. Filing as a separate follow-up.

## Plan + audit references
- Plan: \`/Users/thomashulihan/.claude/plans/write-the-plan-to-warm-russell.md\`
- Audit verdict: APPROVED_WITH_REVISIONS, revised score 90/100 (\`.plan-grader/instagram-comments-post-detail-schema-completeness-20260501-162443/\`)