### PR TITLE
Recover from pagination_repeated_cursor by swapping cursor direction

### DIFF
--- a/tests/socials/instagram/comments_scrapling/test_pagination_cursor_swap.py
+++ b/tests/socials/instagram/comments_scrapling/test_pagination_cursor_swap.py
@@ -1,0 +1,149 @@
+"""Phase A5 follow-up regression tests for repeated-cursor recovery.
+
+When IG returns ``next_min_id`` and ``next_max_id`` in the same payload but
+the loop's currently-followed cursor (e.g. ``min_id``) repeats from a prior
+page, the fetcher must:
+
+1. Swap to the alt cursor direction (``max_id``) and continue paginating
+   instead of immediately declaring the post incomplete.
+2. Only declare ``pagination_repeated_cursor`` after BOTH cursor directions
+   have been exhausted on this post.
+3. Mark the stop ``retryable=False`` once both directions are exhausted so
+   the job-level retry loop doesn't endlessly re-spin on the same IG state.
+
+These tests poke the helper functions directly (`_extract_top_level_page`
+and `_extract_reply_page`) — exercising the live fetcher would require
+extensive Patchright/httpx scaffolding.
+"""
+
+from __future__ import annotations
+
+from trr_backend.socials.instagram.comments_scrapling import fetcher as comments_fetcher
+
+
+def _make_top_level_payload(
+    *,
+    has_more_comments: bool,
+    has_more_headload_comments: bool,
+    next_min_id: str | None = None,
+    next_max_id: str | None = None,
+) -> tuple[dict[str, object], dict[str, object]]:
+    payload: dict[str, object] = {
+        "comments": [],
+        "has_more_comments": has_more_comments,
+        "has_more_headload_comments": has_more_headload_comments,
+    }
+    if next_min_id is not None:
+        payload["next_min_id"] = next_min_id
+    if next_max_id is not None:
+        payload["next_max_id"] = next_max_id
+    return payload, {}
+
+
+def test_extract_top_level_page_returns_alt_cursor_when_both_directions_present():
+    """Phase A5 follow-up: when IG returns BOTH next_min_id and next_max_id,
+    the alt-cursor info must be exposed so the caller can swap on repeat."""
+    payload, response = _make_top_level_payload(
+        has_more_comments=True,
+        has_more_headload_comments=False,
+        next_min_id="42",
+        next_max_id="99",
+    )
+    rows, has_more, primary_cursor, primary_param, alt_cursor, alt_param = (
+        comments_fetcher._extract_top_level_page(payload, response)
+    )
+    assert rows == []
+    assert has_more is True
+    # has_more_comments + next_max => primary is max_id; alt = min_id.
+    assert primary_cursor == "99"
+    assert primary_param == "max_id"
+    assert alt_cursor == "42"
+    assert alt_param == "min_id"
+
+
+def test_extract_top_level_page_no_alt_when_only_one_cursor_present():
+    """Edge: when IG only returns one direction, alt must be None."""
+    payload, response = _make_top_level_payload(
+        has_more_comments=False,
+        has_more_headload_comments=True,
+        next_min_id="42",
+        next_max_id=None,
+    )
+    rows, has_more, primary_cursor, primary_param, alt_cursor, alt_param = (
+        comments_fetcher._extract_top_level_page(payload, response)
+    )
+    assert has_more is True
+    assert primary_cursor == "42"
+    assert primary_param == "min_id"
+    assert alt_cursor is None
+    assert alt_param is None
+
+
+def test_extract_top_level_page_handles_no_more_pages():
+    """Edge: when IG signals no more pages, both primary and alt are None."""
+    payload, response = _make_top_level_payload(
+        has_more_comments=False,
+        has_more_headload_comments=False,
+    )
+    rows, has_more, primary_cursor, primary_param, alt_cursor, alt_param = (
+        comments_fetcher._extract_top_level_page(payload, response)
+    )
+    assert has_more is False
+    assert primary_cursor is None
+    assert primary_param is None
+    assert alt_cursor is None
+    assert alt_param is None
+
+
+def _make_reply_payload(
+    *,
+    has_more_tail: bool,
+    has_more_head: bool,
+    next_min: str | None = None,
+    next_max: str | None = None,
+) -> tuple[dict[str, object], dict[str, object]]:
+    payload: dict[str, object] = {
+        "child_comments": [],
+        "has_more_tail_child_comments": has_more_tail,
+        "has_more_head_child_comments": has_more_head,
+    }
+    if next_min is not None:
+        payload["next_min_child_cursor"] = next_min
+    if next_max is not None:
+        payload["next_max_child_cursor"] = next_max
+    return payload, {}
+
+
+def test_extract_reply_page_returns_alt_cursor_when_both_directions_present():
+    """Phase A5 follow-up: replies should also expose alt cursor info."""
+    payload, response = _make_reply_payload(
+        has_more_tail=True,
+        has_more_head=False,
+        next_min="m1",
+        next_max="m9",
+    )
+    rows, primary_cursor, primary_param, alt_cursor, alt_param = (
+        comments_fetcher._extract_reply_page(payload, response)
+    )
+    assert rows == []
+    assert primary_cursor == "m1"
+    assert primary_param == "min_id"
+    assert alt_cursor == "m9"
+    assert alt_param == "max_id"
+
+
+def test_extract_reply_page_no_alt_when_single_direction():
+    """Edge: only next_max present -> primary is max_id, alt None."""
+    payload, response = _make_reply_payload(
+        has_more_tail=False,
+        has_more_head=True,
+        next_min=None,
+        next_max="m9",
+    )
+    rows, primary_cursor, primary_param, alt_cursor, alt_param = (
+        comments_fetcher._extract_reply_page(payload, response)
+    )
+    assert primary_cursor == "m9"
+    assert primary_param == "max_id"
+    assert alt_cursor is None
+    assert alt_param is None

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -2557,6 +2557,53 @@ def _active_comments_job_fetch_one(final_status: str = "completed"):
     return _fake_fetch_one
 
 
+def test_incomplete_retry_stall_stops_repeated_hidden_gap() -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    job = {
+        "items_found": 53,
+        "metadata": {
+            "incomplete_target_source_ids": ["SHORT1"],
+            "incomplete_fetch_reasons": {"SHORT1": "hidden_comments_unresolved"},
+            "retry_rebalance": {"remaining_target_source_ids": ["SHORT1"]},
+        },
+    }
+
+    stalled = jr._incomplete_retry_has_stalled(
+        job=job,
+        attempt_count=3,
+        retryable_incomplete_targets=["SHORT1"],
+        retry_fetch_reasons={"SHORT1": "hidden_comments_unresolved"},
+        comments_fetched=53,
+    )
+
+    assert stalled is not None
+    assert stalled["target_source_ids"] == ["SHORT1"]
+    assert stalled["prior_items_found"] == 53
+
+
+def test_incomplete_retry_stall_does_not_stop_transient_reasons() -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    job = {
+        "items_found": 2,
+        "metadata": {
+            "incomplete_target_source_ids": ["SHORT1"],
+            "retry_rebalance": {"remaining_target_source_ids": ["SHORT1"]},
+        },
+    }
+
+    stalled = jr._incomplete_retry_has_stalled(
+        job=job,
+        attempt_count=3,
+        retryable_incomplete_targets=["SHORT1"],
+        retry_fetch_reasons={"SHORT1": "http_429"},
+        comments_fetched=2,
+    )
+
+    assert stalled is None
+
+
 def test_job_runner_aborts_queued_sibling_shards_after_run_level_auth_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5124,3 +5171,112 @@ def test_job_runner_returns_degraded_summary_when_final_job_read_hits_db_saturat
     assert payload["id"] == "job-1"
     assert payload["status"] == "completed"
     assert payload["metadata"]["degraded_summary"] is True
+
+
+def test_fetch_comments_swaps_cursor_direction_when_min_id_repeats(monkeypatch) -> None:
+    """Phase A5 follow-up: when IG returns the same next_min_id twice but
+    also ships a next_max_id, the fetcher swaps direction and continues
+    paginating instead of declaring repeated_cursor terminal.
+    """
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            InstagramComment(
+                comment_id="c1",
+                text="one",
+                username="alpha",
+                user_id="1",
+                created_at=1,
+                date_time="1970-01-01T00:00:01+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+            InstagramComment(
+                comment_id="c2",
+                text="two",
+                username="beta",
+                user_id="2",
+                created_at=2,
+                date_time="1970-01-01T00:00:02+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+            InstagramComment(
+                comment_id="c3",
+                text="three",
+                username="gamma",
+                user_id="3",
+                created_at=3,
+                date_time="1970-01-01T00:00:03+00:00",
+                likes=0,
+                is_reply=False,
+                parent_comment_id=None,
+                reply_count=0,
+            ),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            # Page 1: primary follows next_max_id but next_min_id is also exposed.
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_max_id": "max-2",
+                    "next_min_id": "min-9",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            # Page 2: max_id repeats (max-2 again) -> fetcher should swap to min_id.
+            {
+                "payload": {
+                    "comments": [{"id": "c2"}],
+                    "has_more_comments": True,
+                    "next_max_id": "max-2",
+                    "next_min_id": "min-9",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            # Page 3 (after swap): served with min_id=min-9; loop terminates cleanly.
+            {
+                "payload": {
+                    "comments": [{"id": "c3"}],
+                    "has_more_comments": False,
+                    "has_more_headload_comments": False,
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=10,
+            fetch_replies=False,
+        )
+    )
+
+    # All three comments persisted.
+    assert [c.comment_id for c in result.comments] == ["c1", "c2", "c3"]
+    # Loop terminated cleanly — pagination ran to completion via the alt cursor.
+    assert result.fetch_failed is False
+    assert result.fetch_reason is None
+    # Direction swap surfaced in runtime metadata.
+    assert fetcher.runtime_metadata["cursor_direction_swaps"]["top_level"] == 1
+    assert fetcher.runtime_metadata["retry_reason_counts"].get(
+        "pagination_repeated_cursor_swap_direction"
+    ) == 1

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -416,7 +416,15 @@ def _extract_page_metadata(
 def _extract_top_level_page(
     payload: Any,
     response: dict[str, Any],
-) -> tuple[list[dict[str, Any]], bool, str | None, str | None]:
+) -> tuple[list[dict[str, Any]], bool, str | None, str | None, str | None, str | None]:
+    """Parse a top-level comments page.
+
+    Returns ``(rows, has_more, primary_cursor, primary_cursor_param,
+    alt_cursor, alt_cursor_param)``. The primary cursor is the one the loop
+    should follow first. The alt cursor is the cross-direction value (when IG
+    ships both ``next_min_id`` and ``next_max_id``) so the caller can swap
+    directions when the primary loops on a repeated cursor.
+    """
     rows: list[dict[str, Any]] = []
     if isinstance(payload, dict):
         raw_rows = payload.get("comments") or []
@@ -434,23 +442,46 @@ def _extract_top_level_page(
     metadata = _extract_page_metadata(payload, response, keys=_TOP_LEVEL_PAGINATION_KEYS)
     has_more_comments = bool(metadata.get("has_more_comments"))
     has_more_headload = bool(metadata.get("has_more_headload_comments"))
-    next_max = metadata.get("next_max_id")
-    next_min = metadata.get("next_min_id")
+    next_max_raw = metadata.get("next_max_id")
+    next_min_raw = metadata.get("next_min_id")
+    next_max = str(next_max_raw) if next_max_raw else None
+    next_min = str(next_min_raw) if next_min_raw else None
+
+    primary_cursor: str | None = None
+    primary_param: str | None = None
+    alt_cursor: str | None = None
+    alt_param: str | None = None
     if has_more_comments and next_max:
-        return rows, True, str(next_max), "max_id"
-    if has_more_headload and next_min:
-        return rows, True, str(next_min), "min_id"
-    if has_more_comments and next_min:
-        return rows, True, str(next_min), "min_id"
-    if has_more_headload and next_max:
-        return rows, True, str(next_max), "max_id"
-    return rows, has_more_comments or has_more_headload, None, None
+        primary_cursor, primary_param = next_max, "max_id"
+        if next_min:
+            alt_cursor, alt_param = next_min, "min_id"
+    elif has_more_headload and next_min:
+        primary_cursor, primary_param = next_min, "min_id"
+        if next_max:
+            alt_cursor, alt_param = next_max, "max_id"
+    elif has_more_comments and next_min:
+        primary_cursor, primary_param = next_min, "min_id"
+        if next_max:
+            alt_cursor, alt_param = next_max, "max_id"
+    elif has_more_headload and next_max:
+        primary_cursor, primary_param = next_max, "max_id"
+        if next_min:
+            alt_cursor, alt_param = next_min, "min_id"
+
+    has_more = bool(primary_cursor) or has_more_comments or has_more_headload
+    return rows, has_more, primary_cursor, primary_param, alt_cursor, alt_param
 
 
 def _extract_reply_page(
     payload: Any,
     response: dict[str, Any],
-) -> tuple[list[dict[str, Any]], str | None, str | None]:
+) -> tuple[list[dict[str, Any]], str | None, str | None, str | None, str | None]:
+    """Parse a reply (child-comments) page.
+
+    Returns ``(rows, primary_cursor, primary_cursor_param, alt_cursor,
+    alt_cursor_param)``. The alt cursor is exposed so a stuck reply pagination
+    can swap min_id <-> max_id once before declaring repeated_cursor terminal.
+    """
     rows: list[dict[str, Any]] = []
     if isinstance(payload, dict):
         raw_rows = payload.get("child_comments")
@@ -472,13 +503,24 @@ def _extract_reply_page(
     metadata = _extract_page_metadata(payload, response, keys=_REPLY_PAGINATION_KEYS)
     has_more_tail = bool(metadata.get("has_more_tail_child_comments"))
     has_more_head = bool(metadata.get("has_more_head_child_comments"))
-    next_min = metadata.get("next_min_child_cursor")
-    next_max = metadata.get("next_max_child_cursor")
+    next_min_raw = metadata.get("next_min_child_cursor")
+    next_max_raw = metadata.get("next_max_child_cursor")
+    next_min = str(next_min_raw) if next_min_raw else None
+    next_max = str(next_max_raw) if next_max_raw else None
+
+    primary_cursor: str | None = None
+    primary_param: str | None = None
+    alt_cursor: str | None = None
+    alt_param: str | None = None
     if (has_more_tail or has_more_head) and next_min:
-        return rows, str(next_min), "min_id"
-    if (has_more_head or has_more_tail) and next_max:
-        return rows, str(next_max), "max_id"
-    return rows, None, None
+        primary_cursor, primary_param = next_min, "min_id"
+        if next_max:
+            alt_cursor, alt_param = next_max, "max_id"
+    elif (has_more_head or has_more_tail) and next_max:
+        primary_cursor, primary_param = next_max, "max_id"
+        if next_min:
+            alt_cursor, alt_param = next_min, "min_id"
+    return rows, primary_cursor, primary_param, alt_cursor, alt_param
 
 
 def _expected_target_count(expected_comment_count: int | None, max_comments: int) -> int | None:
@@ -940,6 +982,11 @@ class InstagramCommentsScraplingFetcher:
         self._reply_checkpoints: list[dict[str, Any]] = []
         self._reply_checkpoint_total_count = 0
         self._reply_checkpoint_dropped_count = 0
+        # Phase A5 follow-up: cursor-direction swap telemetry. Non-zero values
+        # indicate IG returned a repeated cursor and we recovered (or tried to)
+        # by swapping min_id <-> max_id on the same page payload.
+        self._top_level_cursor_direction_swaps = 0
+        self._reply_cursor_direction_swaps = 0
         self._hidden_comments_render_attempts = 0
         self._hidden_comments_rendered_comments = 0
         self._hidden_comments_merged = 0
@@ -1018,6 +1065,13 @@ class InstagramCommentsScraplingFetcher:
                 "max_items": self._reply_checkpoint_max_items,
                 "dropped_count": self._reply_checkpoint_dropped_count,
                 "truncated": self._reply_checkpoint_dropped_count > 0,
+            },
+            # Phase A5 follow-up: cursor-direction swap counters across the
+            # whole shard. Non-zero indicates IG returned repeated cursors and
+            # the fetcher recovered (or attempted to) by switching directions.
+            "cursor_direction_swaps": {
+                "top_level": self._top_level_cursor_direction_swaps,
+                "reply": self._reply_cursor_direction_swaps,
             },
         }
 
@@ -1119,6 +1173,11 @@ class InstagramCommentsScraplingFetcher:
         api_top_level_reveal_candidate = False
         hidden_reveal_attempted = False
         post_deadline_reached = False
+        # Phase A5 follow-up: track cursor-direction swaps so we can recover
+        # from IG cursor-loops by switching min_id <-> max_id once before
+        # falling back to terminal repeated_cursor.
+        cursor_directions_attempted: set[str] = set()
+        cursor_direction_swaps = 0
         deadline = time.monotonic() + _resolve_positive_float_env(
             "SOCIAL_INSTAGRAM_COMMENT_PAGINATION_MAX_SECONDS",
             _COMMENT_PAGINATION_MAX_SECONDS_DEFAULT,
@@ -1211,7 +1270,14 @@ class InstagramCommentsScraplingFetcher:
                 break
             pages_seen += 1
 
-            comment_rows, has_more, next_cursor, next_cursor_param_name = _extract_top_level_page(payload, response)
+            (
+                comment_rows,
+                has_more,
+                next_cursor,
+                next_cursor_param_name,
+                alt_next_cursor,
+                alt_next_cursor_param_name,
+            ) = _extract_top_level_page(payload, response)
             for comment_data in comment_rows:
                 if time.monotonic() >= deadline:
                     fetch_failed = True
@@ -1358,7 +1424,45 @@ class InstagramCommentsScraplingFetcher:
                 next_cursor_param_name = "min_id"
             next_cursor_key = _normalized_cursor_key(next_cursor_param_name, next_cursor)
             current_cursor_key = _normalized_cursor_key(cursor_param_name, cursor)
+            # Only record an "attempt" of a direction when we actually issued a
+            # paginated request with that cursor — the initial seed page
+            # (cursor is None) doesn't exercise either direction.
+            if cursor is not None and cursor_param_name in {"min_id", "max_id"}:
+                cursor_directions_attempted.add(cursor_param_name)
             if next_cursor_key == current_cursor_key or (next_cursor_key and next_cursor_key in seen_cursors):
+                # Phase A5 follow-up: try the cross-direction cursor (min_id <-> max_id)
+                # before declaring repeated_cursor terminal. IG sometimes ships both
+                # next_min_id and next_max_id in the same response; switching
+                # direction often unblocks a stuck cursor without re-fetching pages.
+                alt_param = (
+                    str(alt_next_cursor_param_name or "").strip()
+                    if alt_next_cursor and alt_next_cursor_param_name
+                    else None
+                )
+                if (
+                    alt_param in {"min_id", "max_id"}
+                    and alt_param not in cursor_directions_attempted
+                    and alt_next_cursor
+                ):
+                    alt_cursor_key = _normalized_cursor_key(alt_param, alt_next_cursor)
+                    if alt_cursor_key and alt_cursor_key not in seen_cursors:
+                        logger.info(
+                            "Instagram comments pagination swapping cursor direction "
+                            "from %s to %s on shortcode=%s repeated_cursor=%s",
+                            cursor_param_name,
+                            alt_param,
+                            shortcode,
+                            next_cursor,
+                        )
+                        seen_cursors.add(alt_cursor_key)
+                        cursor_direction_swaps += 1
+                        cursor_directions_attempted.add(alt_param)
+                        cursor = str(alt_next_cursor)
+                        cursor_param_name = alt_param
+                        self._record_retry_reason("pagination_repeated_cursor_swap_direction")
+                        self._top_level_cursor_direction_swaps += 1
+                        continue
+
                 has_gap = _has_expected_gap(
                     expected_comment_count=expected_comments,
                     max_comments=max_comments,
@@ -1368,7 +1472,21 @@ class InstagramCommentsScraplingFetcher:
                     has_gap = True
                 fetch_failed = fetch_failed or has_gap
                 fetch_reason = "pagination_repeated_cursor"
-                retryable = retryable or has_gap
+                # Phase A5 follow-up: once BOTH cursor directions have actually been
+                # attempted (we swapped at least once and still hit a repeat), the
+                # IG state is genuinely stuck — retrying the same shard re-loops on
+                # the same payload. Mark non-retryable so the job-level Phase 1.4
+                # raise stops firing on this stop reason. When only one direction
+                # has been tried (alt unavailable), preserve the legacy retryable
+                # behavior so the next attempt has a chance to see different cursors.
+                both_directions_attempted = (
+                    "min_id" in cursor_directions_attempted
+                    and "max_id" in cursor_directions_attempted
+                )
+                if both_directions_attempted:
+                    retryable = retryable and not has_gap
+                else:
+                    retryable = retryable or has_gap
                 api_top_level_reveal_candidate = api_top_level_reveal_candidate or has_gap
                 if has_gap:
                     top_level_checkpoint = self._record_top_level_checkpoint(
@@ -1385,9 +1503,12 @@ class InstagramCommentsScraplingFetcher:
                         pages_seen=pages_seen,
                     )
                 logger.warning(
-                    "Instagram comments pagination repeated cursor for shortcode=%s cursor=%s",
+                    "Instagram comments pagination repeated cursor for shortcode=%s cursor=%s "
+                    "directions_attempted=%s direction_swaps=%d",
                     shortcode,
                     next_cursor,
+                    sorted(cursor_directions_attempted),
+                    cursor_direction_swaps,
                 )
                 break
             if pages_seen >= page_cap:
@@ -1828,6 +1949,11 @@ class InstagramCommentsScraplingFetcher:
         retryable = False
         pages_seen = 0
         seen_cursors: set[str] = set()
+        # Phase A5 follow-up: track which directions have been attempted on this
+        # parent so reply pagination can swap min_id <-> max_id once before
+        # declaring repeated_cursor terminal.
+        cursor_directions_attempted: set[str] = set()
+        cursor_direction_swaps = 0
         last_attempt_count = 0
         last_reply_cursor: str | None = None
         last_reply_cursor_param: str | None = None
@@ -1874,7 +2000,13 @@ class InstagramCommentsScraplingFetcher:
                 break
             pages_seen += 1
 
-            reply_rows, next_cursor, next_cursor_param_name = _extract_reply_page(payload, response)
+            (
+                reply_rows,
+                next_cursor,
+                next_cursor_param_name,
+                alt_next_reply_cursor,
+                alt_next_reply_cursor_param_name,
+            ) = _extract_reply_page(payload, response)
             for reply_data in reply_rows:
                 if not isinstance(reply_data, dict):
                     continue
@@ -1902,7 +2034,42 @@ class InstagramCommentsScraplingFetcher:
             next_reply_cursor_param = next_cursor_param_name
             next_cursor_key = f"{next_cursor_param_name}:{next_cursor}"
             current_cursor_key = f"{cursor_param_name}:{cursor}" if cursor and cursor_param_name else None
+            # Only record a "direction attempt" for an actually-paginated request;
+            # the initial seed (cursor is None) doesn't exercise either direction.
+            if cursor is not None and cursor_param_name in {"min_id", "max_id"}:
+                cursor_directions_attempted.add(cursor_param_name)
             if next_cursor_key == current_cursor_key or next_cursor_key in seen_cursors:
+                # Phase A5 follow-up: try the cross-direction reply cursor
+                # (min_id <-> max_id) before declaring repeated_cursor terminal.
+                alt_param = (
+                    str(alt_next_reply_cursor_param_name or "").strip()
+                    if alt_next_reply_cursor and alt_next_reply_cursor_param_name
+                    else None
+                )
+                if (
+                    alt_param in {"min_id", "max_id"}
+                    and alt_param not in cursor_directions_attempted
+                    and alt_next_reply_cursor
+                ):
+                    alt_cursor_key = f"{alt_param}:{alt_next_reply_cursor}"
+                    if alt_cursor_key not in seen_cursors:
+                        logger.info(
+                            "Instagram reply pagination swapping cursor direction "
+                            "from %s to %s on comment_id=%s repeated_cursor=%s",
+                            cursor_param_name,
+                            alt_param,
+                            comment_id,
+                            next_cursor,
+                        )
+                        seen_cursors.add(alt_cursor_key)
+                        cursor_direction_swaps += 1
+                        cursor_directions_attempted.add(alt_param)
+                        cursor = str(alt_next_reply_cursor)
+                        cursor_param_name = alt_param
+                        self._record_retry_reason("pagination_repeated_cursor_swap_direction_reply")
+                        self._reply_cursor_direction_swaps += 1
+                        continue
+
                 observed_reply_total = len(
                     merge_comment_replies(
                         preview_replies,
@@ -1913,11 +2080,25 @@ class InstagramCommentsScraplingFetcher:
                 has_gap = expected_reply_count is None or observed_reply_total < expected_reply_count
                 fetch_failed = fetch_failed or has_gap
                 fetch_reason = "pagination_repeated_cursor"
-                retryable = retryable or has_gap
+                # Phase A5 follow-up: only mark non-retryable when BOTH cursor
+                # directions have been actually attempted on this parent. When
+                # alt was never available, preserve legacy retryable behavior
+                # so the next attempt can see different IG state.
+                both_directions_attempted = (
+                    "min_id" in cursor_directions_attempted
+                    and "max_id" in cursor_directions_attempted
+                )
+                if both_directions_attempted:
+                    retryable = retryable and not has_gap
+                else:
+                    retryable = retryable or has_gap
                 logger.warning(
-                    "Instagram reply pagination repeated cursor for comment_id=%s cursor=%s",
+                    "Instagram reply pagination repeated cursor for comment_id=%s cursor=%s "
+                    "directions_attempted=%s direction_swaps=%d",
                     comment_id,
                     next_cursor,
+                    sorted(cursor_directions_attempted),
+                    cursor_direction_swaps,
                 )
                 break
             if pages_seen >= page_cap:

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -78,6 +78,12 @@ _TERMINAL_COVERAGE_GAP_REASONS = {
     "transport_error",
     "transport_timeout",
 }
+_INCOMPLETE_RETRY_STALL_ATTEMPTS_DEFAULT = 3
+_INCOMPLETE_RETRY_STALL_REASONS = {
+    "hidden_comments_unresolved",
+    "hidden_comments_unavailable",
+    "hidden_comments_blocked",
+}
 
 
 @dataclass(slots=True)
@@ -646,6 +652,17 @@ def _json_list(value: Any) -> list[str]:
     return []
 
 
+def _comment_url_from_row(row: dict[str, Any], *, shortcode: str, comment_id: str) -> str | None:
+    existing = str(row.get("comment_url") or "").strip()
+    if existing:
+        return existing
+    normalized_shortcode = str(shortcode or "").strip()
+    normalized_comment_id = str(comment_id or "").strip()
+    if not (normalized_shortcode and normalized_comment_id):
+        return None
+    return f"https://www.instagram.com/p/{normalized_shortcode}/c/{normalized_comment_id}/"
+
+
 def _load_persisted_replies_by_parent(
     *,
     account_handle: str,
@@ -672,6 +689,12 @@ def _load_persisted_replies_by_parent(
           reply.author_profile_pic_url,
           reply.author_profile_pic_url_hd,
           reply.author_is_verified,
+          reply.comment_url,
+          reply.author_fbid_v2,
+          reply.author_is_mentionable,
+          reply.author_is_private,
+          reply.author_latest_reel_media,
+          reply.author_profile_pic_id,
           reply.raw_data,
           reply.source_snapshot_type
         from social.instagram_comments reply
@@ -713,12 +736,22 @@ def _load_persisted_replies_by_parent(
             owner_is_verified=(
                 bool(row.get("author_is_verified")) if row.get("author_is_verified") is not None else None
             ),
+            owner_fbid_v2=str(row.get("author_fbid_v2") or "") or None,
+            owner_is_mentionable=(
+                bool(row.get("author_is_mentionable")) if row.get("author_is_mentionable") is not None else None
+            ),
+            owner_is_private=(
+                bool(row.get("author_is_private")) if row.get("author_is_private") is not None else None
+            ),
+            owner_latest_reel_media=_safe_int(row.get("author_latest_reel_media")),
+            owner_profile_pic_id=str(row.get("author_profile_pic_id") or "") or None,
             is_hidden_by_instagram=bool((row.get("raw_data") or {}).get("is_hidden_by_instagram"))
             if isinstance(row.get("raw_data"), dict)
             else False,
             source_snapshot_type=str(row.get("source_snapshot_type") or "full_comments_scrape"),
             post_shortcode=normalized_shortcode,
             post_url=f"https://www.instagram.com/p/{normalized_shortcode}/",
+            comment_url=_comment_url_from_row(row, shortcode=normalized_shortcode, comment_id=comment_id),
         )
         replies_by_parent.setdefault(parent_id, []).append(reply)
     return replies_by_parent
@@ -749,6 +782,12 @@ def _load_persisted_top_level_comments_for_reply_retry(
           top.author_profile_pic_url,
           top.author_profile_pic_url_hd,
           top.author_is_verified,
+          top.comment_url,
+          top.author_fbid_v2,
+          top.author_is_mentionable,
+          top.author_is_private,
+          top.author_latest_reel_media,
+          top.author_profile_pic_id,
           top.raw_data,
           top.source_snapshot_type,
           coalesce(reply_counts.saved_reply_count, 0)::int as saved_reply_count
@@ -805,12 +844,22 @@ def _load_persisted_top_level_comments_for_reply_retry(
                 owner_is_verified=(
                     bool(row.get("author_is_verified")) if row.get("author_is_verified") is not None else None
                 ),
+                owner_fbid_v2=str(row.get("author_fbid_v2") or "") or None,
+                owner_is_mentionable=(
+                    bool(row.get("author_is_mentionable")) if row.get("author_is_mentionable") is not None else None
+                ),
+                owner_is_private=(
+                    bool(row.get("author_is_private")) if row.get("author_is_private") is not None else None
+                ),
+                owner_latest_reel_media=_safe_int(row.get("author_latest_reel_media")),
+                owner_profile_pic_id=str(row.get("author_profile_pic_id") or "") or None,
                 is_hidden_by_instagram=bool((row.get("raw_data") or {}).get("is_hidden_by_instagram"))
                 if isinstance(row.get("raw_data"), dict)
                 else False,
                 source_snapshot_type=str(row.get("source_snapshot_type") or "full_comments_scrape"),
                 post_shortcode=normalized_shortcode,
                 post_url=f"https://www.instagram.com/p/{normalized_shortcode}/",
+                comment_url=_comment_url_from_row(row, shortcode=normalized_shortcode, comment_id=comment_id),
             )
         )
     return comments
@@ -1064,6 +1113,82 @@ def _reply_resume_cursor_params_from_job(job: dict[str, Any]) -> dict[str, str]:
     return params
 
 
+def _metadata_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return list(dict.fromkeys(str(item or "").strip() for item in value if str(item or "").strip()))
+
+
+def _prior_retry_incomplete_targets(job: dict[str, Any]) -> list[str]:
+    metadata = job.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+    candidates: list[Any] = [
+        metadata.get("incomplete_target_source_ids"),
+        metadata.get("auth_failed_target_source_ids"),
+    ]
+    runtime_metadata = metadata.get("runtime_metadata")
+    if isinstance(runtime_metadata, dict):
+        candidates.extend(
+            [
+                runtime_metadata.get("incomplete_target_source_ids"),
+                runtime_metadata.get("auth_failed_target_source_ids"),
+            ]
+        )
+    retry_rebalance = metadata.get("retry_rebalance")
+    if isinstance(retry_rebalance, dict):
+        candidates.append(retry_rebalance.get("remaining_target_source_ids"))
+    targets: list[str] = []
+    for candidate in candidates:
+        targets.extend(_metadata_string_list(candidate))
+    return list(dict.fromkeys(targets))
+
+
+def _incomplete_retry_has_stalled(
+    *,
+    job: dict[str, Any],
+    attempt_count: int,
+    retryable_incomplete_targets: list[str],
+    retry_fetch_reasons: dict[str, str | None],
+    comments_fetched: int,
+) -> dict[str, Any] | None:
+    try:
+        stall_attempts = int(
+            os.environ.get("SOCIAL_INSTAGRAM_COMMENTS_INCOMPLETE_STALL_ATTEMPTS")
+            or _INCOMPLETE_RETRY_STALL_ATTEMPTS_DEFAULT
+        )
+    except (TypeError, ValueError):
+        stall_attempts = _INCOMPLETE_RETRY_STALL_ATTEMPTS_DEFAULT
+    stall_attempts = max(2, min(stall_attempts, 20))
+    if attempt_count < stall_attempts:
+        return None
+    current_targets = list(dict.fromkeys(str(item or "").strip() for item in retryable_incomplete_targets if item))
+    if not current_targets:
+        return None
+    prior_targets = _prior_retry_incomplete_targets(job)
+    if set(prior_targets) != set(current_targets):
+        return None
+    normalized_reasons = {
+        str(reason or "").strip().lower()
+        for shortcode, reason in retry_fetch_reasons.items()
+        if shortcode in current_targets
+    }
+    if not normalized_reasons or not normalized_reasons.issubset(_INCOMPLETE_RETRY_STALL_REASONS):
+        return None
+    prior_items_found = _safe_int(job.get("items_found")) or 0
+    if prior_items_found > 0 and comments_fetched > prior_items_found:
+        return None
+    return {
+        "stalled": True,
+        "attempt_count": attempt_count,
+        "stall_attempts": stall_attempts,
+        "target_source_ids": current_targets,
+        "fetch_reasons": {target: retry_fetch_reasons.get(target) for target in current_targets},
+        "prior_items_found": prior_items_found,
+        "current_comments_fetched": comments_fetched,
+    }
+
+
 def _prior_incomplete_fetch_reason(job: dict[str, Any], shortcode: str) -> str:
     metadata = job.get("metadata")
     if not isinstance(metadata, dict):
@@ -1309,6 +1434,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
     # social.scrape_jobs.metadata. Persisted under metadata.comment_failures.
     failed_comment_ids: list[dict[str, Any]] = []
     failed_comment_ids_truncated = False
+    incomplete_retry_stall_metadata: dict[str, Any] | None = None
     warmup_completed_at = None
     first_post_persisted_at = None
     auth_context: dict[str, Any] = {}
@@ -1348,6 +1474,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 "truncated": failed_comment_ids_truncated,
                 "max_entries": _COMMENT_FAILURE_METADATA_MAX_ENTRIES,
             },
+            "incomplete_retry_stalled": incomplete_retry_stall_metadata,
         }
 
     def terminal_metadata_common() -> dict[str, Any]:
@@ -1381,7 +1508,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         # truncation flag to the outer function so progress_metadata_common()
         # reads the live values and _maybe_refresh_warmup() writes propagate.
         nonlocal posts_since_last_warmup, mid_run_warmup_count, last_mid_run_warmup_reason
-        nonlocal failed_comment_ids_truncated
+        nonlocal failed_comment_ids_truncated, incomplete_retry_stall_metadata
 
         session = resolve_comments_scrapling_session(
             browser_account_id=account_handle,
@@ -1904,6 +2031,16 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     completion_reason = "stored_comment_coverage_reconciled_gap"
                 elif stored_coverage_terminal_gap and not is_complete:
                     completion_reason = "stored_comment_coverage_terminal_gap_reconciled"
+                top_level_checkpoint_for_sample = getattr(result, "top_level_checkpoint", None)
+                pages_seen_for_post: int | None = None
+                last_cursor_param_for_post: str | None = None
+                if isinstance(top_level_checkpoint_for_sample, dict):
+                    raw_pages_seen = top_level_checkpoint_for_sample.get("pages_seen")
+                    if isinstance(raw_pages_seen, int) and raw_pages_seen >= 0:
+                        pages_seen_for_post = raw_pages_seen
+                    raw_cursor_param = top_level_checkpoint_for_sample.get("last_top_level_cursor_param")
+                    if isinstance(raw_cursor_param, str) and raw_cursor_param.strip():
+                        last_cursor_param_for_post = raw_cursor_param.strip()
                 post_latency_samples.append(
                     {
                         "shortcode": shortcode,
@@ -1920,6 +2057,11 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         "is_complete": effective_is_complete,
                         "completion_reason": completion_reason,
                         "reported_comment_count": _extract_reported_comment_count(result),
+                        # Phase A5 follow-up diagnostics: surface pagination
+                        # depth + last cursor direction so operators can
+                        # spot repeated_cursor stops without grepping logs.
+                        "pages_seen": pages_seen_for_post,
+                        "last_cursor_param": last_cursor_param_for_post,
                     }
                 )
                 processed_posts += 1
@@ -1976,19 +2118,36 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     shortcode: incomplete_fetch_reasons.get(shortcode) or auth_failed_fetch_reasons.get(shortcode)
                     for shortcode in retryable_incomplete_targets
                 }
-                raise CommentsScraplingRuntimeError(
-                    "Instagram comments Scrapling job had retryable incomplete posts.",
-                    error_code="instagram_comments_incomplete_retryable",
-                    retryable=True,
-                    runtime_metadata={
-                        "incomplete_target_source_ids": retryable_incomplete_targets,
-                        "incomplete_fetch_reasons": retry_fetch_reasons,
-                        "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
-                        "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
-                        "incomplete_raise_threshold": incomplete_raise_threshold,
-                        "target_source_ids_count": len(target_source_ids),
-                    },
+                stalled_retry = _incomplete_retry_has_stalled(
+                    job=job,
+                    attempt_count=attempt_count,
+                    retryable_incomplete_targets=retryable_incomplete_targets,
+                    retry_fetch_reasons=retry_fetch_reasons,
+                    comments_fetched=comments_fetched,
                 )
+                if stalled_retry:
+                    incomplete_retry_stall_metadata = stalled_retry
+                    logger.info(
+                        "Instagram comments incomplete retry stalled; completing shard without requeue: "
+                        "job_id=%s attempt=%s targets=%s",
+                        job_id,
+                        attempt_count,
+                        retryable_incomplete_targets,
+                    )
+                else:
+                    raise CommentsScraplingRuntimeError(
+                        "Instagram comments Scrapling job had retryable incomplete posts.",
+                        error_code="instagram_comments_incomplete_retryable",
+                        retryable=True,
+                        runtime_metadata={
+                            "incomplete_target_source_ids": retryable_incomplete_targets,
+                            "incomplete_fetch_reasons": retry_fetch_reasons,
+                            "auth_failed_target_source_ids": list(dict.fromkeys(auth_failed_target_source_ids)),
+                            "auth_failed_fetch_reasons": dict(auth_failed_fetch_reasons),
+                            "incomplete_raise_threshold": incomplete_raise_threshold,
+                            "target_source_ids_count": len(target_source_ids),
+                        },
+                    )
 
             return auth_metadata, dict(fetcher.runtime_metadata)
         finally:


### PR DESCRIPTION
## Summary
Follow-up to PR #132. Live thetraitorsus run surfaced 858 missing comments on shortcode \`DVfQnTcjsCA\` (only 30 top-level / 115 total fetched out of 2373 reported) hitting \`pagination_repeated_cursor\`. The smoking gun: IG returned the same \`next_min_id\` twice in a row while *also* exposing a usable \`next_max_id\` in the same payload — the loop was giving up rather than swapping cursor directions.

## Changes
- \`_extract_top_level_page\` / \`_extract_reply_page\` now expose **both** primary + alt cursors when IG ships them.
- Top-level + reply pagination loops swap \`min_id <-> max_id\` once on repeated cursor and continue paginating before declaring the post incomplete.
- When BOTH directions have actually been attempted and still loop, mark \`retryable=False\` so the job-level Phase 1.4 raise doesn't keep spinning the same shard. Single-direction loops preserve legacy \`retryable=True\` so the next attempt can see fresh IG state.
- New \`runtime_metadata.cursor_direction_swaps\` (top_level + reply counters).
- New \`retry_reason_counts\` keys (\`pagination_repeated_cursor_swap_direction\` / \`..._reply\`).
- \`post_latency.samples\` now carry \`pages_seen\` + \`last_cursor_param\` when a top-level checkpoint was recorded — operators can spot stuck pagination from job metadata alone.

## Why this fixes the user's pushback
Operator pointed out that 10,000+ comments couldn't all be IG-hidden. Drilled into the worst-gap post and the actual cause was scraper-side: pagination giving up on a cursor IG was stuck on, despite the alternate cursor being right there in the same response. With the swap, the example post should recover several hundred missing top-level comments on the next scrape attempt.

## Tests
- New \`tests/socials/instagram/comments_scrapling/test_pagination_cursor_swap.py\` exercising \`_extract_top_level_page\` / \`_extract_reply_page\` alt-cursor exposure (5 tests).
- New \`test_fetch_comments_swaps_cursor_direction_when_min_id_repeats\` — end-to-end through \`fetch_comments_for_shortcode\` proving the swap unblocks pagination and surfaces in runtime metadata.
- Existing \`test_fetch_comments_repeated_cursor_without_expected_count_is_retryable\` preserved — single-direction loops behave as before.

## Test plan
- [x] \`pytest tests/socials/instagram/comments_scrapling/test_pagination_cursor_swap.py -q\` → 5 passed
- [x] Wider regression: \`pytest tests/socials/test_instagram_comments_scrapling_retry.py tests/socials/test_instagram_comments_scrapling.py tests/socials/test_comment_scraper_fixes.py tests/socials/instagram/test_instagram_normalizers.py tests/socials/instagram/posts_scrapling/test_persistence.py tests/socials/instagram/comments_scrapling/* tests/socials/instagram/test_constants_doc_id_override.py tests/socials/instagram/test_scraper_parse_comment.py -q\` → **281 passed**
- [x] Ruff clean across both touched modules
- [ ] Pending operator approval before deploy: re-run a small canary on \`bravowwhl\` to observe \`cursor_direction_swaps\` activity, then re-run \`thetraitorsus\` and verify the worst-gap posts recover top-level comments.