### PR TITLE
Fallback-build comment_url when payload lacks it (Phase 2 follow-up)

### DIFF
--- a/tests/socials/instagram/comments_scrapling/test_persistence.py
+++ b/tests/socials/instagram/comments_scrapling/test_persistence.py
@@ -64,6 +64,12 @@ def test_no_season_persistence_preserves_media_and_reply_metadata() -> None:
     fake_repo = SimpleNamespace(
         _column_exists=lambda _schema, _table, column: column
         in {
+            "comment_url",
+            "author_fbid_v2",
+            "author_is_mentionable",
+            "author_is_private",
+            "author_latest_reel_media",
+            "author_profile_pic_id",
             "media_urls",
             "hosted_media_urls",
             "media_mirror_status",
@@ -93,18 +99,25 @@ def test_no_season_persistence_preserves_media_and_reply_metadata() -> None:
         media_urls=["https://images.example/reply-sticker.gif"],
         hosted_media_urls=["https://cdn.example/reply-sticker.gif"],
     )
+    reply.owner_fbid_v2 = "reply-fbid"
+    reply.owner_is_mentionable = True
+    reply.owner_is_private = False
+    reply.owner_latest_reel_media = 1_775_000_001
+    reply.owner_profile_pic_id = "reply-pic"
     comment = _comment(
         "comment-1",
         media_urls=["https://images.example/comment-gift.gif"],
         hosted_media_urls=["https://cdn.example/comment-gift.gif"],
         replies=[reply],
     )
+    comment.comment_url = "https://www.instagram.com/p/ABC123/c/comment-1/"
     stats: dict[str, int] = {}
 
     written = persistence._persist_without_season_context(
         repo=fake_repo,
         post_id="post-1",
         account_handle="bravotv",
+        shortcode="ABC123",
         comments=[comment],
         run_id="run-1",
         job_id="job-1",
@@ -119,11 +132,18 @@ def test_no_season_persistence_preserves_media_and_reply_metadata() -> None:
     assert captured_batches[0][0]["hosted_media_urls"] == ["https://cdn.example/comment-gift.gif"]
     assert captured_batches[0][0]["media_mirror_status"] == "deferred"
     assert captured_batches[0][0]["media_mirror_error"] == "season_context_missing"
+    assert captured_batches[0][0]["comment_url"] == "https://www.instagram.com/p/ABC123/c/comment-1/"
     assert captured_batches[0][0]["source_snapshot_type"] == "full_comments_scrape"
     assert captured_batches[1][0]["media_urls"] == ["https://images.example/reply-sticker.gif"]
     assert captured_batches[1][0]["hosted_media_urls"] == ["https://cdn.example/reply-sticker.gif"]
     assert captured_batches[1][0]["media_mirror_status"] == "deferred"
     assert captured_batches[1][0]["media_mirror_error"] == "season_context_missing"
+    assert captured_batches[1][0]["comment_url"] == "https://www.instagram.com/p/ABC123/c/reply-1/"
+    assert captured_batches[1][0]["author_fbid_v2"] == "reply-fbid"
+    assert captured_batches[1][0]["author_is_mentionable"] is True
+    assert captured_batches[1][0]["author_is_private"] is False
+    assert captured_batches[1][0]["author_latest_reel_media"] == 1_775_000_001
+    assert captured_batches[1][0]["author_profile_pic_id"] == "reply-pic"
     assert captured_batches[1][0]["parent_comment_id"] == "row-comment-1"
     assert captured_batches[1][0]["parent_comment_external_id"] == "comment-1"
     assert captured_batches[1][0]["reply_depth"] == 1

--- a/trr_backend/repositories/social_season_analytics.py
+++ b/trr_backend/repositories/social_season_analytics.py
@@ -19101,7 +19101,11 @@ def _upsert_instagram_comment_tree(
     # Phase 2: Apify-source owner-metadata columns (migration
     # 20260501210512_instagram_comments_owner_metadata.sql).
     if _column_exists("social", "instagram_comments", "comment_url"):
-        payload["comment_url"] = str(getattr(comment, "comment_url", "") or "").strip() or None
+        payload["comment_url"] = _instagram_comment_url_for_payload(
+            comment,
+            post_shortcode=getattr(comment, "post_shortcode", None),
+            comment_id=comment_external_id,
+        )
     if _column_exists("social", "instagram_comments", "author_fbid_v2"):
         payload["author_fbid_v2"] = str(getattr(comment, "owner_fbid_v2", "") or "").strip() or None
     if _column_exists("social", "instagram_comments", "author_is_mentionable"):
@@ -19221,6 +19225,17 @@ def _instagram_comment_effective_reply_depth(comment: Any, *, parent_external_id
     if parsed_depth > 0 or not parent_external_id:
         return max(0, parsed_depth)
     return max(0, int(fallback or 0))
+
+
+def _instagram_comment_url_for_payload(comment: Any, *, post_shortcode: str | None, comment_id: str) -> str | None:
+    existing = str(getattr(comment, "comment_url", "") or "").strip()
+    if existing:
+        return existing
+    shortcode = str(post_shortcode or "").strip()
+    external_id = str(comment_id or "").strip()
+    if not (shortcode and external_id):
+        return None
+    return f"https://www.instagram.com/p/{shortcode}/c/{external_id}/"
 
 
 def _batch_upsert_instagram_comments(
@@ -19367,8 +19382,10 @@ def _batch_upsert_instagram_comments(
             payload["media_mirror_error"] = None
         # Phase 2: Apify-source owner-metadata column writes.
         if _instagram_comment_has_comment_url:
-            payload["comment_url"] = (
-                str(getattr(comment_obj, "comment_url", "") or "").strip() or None
+            payload["comment_url"] = _instagram_comment_url_for_payload(
+                comment_obj,
+                post_shortcode=getattr(comment_obj, "post_shortcode", None),
+                comment_id=external_id,
             )
         if _instagram_comment_has_author_fbid_v2:
             payload["author_fbid_v2"] = (

--- a/trr_backend/socials/instagram/comments_scrapling/persistence.py
+++ b/trr_backend/socials/instagram/comments_scrapling/persistence.py
@@ -55,6 +55,17 @@ def _comment_effective_reply_depth(comment: InstagramComment, parent_external_id
     return max(0, int(fallback or 0))
 
 
+def _comment_url_for_payload(*, comment: InstagramComment, shortcode: str, external_id: str) -> str | None:
+    existing = str(getattr(comment, "comment_url", "") or "").strip()
+    if existing:
+        return existing
+    normalized_shortcode = str(shortcode or "").strip()
+    normalized_external_id = str(external_id or "").strip()
+    if not (normalized_shortcode and normalized_external_id):
+        return None
+    return f"https://www.instagram.com/p/{normalized_shortcode}/c/{normalized_external_id}/"
+
+
 def find_instagram_post_for_comments(
     *,
     account_handle: str,
@@ -223,6 +234,7 @@ def persist_instagram_comments_for_post(
             repo=repo,
             post_id=post_id,
             account_handle=account_handle,
+            shortcode=shortcode,
             comments=comments,
             run_id=run_id,
             job_id=job_id,
@@ -260,6 +272,7 @@ def _persist_without_season_context(
     repo: Any,
     post_id: str,
     account_handle: str,
+    shortcode: str,
     comments: list[InstagramComment],
     run_id: str | None,
     job_id: str | None,
@@ -349,8 +362,10 @@ def _persist_without_season_context(
             )
         # Phase 2: write Apify-source owner-metadata columns when present.
         if has_comment_url:
-            payload["comment_url"] = (
-                str(getattr(comment_obj, "comment_url", "") or "").strip() or None
+            payload["comment_url"] = _comment_url_for_payload(
+                comment=comment_obj,
+                shortcode=str(getattr(comment_obj, "post_shortcode", "") or shortcode),
+                external_id=external_id,
             )
         if has_author_fbid_v2:
             payload["author_fbid_v2"] = (


### PR DESCRIPTION
## Summary
Follow-up to PR #132. Live canary surfaced that re-ingests of the same \`(post_id, comment_id)\` were clobbering \`comment_url\` to NULL on UPSERT, and replies parsed via the dedicated reply endpoint never got the column populated at all. Root cause: the persistence write sites only set \`payload[\"comment_url\"]\` when the dataclass value was non-empty.

## Fix
Two small helpers that fall back to building the URL from \`shortcode + comment_id\` when the dataclass field is empty:
- \`_comment_url_for_payload\` in \`comments_scrapling/persistence.py\`
- \`_instagram_comment_url_for_payload\` in \`repositories/social_season_analytics.py\`

Wired through all three persistence paths:
- \`_persist_without_season_context\` (now accepts \`shortcode\` parameter)
- \`_upsert_instagram_comment_tree\` (uses \`comment.post_shortcode\` already on the dataclass)
- \`_batch_upsert_instagram_comments\` (same)

## Tests
\`tests/socials/instagram/comments_scrapling/test_persistence.py\` extended to assert the new owner-metadata + comment_url columns are written for both top-level comments AND replies through the no-season path.

## Test plan
- [x] Wider regression: 281 passed, ruff clean
- [ ] Pending operator approval: re-run canary, verify ALL rows (top-level + reply, fresh + re-ingest) have \`comment_url\` populated

Builds on PR #132 + #133.