### PR TITLE
chore: exclude retired brain docs from review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_filters:
+    - "!TRR Backend Brain/**"
+    - "!**/BRAIN.md"


### PR DESCRIPTION
## Summary
- add CodeRabbit path filters for retired Brain docs

## Validation
- one-file config-only PR
- pending CodeRabbit and repository checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings to refine coverage scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->