### PR TITLE
ci: forward-only lint gate + non-blocking type/test/lock jobs + pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,7 @@ jobs:
           diff -u /tmp/requirements.lock.before.txt requirements.lock.txt
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: uv pip sync --system requirements.lock.txt
 
       - name: Import gate
         run: python -c "import api.main"
@@ -81,13 +79,142 @@ jobs:
       - name: Check repo hygiene
         run: python scripts/check_repo_hygiene.py
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.9.27"
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: uv pip sync --system requirements.lock.txt
 
       - name: Import gate
         run: python -c "import api.main"
 
       - name: Run API smoke subset
         run: python -m pytest tests/api -q
+
+
+  lint:
+    name: Ruff (changed files, forward-only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.9.27"
+
+      - name: Determine changed Python files
+        id: changed
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          if [ -z "$base" ] \
+            || [ "$base" = "0000000000000000000000000000000000000000" ] \
+            || ! git cat-file -e "$base" 2>/dev/null; then
+            base="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+          files="$(git diff --name-only --diff-filter=ACM "$base"...HEAD -- '*.py' | tr '\n' ' ')"
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "Changed Python files: ${files:-<none>}"
+
+      # Forward-only: lints only files touched by this change, so the existing
+      # backlog (186 lint findings / 80 unformatted files as of 2026-06) does
+      # not block CI. Burn the backlog down separately, then drop the diff scope.
+      - name: Ruff check (changed files only)
+        if: steps.changed.outputs.files != ''
+        run: uvx ruff@0.14.4 check ${{ steps.changed.outputs.files }}
+
+      - name: Ruff format check (changed files only)
+        if: steps.changed.outputs.files != ''
+        run: uvx ruff@0.14.4 format --check ${{ steps.changed.outputs.files }}
+
+
+  typecheck:
+    name: Pyright (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.9"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.9.27"
+
+      - name: Install dependencies
+        run: |
+          uv pip sync --system requirements.lock.txt
+          uv pip install --system pyright
+
+      - name: Pyright
+        run: pyright
+
+
+  modal-locks:
+    name: Modal lockfile freshness (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.9.27"
+
+      # Mirrors the base-lockfile freshness check for the three Modal lockfiles.
+      # Non-blocking until confirmed reproducible under the pinned uv version.
+      - name: Verify lean/browser/vision lockfile freshness
+        run: |
+          set -euo pipefail
+          recompile_and_diff() {
+            local infile="$1" lockfile="$2"; shift 2
+            cp "$lockfile" "/tmp/$(basename "$lockfile").before"
+            uv pip compile "$infile" "$@" -o "$lockfile"
+            diff -u "/tmp/$(basename "$lockfile").before" "$lockfile"
+          }
+          recompile_and_diff requirements.modal.lean.in requirements.modal.lean.lock.txt
+          recompile_and_diff requirements.modal.browser.in requirements.modal.browser.lock.txt \
+            --python-platform x86_64-manylinux_2_28
+          recompile_and_diff requirements.modal.vision.in requirements.modal.vision.lock.txt \
+            --python-platform x86_64-manylinux_2_28 --index-strategy unsafe-best-match
+
+
+  test-full:
+    name: Full pytest (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.9"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.9.27"
+
+      - name: Install dependencies
+        run: uv pip sync --system requirements.lock.txt
+
+      - name: Run full suite (excluding browser/vision/live)
+        run: python -m pytest tests -q -m "not browser and not vision and not live"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
@@ -121,20 +122,29 @@ jobs:
             || ! git cat-file -e "$base" 2>/dev/null; then
             base="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
           fi
-          files="$(git diff --name-only --diff-filter=ACM "$base"...HEAD -- '*.py' | tr '\n' ' ')"
-          echo "files=$files" >> "$GITHUB_OUTPUT"
-          echo "Changed Python files: ${files:-<none>}"
+          # diff-filter=ACMR also catches renamed-with-modifications files.
+          {
+            echo "files<<EOF"
+            git diff --name-only --diff-filter=ACMR "$base"...HEAD -- '*.py'
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       # Forward-only: lints only files touched by this change, so the existing
       # backlog (186 lint findings / 80 unformatted files as of 2026-06) does
       # not block CI. Burn the backlog down separately, then drop the diff scope.
+      # File list is passed via env (not template interpolation) and consumed by
+      # xargs, so a crafted filename cannot inject shell commands.
       - name: Ruff check (changed files only)
         if: steps.changed.outputs.files != ''
-        run: uvx ruff@0.14.4 check ${{ steps.changed.outputs.files }}
+        env:
+          CHANGED_PY_FILES: ${{ steps.changed.outputs.files }}
+        run: printf '%s' "$CHANGED_PY_FILES" | xargs -r uvx ruff@0.14.4 check
 
       - name: Ruff format check (changed files only)
         if: steps.changed.outputs.files != ''
-        run: uvx ruff@0.14.4 format --check ${{ steps.changed.outputs.files }}
+        env:
+          CHANGED_PY_FILES: ${{ steps.changed.outputs.files }}
+        run: printf '%s' "$CHANGED_PY_FILES" | xargs -r uvx ruff@0.14.4 format --check
 
 
   typecheck:
@@ -144,6 +154,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -158,7 +170,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip sync --system requirements.lock.txt
-          uv pip install --system pyright
+          uv pip install --system pyright==1.1.390
 
       - name: Pyright
         run: pyright
@@ -171,6 +183,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v4
@@ -202,6 +216,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Pre-commit hooks for TRR-Backend.
+#
+# One-time setup:
+#   uv tool install pre-commit   # or: pipx install pre-commit
+#   pre-commit install
+#
+# Hooks run only on STAGED files by default, so the existing lint/format
+# backlog (legacy files) never blocks a commit that does not touch them.
+# To lint the whole tree on demand:  pre-commit run --all-files
+# To bump pinned hook versions:      pre-commit autoupdate
+#
+# ruff/ruff-format reuse ruff.toml; gitleaks auto-discovers .gitleaks.toml
+# and .gitleaksignore at the repo root.
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+        args: [--allow-multiple-documents]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,24 @@ ruff format --check .
 pytest
 ```
 
+## Pre-commit hooks
+
+Hooks run `ruff`, `gitleaks`, and basic hygiene checks on staged files before
+each commit. They only touch files you actually change, so the existing
+lint/format backlog will not block unrelated commits.
+
+```bash
+uv tool install pre-commit   # or: pipx install pre-commit
+pre-commit install
+# optional: lint the whole tree
+pre-commit run --all-files
+```
+
+CI gates new code forward-only: the `lint` job runs `ruff` on the Python files
+changed in each PR (pinned to ruff 0.14.4), so legacy debt does not need to be
+fixed all at once. `pyright`, the full test suite, and Modal lockfile freshness
+run as non-blocking signal jobs until their backlogs are burned down.
+
 ## Security
 
 - Never commit `.env` or anything under `keys/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,10 @@ Hooks run `ruff`, `gitleaks`, and basic hygiene checks on staged files before
 each commit. They only touch files you actually change, so the existing
 lint/format backlog will not block unrelated commits.
 
+Note: the `ruff` / `ruff-format` and end-of-file/trailing-whitespace hooks
+**auto-fix in place**. When a hook rewrites a file, the commit is aborted so you
+can review and `git add` the changes, then commit again.
+
 ```bash
 uv tool install pre-commit   # or: pipx install pre-commit
 pre-commit install

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,8 @@ pythonpath = .
 testpaths = tests
 python_files = test_*.py
 addopts = -ra
+markers =
+    browser: test launches a real browser (Playwright/Scrapling); excluded from the lean CI lane.
+    vision: test requires the vision/ML stack (deepface, opencv, torch, insightface); excluded from the lean CI lane.
+    live: test hits a live external service, network, or database; excluded from offline CI.
 


### PR DESCRIPTION
## What
Phase 1 of the tooling upgrade — CI hardening + local pre-commit. Pure tooling/config; touches no application Python.

### CI (`.github/workflows/ci.yml`)
- **`lint`** (blocking): runs `ruff` only on the Python files changed in the PR (pinned 0.14.4) — *forward-only* so the existing lint backlog doesn't block, while new code is held to standard.
- **`typecheck`** (pyright), **`test-full`** (full pytest minus browser/vision/live), **`modal-locks`** (lean/browser/vision lockfile freshness): non-blocking signal jobs, matching the existing py3.12 `continue-on-error` canary idiom. Flip to blocking once each backlog is burned down.

### Other
- `pytest.ini`: register `browser` / `vision` / `live` markers used by `test-full`.
- `.pre-commit-config.yaml`: ruff + gitleaks (reuses existing `.gitleaks.toml`) + hygiene hooks, staged-files only.
- `CONTRIBUTING.md`: document setup + the forward-only policy.

## Notes
- Includes a small pre-existing `ci.yml` install-step tweak (`uv pip sync --system`) already in the working tree.
- Phase 2/3 (Pandera contracts, SQLMesh rollup) are intentionally **not** in this PR — they're interleaved with other in-flight work and will land separately.

## Test
All new jobs validated locally: pre-commit configs pass `pre-commit validate-config`; workflow YAML parses; pytest marker filter collects clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to use lockfile-based dependency syncing for faster, repeatable runs.
  * Expanded CI with non-blocking linting (changed files only), type checking, lockfile freshness validation, and a fuller test run.
* **Documentation**
  * Added repo pre-commit configuration and guidance for running hooks locally.
  * Documented that certain CI checks are signal-only to reduce backlog impact.
* **Tests**
  * Added `browser`, `vision`, and `live` markers to better organize and filter test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->