### PR TITLE
Admin social progress timing and handle indexes

### DIFF
--- a/api/routers/socials/__init__.py
+++ b/api/routers/socials/__init__.py
@@ -496,7 +496,9 @@ def post_social_landing_progress_rollup(
         cache_key,
     )
     if cached_payload is not None:
+        total_ms = int((perf_counter() - started_at) * 1000)
         cached_payload["cache_status"] = "hit"
+        cached_payload["timing"] = {"backend_ms": total_ms, "database_ms": 0, "total_ms": total_ms}
         return cached_payload
 
     instagram_reported_comments_sql = _instagram_reported_comments_sql("p")

--- a/api/routers/socials/__init__.py
+++ b/api/routers/socials/__init__.py
@@ -481,12 +481,15 @@ def post_social_landing_progress_rollup(
 ) -> dict[str, Any]:
     from trr_backend.db import pg
 
+    started_at = perf_counter()
     targets = _normalize_landing_progress_targets(payload.platforms, payload.account_handles)
     if not targets:
+        total_ms = int((perf_counter() - started_at) * 1000)
         return {
             "rows": [],
             "cache_status": "bypass",
             "generated_at": datetime.now(tz=UTC).isoformat(),
+            "timing": {"backend_ms": total_ms, "database_ms": 0, "total_ms": total_ms},
         }
 
     cache_key = _landing_progress_cache_key(targets)
@@ -499,9 +502,9 @@ def post_social_landing_progress_rollup(
         cached_payload["cache_status"] = "hit"
         return cached_payload
 
-    started_at = perf_counter()
     instagram_reported_comments_sql = _instagram_reported_comments_sql("p")
     try:
+        db_started_at = perf_counter()
         rows = pg.fetch_all(
             f"""
             WITH targets AS (
@@ -779,11 +782,14 @@ def post_social_landing_progress_rollup(
             [[platform for platform, _handle in targets], [handle for _platform, handle in targets]],
             pool_name="social_profile",
         )
+        db_ms = int((perf_counter() - db_started_at) * 1000)
+        total_ms = int((perf_counter() - started_at) * 1000)
         generated_at = datetime.now(tz=UTC).isoformat()
         payload_out = {
             "rows": jsonable_encoder(rows),
             "cache_status": "miss",
             "generated_at": generated_at,
+            "timing": {"backend_ms": total_ms, "database_ms": db_ms, "total_ms": total_ms},
         }
         _set_ttl_cached_payload(
             _SOCIAL_LANDING_PROGRESS_ROLLUP_CACHE,
@@ -794,10 +800,11 @@ def post_social_landing_progress_rollup(
             max_entries=SOCIAL_LANDING_PROGRESS_ROLLUP_CACHE_MAX_ENTRIES,
         )
         logger.info(
-            "Built social landing progress rollup targets=%s rows=%s elapsed_ms=%s cache_status=miss",
+            "Built social landing progress rollup targets=%s rows=%s elapsed_ms=%s db_ms=%s cache_status=miss",
             len(targets),
             len(rows),
-            int((perf_counter() - started_at) * 1000),
+            total_ms,
+            db_ms,
         )
         return payload_out
     except Exception as exc:  # noqa: BLE001

--- a/api/routers/socials/__init__.py
+++ b/api/routers/socials/__init__.py
@@ -244,10 +244,7 @@ def _landing_progress_cache_key(targets: list[tuple[str, str]]) -> tuple[Any, ..
 
 
 def _sql_json_text_non_negative_int(expr: str) -> str:
-    return (
-        "coalesce(nullif(regexp_replace(coalesce("
-        f"{expr}, ''), '[^0-9]', '', 'g'), '')::bigint, 0)"
-    )
+    return f"coalesce(nullif(regexp_replace(coalesce({expr}, ''), '[^0-9]', '', 'g'), '')::bigint, 0)"
 
 
 def _instagram_reported_comments_sql(alias: str) -> str:
@@ -4775,7 +4772,10 @@ def get_social_account_comments_audit_cursor_retries_route(
     if platform.strip().lower() != "instagram":
         raise HTTPException(
             status_code=400,
-            detail={"code": "SOCIAL_ACCOUNT_COMMENTS_UNSUPPORTED_PLATFORM", "message": "Audit cursor retries are Instagram-only."},
+            detail={
+                "code": "SOCIAL_ACCOUNT_COMMENTS_UNSUPPORTED_PLATFORM",
+                "message": "Audit cursor retries are Instagram-only.",
+            },
         )
     try:
         return get_instagram_comments_audit_cursor_recovery(
@@ -4806,7 +4806,10 @@ async def post_social_account_comments_audit_cursor_retries_route(
     if platform.strip().lower() != "instagram":
         raise HTTPException(
             status_code=400,
-            detail={"code": "SOCIAL_ACCOUNT_COMMENTS_UNSUPPORTED_PLATFORM", "message": "Audit cursor retries are Instagram-only."},
+            detail={
+                "code": "SOCIAL_ACCOUNT_COMMENTS_UNSUPPORTED_PLATFORM",
+                "message": "Audit cursor retries are Instagram-only.",
+            },
         )
     try:
         return await run_in_threadpool(

--- a/supabase/migrations/20260618170000_social_landing_progress_normalized_handle_indexes.sql
+++ b/supabase/migrations/20260618170000_social_landing_progress_normalized_handle_indexes.sql
@@ -1,0 +1,56 @@
+BEGIN;
+
+-- Match the normalized-handle predicates used by the admin social landing
+-- progress rollup so Postgres can narrow each platform table before aggregate
+-- work begins.
+CREATE INDEX IF NOT EXISTS idx_social_instagram_posts_landing_account_norm
+  ON social.instagram_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_tiktok_posts_landing_account_norm
+  ON social.tiktok_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_twitter_tweets_landing_account_norm
+  ON social.twitter_tweets ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_youtube_videos_landing_account_norm
+  ON social.youtube_videos ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_facebook_posts_landing_account_norm
+  ON social.facebook_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_threads_posts_landing_account_norm
+  ON social.meta_threads_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_ig_catalog_posts_landing_account_norm
+  ON social.instagram_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_tiktok_catalog_posts_landing_account_norm
+  ON social.tiktok_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_twitter_catalog_posts_landing_account_norm
+  ON social.twitter_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_youtube_catalog_posts_landing_account_norm
+  ON social.youtube_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_facebook_catalog_posts_landing_account_norm
+  ON social.facebook_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_threads_catalog_posts_landing_account_norm
+  ON social.threads_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
+
+CREATE INDEX IF NOT EXISTS idx_social_instagram_profiles_landing_account_norm
+  ON social.instagram_profiles (
+    (ltrim(lower(coalesce(normalized_username, username, source_account, '')), '@')),
+    last_scraped_at DESC NULLS LAST,
+    updated_at DESC NULLS LAST,
+    id
+  );
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_socialblade_landing_platform_handle_norm
+  ON pipeline.socialblade_growth_data (
+    (lower(coalesce(nullif(platform, ''), 'instagram'))),
+    (ltrim(lower(coalesce(nullif(account_handle, ''), instagram_handle, '')), '@'))
+  );
+
+COMMIT;

--- a/supabase/migrations/20260618170000_social_landing_progress_normalized_handle_indexes.sql
+++ b/supabase/migrations/20260618170000_social_landing_progress_normalized_handle_indexes.sql
@@ -1,45 +1,43 @@
-BEGIN;
-
 -- Match the normalized-handle predicates used by the admin social landing
 -- progress rollup so Postgres can narrow each platform table before aggregate
 -- work begins.
-CREATE INDEX IF NOT EXISTS idx_social_instagram_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_instagram_posts_landing_account_norm
   ON social.instagram_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_tiktok_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_tiktok_posts_landing_account_norm
   ON social.tiktok_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_twitter_tweets_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_twitter_tweets_landing_account_norm
   ON social.twitter_tweets ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_youtube_videos_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_youtube_videos_landing_account_norm
   ON social.youtube_videos ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_facebook_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_facebook_posts_landing_account_norm
   ON social.facebook_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_threads_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_threads_posts_landing_account_norm
   ON social.meta_threads_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_ig_catalog_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_ig_catalog_posts_landing_account_norm
   ON social.instagram_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_tiktok_catalog_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_tiktok_catalog_posts_landing_account_norm
   ON social.tiktok_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_twitter_catalog_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_twitter_catalog_posts_landing_account_norm
   ON social.twitter_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_youtube_catalog_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_youtube_catalog_posts_landing_account_norm
   ON social.youtube_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_facebook_catalog_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_facebook_catalog_posts_landing_account_norm
   ON social.facebook_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_threads_catalog_posts_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_threads_catalog_posts_landing_account_norm
   ON social.threads_account_catalog_posts ((ltrim(lower(coalesce(source_account, '')), '@')));
 
-CREATE INDEX IF NOT EXISTS idx_social_instagram_profiles_landing_account_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_social_instagram_profiles_landing_account_norm
   ON social.instagram_profiles (
     (ltrim(lower(coalesce(normalized_username, username, source_account, '')), '@')),
     last_scraped_at DESC NULLS LAST,
@@ -47,10 +45,8 @@ CREATE INDEX IF NOT EXISTS idx_social_instagram_profiles_landing_account_norm
     id
   );
 
-CREATE INDEX IF NOT EXISTS idx_pipeline_socialblade_landing_platform_handle_norm
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pipeline_socialblade_landing_platform_handle_norm
   ON pipeline.socialblade_growth_data (
     (lower(coalesce(nullif(platform, ''), 'instagram'))),
     (ltrim(lower(coalesce(nullif(account_handle, ''), instagram_handle, '')), '@'))
   );
-
-COMMIT;

--- a/tests/api/test_admin_socials_landing_summary.py
+++ b/tests/api/test_admin_socials_landing_summary.py
@@ -229,7 +229,9 @@ def test_social_landing_progress_rollup_uses_social_profile_pool_and_caches(monk
     assert first["timing"]["database_ms"] >= 0
     assert first["timing"]["backend_ms"] >= first["timing"]["database_ms"]
     assert first["timing"]["total_ms"] == first["timing"]["backend_ms"]
-    assert second["timing"] == first["timing"]
+    assert second["timing"]["database_ms"] == 0
+    assert second["timing"]["backend_ms"] >= 0
+    assert second["timing"]["total_ms"] == second["timing"]["backend_ms"]
     assert first["rows"][0] == {
         "platform": "instagram",
         "account_handle": "bravotv",

--- a/tests/api/test_admin_socials_landing_summary.py
+++ b/tests/api/test_admin_socials_landing_summary.py
@@ -161,6 +161,9 @@ def test_social_landing_progress_rollup_returns_empty_rows_without_db(monkeypatc
     assert payload["rows"] == []
     assert payload["cache_status"] == "bypass"
     assert "generated_at" in payload
+    assert payload["timing"]["database_ms"] == 0
+    assert payload["timing"]["backend_ms"] >= 0
+    assert payload["timing"]["total_ms"] >= 0
 
 
 def test_social_landing_progress_rollup_rejects_mismatched_targets() -> None:
@@ -223,6 +226,10 @@ def test_social_landing_progress_rollup_uses_social_profile_pool_and_caches(monk
     assert "comment_counts AS" not in str(captured["query"])
     assert first["cache_status"] == "miss"
     assert second["cache_status"] == "hit"
+    assert first["timing"]["database_ms"] >= 0
+    assert first["timing"]["backend_ms"] >= first["timing"]["database_ms"]
+    assert first["timing"]["total_ms"] == first["timing"]["backend_ms"]
+    assert second["timing"] == first["timing"]
     assert first["rows"][0] == {
         "platform": "instagram",
         "account_handle": "bravotv",


### PR DESCRIPTION
## Summary
- Add backend/database timing to admin social landing progress rollup responses.
- Preserve timing fields on cached rollup responses.
- Add normalized-handle indexes for social landing progress table lookups.
- Extend landing progress rollup tests for timing payloads.

## Validation
- `/Users/thomashulihan/Projects/TRR/TRR-Backend/.venv/bin/pytest -q tests/api/test_admin_socials_landing_summary.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added additional database indexes to speed up admin social landing progress rollup lookups using normalized handle expressions and improved Instagram handle indexing.
  * Enhanced the admin rollup response with execution timing details (backend, database, total) across empty-result, cache-hit, and cache-miss paths.

* **Tests**
  * Updated social landing progress rollup tests to validate timing fields and expected relationships for cache and no-DB scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->