### PR TITLE
Harden social operator and session safety

### DIFF
--- a/scripts/socials/cleanup_youtube_false_positives.py
+++ b/scripts/socials/cleanup_youtube_false_positives.py
@@ -74,12 +74,19 @@ def _delete_rows(*, row_ids: list[str]) -> int:
     return len(deleted)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Clean known YouTube false positives for a show.")
     parser.add_argument("--show-id", help="Show UUID to scope cleanup.")
     parser.add_argument("--show-name", default=DEFAULT_SHOW_NAME, help=f"Show name (default: {DEFAULT_SHOW_NAME})")
-    parser.add_argument("--dry-run", action="store_true", help="Preview candidate rows without deleting.")
-    args = parser.parse_args()
+    parser.add_argument("--dry-run", action="store_true", help="Preview candidate rows without deleting (default).")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete matched rows. Without this, runs in dry-run.",
+    )
+    parser.set_defaults(dry_run=True)
+    args = parser.parse_args(argv)
+    dry_run = bool(args.dry_run and not args.apply)
 
     resolved_show_id = _resolve_show_id(show_id=args.show_id, show_name=args.show_name)
     candidates = _find_candidate_rows(resolved_show_id=resolved_show_id)
@@ -94,8 +101,8 @@ def main() -> None:
             row.get("title"),
         )
 
-    if args.dry_run:
-        logger.info("Dry run enabled: no rows deleted.")
+    if dry_run:
+        logger.info("Dry run (default): no rows deleted. Re-run with --apply to delete %d rows.", len(candidates))
         return
 
     if not candidates:

--- a/scripts/socials/cleanup_youtube_false_positives.py
+++ b/scripts/socials/cleanup_youtube_false_positives.py
@@ -78,8 +78,9 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Clean known YouTube false positives for a show.")
     parser.add_argument("--show-id", help="Show UUID to scope cleanup.")
     parser.add_argument("--show-name", default=DEFAULT_SHOW_NAME, help=f"Show name (default: {DEFAULT_SHOW_NAME})")
-    parser.add_argument("--dry-run", action="store_true", help="Preview candidate rows without deleting (default).")
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Preview candidate rows without deleting (default).")
+    mode.add_argument(
         "--apply",
         action="store_true",
         help="Actually delete matched rows. Without this, runs in dry-run.",

--- a/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - script execution convenience
 DUPLICATE_ERROR_CODE = "duplicate_comment_media_mirror_job_retired"
 DUPLICATE_ERROR_CLASS = "DuplicateCommentMediaMirrorJobRetired"
 DUPLICATE_ERROR_MESSAGE = "duplicate_active_comment_media_mirror_job_retired"
+ACTIVE_DUPLICATE_STATUSES = ("queued", "pending", "retrying", "running")
 IDENTITY_SQL = """
 coalesce(
   nullif(config->>'comment_db_id', ''),
@@ -199,9 +200,17 @@ def _retire_matches(*, season_ids: list[str], show_ids: list[str], accounts: lis
           last_error_class = %s,
           metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
         where id::text = any(%s)
+          and status = any(%s)
         returning id::text as id
         """,
-        [DUPLICATE_ERROR_MESSAGE, DUPLICATE_ERROR_CODE, DUPLICATE_ERROR_CLASS, payload, duplicate_ids],
+        [
+            DUPLICATE_ERROR_MESSAGE,
+            DUPLICATE_ERROR_CODE,
+            DUPLICATE_ERROR_CLASS,
+            payload,
+            duplicate_ids,
+            list(ACTIVE_DUPLICATE_STATUSES),
+        ],
     )
 
 

--- a/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/scripts/socials/retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -59,8 +59,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--season-id", action="append", default=[], help="Optional season UUID filter.")
     parser.add_argument("--show-id", action="append", default=[], help="Optional show UUID filter.")
     parser.add_argument("--account", action="append", default=[], help="Optional Instagram account handle filter.")
-    parser.add_argument("--dry-run", action="store_true", help="Preview matching duplicate rows (default).")
-    parser.add_argument("--apply", action="store_true", help="Retire duplicate rows by marking them cancelled.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Preview matching duplicate rows (default).")
+    mode.add_argument("--apply", action="store_true", help="Retire duplicate rows by marking them cancelled.")
     parser.add_argument(
         "--confirm-destructive",
         action="store_true",

--- a/scripts/socials/retire_duplicate_instagram_media_mirror_jobs.py
+++ b/scripts/socials/retire_duplicate_instagram_media_mirror_jobs.py
@@ -21,6 +21,7 @@ except ModuleNotFoundError:  # pragma: no cover - script execution convenience
 DUPLICATE_ERROR_CODE = "duplicate_media_mirror_job_retired"
 DUPLICATE_ERROR_CLASS = "DuplicateMediaMirrorJobRetired"
 DUPLICATE_ERROR_MESSAGE = "duplicate_active_media_mirror_job_retired"
+ACTIVE_DUPLICATE_STATUSES = ("queued", "pending", "retrying", "running")
 
 
 @dataclass(slots=True)
@@ -128,9 +129,17 @@ def _retire_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[
           last_error_class = %s,
           metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
         where id::text = any(%s)
+          and status = any(%s)
         returning id::text as id
         """,
-        [DUPLICATE_ERROR_MESSAGE, DUPLICATE_ERROR_CODE, DUPLICATE_ERROR_CLASS, payload, duplicate_ids],
+        [
+            DUPLICATE_ERROR_MESSAGE,
+            DUPLICATE_ERROR_CODE,
+            DUPLICATE_ERROR_CLASS,
+            payload,
+            duplicate_ids,
+            list(ACTIVE_DUPLICATE_STATUSES),
+        ],
     )
 
 

--- a/scripts/socials/retire_duplicate_instagram_media_mirror_jobs.py
+++ b/scripts/socials/retire_duplicate_instagram_media_mirror_jobs.py
@@ -37,8 +37,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--season-id", action="append", default=[], help="Optional season UUID filter.")
     parser.add_argument("--show-id", action="append", default=[], help="Optional show UUID filter.")
-    parser.add_argument("--dry-run", action="store_true", help="Preview matching duplicate rows (default).")
-    parser.add_argument("--apply", action="store_true", help="Retire duplicate rows by marking them cancelled.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Preview matching duplicate rows (default).")
+    mode.add_argument("--apply", action="store_true", help="Retire duplicate rows by marking them cancelled.")
     parser.set_defaults(dry_run=True)
     return parser.parse_args(argv)
 

--- a/scripts/socials/retire_stale_instagram_media_mirror_failures.py
+++ b/scripts/socials/retire_stale_instagram_media_mirror_failures.py
@@ -163,11 +163,12 @@ def _retire_matches(*, season_ids: list[str], show_ids: list[str]) -> list[dict[
           last_error_class = %s,
           metadata = coalesce(metadata, '{}'::jsonb) || %s::jsonb
         where id::text = any(%s)
+          and status = %s
         returning id::text as id,
                   season_id::text as season_id,
                   show_id::text as show_id
         """,
-        [OBSOLETE_ERROR_MESSAGE, OBSOLETE_ERROR_CODE, OBSOLETE_ERROR_CLASS, payload, job_ids],
+        [OBSOLETE_ERROR_MESSAGE, OBSOLETE_ERROR_CODE, OBSOLETE_ERROR_CLASS, payload, job_ids, "failed"],
     )
 
 

--- a/scripts/socials/retire_stale_instagram_media_mirror_failures.py
+++ b/scripts/socials/retire_stale_instagram_media_mirror_failures.py
@@ -58,12 +58,13 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=[],
         help="Optional show UUID filter. Repeat to target multiple shows.",
     )
-    parser.add_argument(
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
         "--dry-run",
         action="store_true",
         help="Preview matching stale failure rows without mutating them (default).",
     )
-    parser.add_argument(
+    mode.add_argument(
         "--apply",
         action="store_true",
         help="Retire the matching stale failures by marking them cancelled with obsolete-failure metadata.",

--- a/tests/scripts/test_cleanup_youtube_false_positives.py
+++ b/tests/scripts/test_cleanup_youtube_false_positives.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import scripts.socials.cleanup_youtube_false_positives as mod
 
 
@@ -23,3 +25,10 @@ def test_main_apply_deletes_candidate_rows(monkeypatch) -> None:
     mod.main(["--apply"])
 
     assert delete_calls == [["row-1"]]
+
+
+def test_main_rejects_apply_and_dry_run_together() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        mod.main(["--apply", "--dry-run"])
+
+    assert exc_info.value.code == 2

--- a/tests/scripts/test_cleanup_youtube_false_positives.py
+++ b/tests/scripts/test_cleanup_youtube_false_positives.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import scripts.socials.cleanup_youtube_false_positives as mod
+
+
+def test_main_defaults_to_dry_run_without_deleting(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_resolve_show_id", lambda **_kwargs: "show-1")
+    monkeypatch.setattr(mod, "_find_candidate_rows", lambda **_kwargs: [{"id": "row-1"}])
+    delete_calls: list[list[str]] = []
+    monkeypatch.setattr(mod, "_delete_rows", lambda *, row_ids: delete_calls.append(row_ids))
+
+    mod.main([])
+
+    assert delete_calls == []
+
+
+def test_main_apply_deletes_candidate_rows(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_resolve_show_id", lambda **_kwargs: "show-1")
+    monkeypatch.setattr(mod, "_find_candidate_rows", lambda **_kwargs: [{"id": "row-1"}])
+    delete_calls: list[list[str]] = []
+    monkeypatch.setattr(mod, "_delete_rows", lambda *, row_ids: delete_calls.append(row_ids) or 1)
+
+    mod.main(["--apply"])
+
+    assert delete_calls == [["row-1"]]

--- a/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -90,11 +90,15 @@ def test_retire_matches_marks_duplicate_comment_media_jobs_cancelled(monkeypatch
 
     assert rows == [{"id": "job-1"}]
     assert len(calls) == 1
-    assert "status = 'cancelled'" in calls[0]["query"]
-    assert calls[0]["params"][0] == mod.DUPLICATE_ERROR_MESSAGE
-    assert calls[0]["params"][1] == mod.DUPLICATE_ERROR_CODE
-    assert calls[0]["params"][2] == mod.DUPLICATE_ERROR_CLASS
-    assert json.loads(calls[0]["params"][3]) == {"duplicate_active_comment_media_mirror_job": True}
-    assert calls[0]["params"][4] == ["job-1"]
+    query = calls[0]["query"]
+    params = calls[0]["params"]
+    assert "status = 'cancelled'" in query
+    assert "and status = any(%s)" in query.lower()
+    assert params[0] == mod.DUPLICATE_ERROR_MESSAGE
+    assert params[1] == mod.DUPLICATE_ERROR_CODE
+    assert params[2] == mod.DUPLICATE_ERROR_CLASS
+    assert json.loads(params[3]) == {"duplicate_active_comment_media_mirror_job": True}
+    assert params[4] == ["job-1"]
+    assert params[5] == list(mod.ACTIVE_DUPLICATE_STATUSES)
     assert "concat(config->>'post_id', ':', config->>'comment_id')" in mod.IDENTITY_SQL
     assert "owner_username" in mod.ACCOUNT_SQL

--- a/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
+++ b/tests/scripts/test_retire_duplicate_instagram_comment_media_mirror_jobs.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import pytest
+
 import scripts.socials.retire_duplicate_instagram_comment_media_mirror_jobs as mod
 
 
@@ -18,6 +20,11 @@ def _base_args(**overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def test_parse_args_rejects_apply_with_dry_run() -> None:
+    with pytest.raises(SystemExit):
+        mod._parse_args(["--apply", "--dry-run"])
 
 
 def test_main_apply_retires_duplicate_comment_media_rows(monkeypatch, capsys) -> None:

--- a/tests/scripts/test_retire_duplicate_instagram_media_mirror_jobs.py
+++ b/tests/scripts/test_retire_duplicate_instagram_media_mirror_jobs.py
@@ -48,9 +48,13 @@ def test_retire_matches_marks_duplicate_jobs_cancelled(monkeypatch) -> None:
 
     assert rows == [{"id": "job-1"}]
     assert len(calls) == 1
-    assert "status = 'cancelled'" in calls[0]["query"]
-    assert calls[0]["params"][0] == mod.DUPLICATE_ERROR_MESSAGE
-    assert calls[0]["params"][1] == mod.DUPLICATE_ERROR_CODE
-    assert calls[0]["params"][2] == mod.DUPLICATE_ERROR_CLASS
-    assert json.loads(calls[0]["params"][3]) == {"duplicate_active_media_mirror_job": True}
-    assert calls[0]["params"][4] == ["job-1", "job-2"]
+    query = calls[0]["query"]
+    params = calls[0]["params"]
+    assert "status = 'cancelled'" in query
+    assert "and status = any(%s)" in query.lower()
+    assert params[0] == mod.DUPLICATE_ERROR_MESSAGE
+    assert params[1] == mod.DUPLICATE_ERROR_CODE
+    assert params[2] == mod.DUPLICATE_ERROR_CLASS
+    assert json.loads(params[3]) == {"duplicate_active_media_mirror_job": True}
+    assert params[4] == ["job-1", "job-2"]
+    assert params[5] == list(mod.ACTIVE_DUPLICATE_STATUSES)

--- a/tests/scripts/test_retire_duplicate_instagram_media_mirror_jobs.py
+++ b/tests/scripts/test_retire_duplicate_instagram_media_mirror_jobs.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import pytest
+
 import scripts.socials.retire_duplicate_instagram_media_mirror_jobs as mod
 
 
@@ -10,6 +12,11 @@ def _base_args(**overrides):
     values = {"season_id": [], "show_id": [], "dry_run": False, "apply": False}
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def test_parse_args_rejects_apply_with_dry_run() -> None:
+    with pytest.raises(SystemExit):
+        mod._parse_args(["--apply", "--dry-run"])
 
 
 def test_main_dry_run_reports_duplicate_rows_without_retiring(monkeypatch, capsys) -> None:

--- a/tests/scripts/test_retire_stale_instagram_media_mirror_failures.py
+++ b/tests/scripts/test_retire_stale_instagram_media_mirror_failures.py
@@ -112,6 +112,8 @@ def test_retire_matches_updates_only_selected_ids(monkeypatch) -> None:
     params = calls[0]["params"]
     assert "status = 'cancelled'" in query
     assert "where id::text = any(%s)" in query.lower()
+    assert "and status = %s" in query.lower()
+    assert "and status = 'failed'" not in query.lower()
     assert params[0] == mod.OBSOLETE_ERROR_MESSAGE
     assert params[1] == mod.OBSOLETE_ERROR_CODE
     assert params[2] == mod.OBSOLETE_ERROR_CLASS
@@ -121,3 +123,4 @@ def test_retire_matches_updates_only_selected_ids(monkeypatch) -> None:
         "obsolete_failure_resolution": "retired_from_retry_backlog",
     }
     assert params[4] == ["job-1", "job-3"]
+    assert params[5] == "failed"

--- a/tests/scripts/test_retire_stale_instagram_media_mirror_failures.py
+++ b/tests/scripts/test_retire_stale_instagram_media_mirror_failures.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import pytest
+
 import scripts.socials.retire_stale_instagram_media_mirror_failures as mod
 
 
@@ -15,6 +17,11 @@ def _base_args(**overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def test_parse_args_rejects_apply_with_dry_run() -> None:
+    with pytest.raises(SystemExit):
+        mod._parse_args(["--apply", "--dry-run"])
 
 
 def test_fetch_matches_keeps_non_retryable_failures_and_skips_retryable() -> None:

--- a/tests/socials/test_cookie_refresh_flows.py
+++ b/tests/socials/test_cookie_refresh_flows.py
@@ -1229,3 +1229,39 @@ def test_threads_refresh_passes_in_protocol_validator(monkeypatch, tmp_path) -> 
         username="u", password="p", cookie_file=str(tmp_path / "t.json")
     )
     assert captured["validator"] is threads_cookie_refresh_mod._validate_threads_cookies_in_protocol
+
+
+def test_reconcile_private_paths_hardens_files_and_directories(tmp_path: Path) -> None:
+    nested = tmp_path / "instagram"
+    nested.mkdir()
+    cookie_file = nested / "bravo.cookies.json"
+    cookie_file.write_text("{}", encoding="utf-8")
+    tmp_path.chmod(0o755)
+    nested.chmod(0o755)
+    cookie_file.chmod(0o644)
+
+    hardened = browser_cookie_refresh.reconcile_private_paths(tmp_path)
+
+    assert hardened == 1
+    assert tmp_path.stat().st_mode & 0o777 == 0o700
+    assert nested.stat().st_mode & 0o777 == 0o700
+    assert cookie_file.stat().st_mode & 0o777 == 0o600
+
+
+def test_reconcile_private_paths_ignores_missing_root(tmp_path: Path) -> None:
+    assert browser_cookie_refresh.reconcile_private_paths(tmp_path / "missing") == 0
+
+
+def test_reconcile_private_paths_swallows_chmod_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cookie_file = tmp_path / "bravo.cookies.json"
+    cookie_file.write_text("{}", encoding="utf-8")
+
+    def _raise_os_error(self: Path, mode: int) -> None:
+        raise OSError("chmod blocked")
+
+    monkeypatch.setattr(Path, "chmod", _raise_os_error)
+
+    assert browser_cookie_refresh.reconcile_private_paths(tmp_path) == 0

--- a/tests/socials/test_cookie_refresh_flows.py
+++ b/tests/socials/test_cookie_refresh_flows.py
@@ -1252,6 +1252,40 @@ def test_reconcile_private_paths_ignores_missing_root(tmp_path: Path) -> None:
     assert browser_cookie_refresh.reconcile_private_paths(tmp_path / "missing") == 0
 
 
+def test_reconcile_private_paths_does_not_chmod_symlink_targets(tmp_path: Path) -> None:
+    private_root = tmp_path / "private"
+    private_root.mkdir()
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    outside_file = outside_root / "credentials.json"
+    outside_file.write_text("{}", encoding="utf-8")
+    outside_root.chmod(0o755)
+    outside_file.chmod(0o644)
+    (private_root / "escaped-dir").symlink_to(outside_root, target_is_directory=True)
+    (private_root / "escaped-file.json").symlink_to(outside_file)
+
+    hardened = browser_cookie_refresh.reconcile_private_paths(private_root)
+
+    assert hardened == 0
+    assert outside_root.stat().st_mode & 0o777 == 0o755
+    assert outside_file.stat().st_mode & 0o777 == 0o644
+
+
+def test_reconcile_private_paths_ignores_symlink_root(tmp_path: Path) -> None:
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    outside_file = outside_root / "credentials.json"
+    outside_file.write_text("{}", encoding="utf-8")
+    outside_root.chmod(0o755)
+    outside_file.chmod(0o644)
+    linked_root = tmp_path / "private-link"
+    linked_root.symlink_to(outside_root, target_is_directory=True)
+
+    assert browser_cookie_refresh.reconcile_private_paths(linked_root) == 0
+    assert outside_root.stat().st_mode & 0o777 == 0o755
+    assert outside_file.stat().st_mode & 0o777 == 0o644
+
+
 def test_reconcile_private_paths_swallows_chmod_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1259,7 +1293,8 @@ def test_reconcile_private_paths_swallows_chmod_failure(
     cookie_file = tmp_path / "bravo.cookies.json"
     cookie_file.write_text("{}", encoding="utf-8")
 
-    def _raise_os_error(self: Path, mode: int) -> None:
+    def _raise_os_error(self: Path, mode: int, *, follow_symlinks: bool = True) -> None:
+        del follow_symlinks
         raise OSError("chmod blocked")
 
     monkeypatch.setattr(Path, "chmod", _raise_os_error)

--- a/tests/socials/test_cookie_refresh_flows.py
+++ b/tests/socials/test_cookie_refresh_flows.py
@@ -443,6 +443,35 @@ def test_cookie_refresh_context_allows_profileless_browser_with_override(
     assert captured["browser_closed"] is True
 
 
+def test_cookie_refresh_context_closes_profileless_browser_when_new_context_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    chrome_root = tmp_path / "Chrome"
+    captured: dict[str, int] = {"close_calls": 0}
+
+    class _FakeBrowser:
+        def new_context(self, **_kwargs: object) -> object:
+            raise RuntimeError("new context failed")
+
+        def close(self) -> None:
+            captured["close_calls"] += 1
+
+    monkeypatch.setattr(browser_cookie_refresh, "_chrome_profile_base_dir", lambda: chrome_root)
+    monkeypatch.setattr(browser_cookie_refresh, "launch_browser", lambda *_args, **_kwargs: _FakeBrowser())
+
+    with pytest.raises(RuntimeError, match="new context failed"):
+        browser_cookie_refresh.open_cookie_refresh_context(
+            SimpleNamespace(chromium=object()),
+            platform="socialblade",
+            headless=True,
+            viewport={"width": 100, "height": 100},
+            require_profile=False,
+        )
+
+    assert captured["close_calls"] == 1
+
+
 def test_social_auth_refresh_rate_limit_blocks_repeated_attempts(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/socials/test_cookie_refresh_flows.py
+++ b/tests/socials/test_cookie_refresh_flows.py
@@ -472,6 +472,32 @@ def test_cookie_refresh_context_closes_profileless_browser_when_new_context_fail
     assert captured["close_calls"] == 1
 
 
+def test_cookie_refresh_context_preserves_new_context_error_when_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    chrome_root = tmp_path / "Chrome"
+
+    class _FakeBrowser:
+        def new_context(self, **_kwargs: object) -> object:
+            raise RuntimeError("new context failed")
+
+        def close(self) -> None:
+            raise RuntimeError("close failed")
+
+    monkeypatch.setattr(browser_cookie_refresh, "_chrome_profile_base_dir", lambda: chrome_root)
+    monkeypatch.setattr(browser_cookie_refresh, "launch_browser", lambda *_args, **_kwargs: _FakeBrowser())
+
+    with pytest.raises(RuntimeError, match="new context failed"):
+        browser_cookie_refresh.open_cookie_refresh_context(
+            SimpleNamespace(chromium=object()),
+            platform="socialblade",
+            headless=True,
+            viewport={"width": 100, "height": 100},
+            require_profile=False,
+        )
+
+
 def test_social_auth_refresh_rate_limit_blocks_repeated_attempts(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/socials/test_cookie_refresh_flows.py
+++ b/tests/socials/test_cookie_refresh_flows.py
@@ -1225,9 +1225,7 @@ def test_threads_refresh_passes_in_protocol_validator(monkeypatch, tmp_path) -> 
         return {"sessionid": "s", "csrftoken": "c"}
 
     monkeypatch.setattr(threads_cookie_refresh_mod, "refresh_simple_login_cookies", _fake_refresh)
-    threads_cookie_refresh_mod.refresh_threads_cookies(
-        username="u", password="p", cookie_file=str(tmp_path / "t.json")
-    )
+    threads_cookie_refresh_mod.refresh_threads_cookies(username="u", password="p", cookie_file=str(tmp_path / "t.json"))
     assert captured["validator"] is threads_cookie_refresh_mod._validate_threads_cookies_in_protocol
 
 

--- a/trr_backend/socials/account_browser_sessions.py
+++ b/trr_backend/socials/account_browser_sessions.py
@@ -16,6 +16,7 @@ from trr_backend.socials.browser_cookie_refresh import (
     cookie_payload,
     ensure_private_file_mode,
     launch_browser,
+    reconcile_private_paths,
     write_cookie_file,
     write_private_json_file,
 )
@@ -25,6 +26,8 @@ logger = logging.getLogger(__name__)
 _SESSION_LOCKS: dict[str, threading.RLock] = {}
 _SESSION_LOCKS_GUARD = threading.Lock()
 _DEFAULT_BROWSER_SESSION_DIR_NAME = "social-browser-sessions"
+_PRIVATE_PATHS_RECONCILED = False
+_PRIVATE_PATHS_RECONCILE_LOCK = threading.Lock()
 
 
 class BrowserSessionExecutionLockTimeout(TimeoutError):
@@ -51,12 +54,21 @@ def _project_root() -> Path:
 
 
 def _storage_root() -> Path:
+    global _PRIVATE_PATHS_RECONCILED
+
     raw = str(os.getenv("SOCIAL_BROWSER_SESSION_DIR") or "").strip()
     if raw:
         root = Path(raw).expanduser()
     else:
         root = _project_root() / "data" / _DEFAULT_BROWSER_SESSION_DIR_NAME
     root.mkdir(parents=True, exist_ok=True)
+    if not _PRIVATE_PATHS_RECONCILED:
+        with _PRIVATE_PATHS_RECONCILE_LOCK:
+            if not _PRIVATE_PATHS_RECONCILED:
+                # keys/ is deferred until the backend has a central keys-dir resolver.
+                hardened = reconcile_private_paths(root)
+                logger.info("Reconciled private social-session paths: hardened_files=%s", hardened)
+                _PRIVATE_PATHS_RECONCILED = True
     return root
 
 

--- a/trr_backend/socials/account_browser_sessions.py
+++ b/trr_backend/socials/account_browser_sessions.py
@@ -30,7 +30,7 @@ _PRIVATE_PATHS_RECONCILED = False
 _PRIVATE_PATHS_RECONCILE_LOCK = threading.Lock()
 
 
-class BrowserSessionExecutionLockTimeout(TimeoutError):
+class BrowserSessionExecutionLockTimeout(TimeoutError):  # noqa: N818 - retained public API
     """Raised when an account-scoped browser session lock cannot be acquired."""
 
     def __init__(self, *, platform: str, account_id: str, timeout_seconds: float) -> None:
@@ -38,8 +38,7 @@ class BrowserSessionExecutionLockTimeout(TimeoutError):
         self.account_id = account_id
         self.timeout_seconds = timeout_seconds
         super().__init__(
-            f"Timed out acquiring {platform} browser-session lock for {account_id} "
-            f"after {timeout_seconds:.1f}s"
+            f"Timed out acquiring {platform} browser-session lock for {account_id} after {timeout_seconds:.1f}s"
         )
 
 

--- a/trr_backend/socials/browser_cookie_refresh.py
+++ b/trr_backend/socials/browser_cookie_refresh.py
@@ -418,7 +418,10 @@ def open_cookie_refresh_context(
     try:
         context = browser.new_context(**context_kwargs)
     except Exception:
-        browser.close()
+        try:
+            browser.close()
+        except Exception:  # noqa: BLE001 - teardown must not mask the launch error
+            logger.warning("Failed to close browser after context creation failed", exc_info=True)
         raise
     return CookieRefreshBrowserContext(context=context, browser=browser)
 

--- a/trr_backend/socials/browser_cookie_refresh.py
+++ b/trr_backend/socials/browser_cookie_refresh.py
@@ -452,20 +452,22 @@ def reconcile_private_paths(*roots: str | Path, dir_mode: int = 0o700, file_mode
     hardened = 0
     for root in roots:
         base = Path(root).expanduser()
-        if not base.exists():
+        if base.is_symlink() or not base.exists():
             continue
         try:
             for path in base.rglob("*"):
                 try:
+                    if path.is_symlink():
+                        continue
                     if path.is_dir():
-                        path.chmod(dir_mode)
+                        path.chmod(dir_mode, follow_symlinks=False)
                     elif path.is_file():
-                        path.chmod(file_mode)
+                        path.chmod(file_mode, follow_symlinks=False)
                         hardened += 1
                 except OSError:
                     logger.debug("Failed to chmod %s during private-path reconcile", path, exc_info=True)
             try:
-                base.chmod(dir_mode)
+                base.chmod(dir_mode, follow_symlinks=False)
             except OSError:
                 logger.debug("Failed to chmod root %s during private-path reconcile", base, exc_info=True)
         except OSError:

--- a/trr_backend/socials/browser_cookie_refresh.py
+++ b/trr_backend/socials/browser_cookie_refresh.py
@@ -447,6 +447,32 @@ def ensure_private_file_mode(path: str | Path) -> None:
         logger.debug("Failed to chmod private cookie/session file %s", target, exc_info=True)
 
 
+def reconcile_private_paths(*roots: str | Path, dir_mode: int = 0o700, file_mode: int = 0o600) -> int:
+    """Best-effort chmod for private credential/session roots."""
+    hardened = 0
+    for root in roots:
+        base = Path(root).expanduser()
+        if not base.exists():
+            continue
+        try:
+            for path in base.rglob("*"):
+                try:
+                    if path.is_dir():
+                        path.chmod(dir_mode)
+                    elif path.is_file():
+                        path.chmod(file_mode)
+                        hardened += 1
+                except OSError:
+                    logger.debug("Failed to chmod %s during private-path reconcile", path, exc_info=True)
+            try:
+                base.chmod(dir_mode)
+            except OSError:
+                logger.debug("Failed to chmod root %s during private-path reconcile", base, exc_info=True)
+        except OSError:
+            logger.debug("Failed to walk %s during private-path reconcile", base, exc_info=True)
+    return hardened
+
+
 def write_private_json_file(path: str | Path, payload: Any) -> None:
     target = Path(path).expanduser()
     target.parent.mkdir(parents=True, exist_ok=True)

--- a/trr_backend/socials/browser_cookie_refresh.py
+++ b/trr_backend/socials/browser_cookie_refresh.py
@@ -351,7 +351,9 @@ def open_cookie_refresh_context(
         reserve_social_auth_refresh_attempt(platform)
 
     resolved_profile = resolve_social_auth_chrome_profile(platform, profile_name)
-    effective_require_profile = social_auth_requires_chrome_profile(platform) if require_profile is None else require_profile
+    effective_require_profile = (
+        social_auth_requires_chrome_profile(platform) if require_profile is None else require_profile
+    )
     profile_selection: ChromeProfileSelection | None = None
     if resolved_profile:
         try:
@@ -413,7 +415,11 @@ def open_cookie_refresh_context(
         )
 
     browser = launch_browser(playwright, headless=headless)
-    context = browser.new_context(**context_kwargs)
+    try:
+        context = browser.new_context(**context_kwargs)
+    except Exception:
+        browser.close()
+        raise
     return CookieRefreshBrowserContext(context=context, browser=browser)
 
 
@@ -639,7 +645,8 @@ def refresh_simple_login_cookies(
                     reuse_valid, reuse_reason = validator(existing_cookies)
                     if not reuse_valid:
                         logger.info(
-                            "%s Chrome-profile cookies failed in-protocol validation (%s); falling through to scripted login",
+                            "%s Chrome-profile cookies failed in-protocol validation (%s); "
+                            "falling through to scripted login",
                             spec.platform,
                             reuse_reason or "unknown",
                         )


### PR DESCRIPTION
## Summary
- close failed cookie-refresh browser sessions
- make destructive operator commands preview by default
- reject contradictory apply and dry-run flags
- prevent permission reconciliation from following symlinks

## Advisor provenance
Replaces advisors 029, 040, and 041. The 040 and 041 defects found during review are repaired here.

## Validation
- 50 focused tests passed with isolated HOME
- Ruff and git diff --check passed

No SQL or app changes.