### PR TITLE
Harden social media URL fetching against SSRF

### DIFF
--- a/tests/socials/test_avatar_ssrf_guard.py
+++ b/tests/socials/test_avatar_ssrf_guard.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from trr_backend.socials.media_url_safety import UnsafeMediaUrlError
+from trr_backend.socials.social_season_analytics_impl import _download_avatar_to_tempfile
+
+
+def test_download_avatar_rejects_cloud_metadata_literal_ip() -> None:
+    with pytest.raises(UnsafeMediaUrlError, match="media_url_blocked_ip"):
+        _download_avatar_to_tempfile(
+            "http://169.254.169.254/latest/meta-data",
+            platform="instagram",
+            headers={},
+        )
+
+
+def test_download_avatar_rejects_loopback_literal_ip() -> None:
+    with pytest.raises(UnsafeMediaUrlError, match="media_url_blocked_ip"):
+        _download_avatar_to_tempfile(
+            "http://127.0.0.1/a.jpg",
+            platform="instagram",
+            headers={},
+        )
+
+
+def test_download_avatar_rejects_disallowed_public_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 80))],
+    )
+
+    with pytest.raises(UnsafeMediaUrlError, match="media_url_host_not_allowed"):
+        _download_avatar_to_tempfile(
+            "http://evil-cdn.org/a.jpg",
+            platform="instagram",
+            headers={},
+        )

--- a/tests/socials/test_avatar_ssrf_guard.py
+++ b/tests/socials/test_avatar_ssrf_guard.py
@@ -4,6 +4,7 @@ import socket
 
 import pytest
 
+import trr_backend.socials.social_season_analytics_impl as social_season_analytics_impl
 from trr_backend.socials.media_url_safety import UnsafeMediaUrlError
 from trr_backend.socials.social_season_analytics_impl import _download_avatar_to_tempfile
 
@@ -36,6 +37,20 @@ def test_download_avatar_rejects_disallowed_public_host(monkeypatch: pytest.Monk
     with pytest.raises(UnsafeMediaUrlError, match="media_url_host_not_allowed"):
         _download_avatar_to_tempfile(
             "http://evil-cdn.org/a.jpg",
+            platform="instagram",
+            headers={},
+        )
+
+
+def test_download_avatar_rejects_reserved_test_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_if_requested(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("reserved test host reached the HTTP client")
+
+    monkeypatch.setattr(social_season_analytics_impl.requests, "get", fail_if_requested)
+
+    with pytest.raises(UnsafeMediaUrlError, match="media_url_host_not_allowed"):
+        _download_avatar_to_tempfile(
+            "https://example.com/avatar.jpg",
             platform="instagram",
             headers={},
         )

--- a/tests/socials/test_media_url_safety.py
+++ b/tests/socials/test_media_url_safety.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import socket
 from types import SimpleNamespace
 
@@ -8,6 +9,8 @@ import pytest
 from trr_backend.socials.media_url_safety import (
     MediaUrlSafetyPolicy,
     UnsafeMediaUrlError,
+    _is_blocked_ip,
+    allowed_hosts_for_platform,
     safe_requests_get,
     validate_media_url,
 )
@@ -33,6 +36,63 @@ def test_validate_media_url_rejects_allowed_host_resolving_to_private_ip(monkeyp
             "https://cdninstagram.com/image.jpg",
             policy=MediaUrlSafetyPolicy(("cdninstagram.com",)),
         )
+
+
+def test_validate_media_url_rejects_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 6379))],
+    )
+
+    with pytest.raises(UnsafeMediaUrlError):
+        validate_media_url(
+            "http://localhost:6379/x",
+            policy=MediaUrlSafetyPolicy(("cdninstagram.com",)),
+        )
+
+
+def test_validate_media_url_rejects_localhost_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 6379))],
+    )
+
+    with pytest.raises(UnsafeMediaUrlError):
+        validate_media_url(
+            "http://something.localhost/x",
+            policy=MediaUrlSafetyPolicy(("cdninstagram.com",)),
+        )
+
+
+def test_validate_media_url_allows_reserved_test_host_with_test_host_policy() -> None:
+    assert (
+        validate_media_url(
+            "http://example.com/x",
+            policy=MediaUrlSafetyPolicy(("cdninstagram.com",), allow_test_hosts=True),
+        )
+        == "http://example.com/x"
+    )
+
+
+def test_validate_media_url_empty_allowlist_fails_closed() -> None:
+    with pytest.raises(UnsafeMediaUrlError, match="media_url_host_not_allowed"):
+        validate_media_url(
+            "http://evil.example-not-reserved.com/x",
+            policy=MediaUrlSafetyPolicy(()),
+        )
+
+
+def test_allowed_hosts_for_platform_includes_reddit() -> None:
+    allowed_hosts = allowed_hosts_for_platform("reddit")
+
+    assert allowed_hosts
+    assert "redd.it" in allowed_hosts
+
+
+def test_is_blocked_ip_rejects_ipv4_mapped_ipv6() -> None:
+    assert _is_blocked_ip(ipaddress.ip_address("::ffff:169.254.169.254")) is True
 
 
 def test_safe_requests_get_revalidates_redirect_targets() -> None:

--- a/trr_backend/socials/media_url_safety.py
+++ b/trr_backend/socials/media_url_safety.py
@@ -21,8 +21,8 @@ class MediaUrlSafetyPolicy:
     resolve_dns: bool = True
 
 
-_RESERVED_TEST_SUFFIXES = (".test", ".example", ".invalid", ".localhost")
-_RESERVED_TEST_HOSTS = {"example.com", "example.net", "example.org", "localhost"}
+_RESERVED_TEST_SUFFIXES = (".test", ".example", ".invalid")
+_RESERVED_TEST_HOSTS = {"example.com", "example.net", "example.org"}
 
 _PLATFORM_ALLOWED_HOST_SUFFIXES: dict[str, tuple[str, ...]] = {
     "instagram": (
@@ -64,6 +64,12 @@ _PLATFORM_ALLOWED_HOST_SUFFIXES: dict[str, tuple[str, ...]] = {
         "googlevideo.com",
         "ytimg.com",
     ),
+    "reddit": (
+        "redd.it",
+        "redditmedia.com",
+        "redditstatic.com",
+        "reddit.com",
+    ),
 }
 
 
@@ -91,6 +97,9 @@ def _is_reserved_test_host(hostname: str) -> bool:
 
 
 def _is_blocked_ip(ip: ipaddress._BaseAddress) -> bool:
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
     return any(
         (
             ip.is_loopback,
@@ -153,12 +162,13 @@ def validate_media_url(
         if _is_blocked_ip(literal_ip):
             raise UnsafeMediaUrlError("media_url_blocked_ip")
         active_policy = policy or MediaUrlSafetyPolicy(tuple(allowed_host_suffixes or ()))
-        if active_policy.allowed_host_suffixes and not _hostname_matches(hostname, active_policy.allowed_host_suffixes):
+        if not _hostname_matches(hostname, active_policy.allowed_host_suffixes):
             raise UnsafeMediaUrlError("media_url_host_not_allowed")
         return candidate
 
     active_policy = policy or MediaUrlSafetyPolicy(tuple(allowed_host_suffixes or ()))
-    if active_policy.allowed_host_suffixes and not _hostname_matches(hostname, active_policy.allowed_host_suffixes):
+    host_allowed = _hostname_matches(hostname, active_policy.allowed_host_suffixes)
+    if not host_allowed:
         if not (active_policy.allow_test_hosts and _is_reserved_test_host(hostname)):
             raise UnsafeMediaUrlError("media_url_host_not_allowed")
 

--- a/trr_backend/socials/social_season_analytics_impl.py
+++ b/trr_backend/socials/social_season_analytics_impl.py
@@ -18524,7 +18524,10 @@ def _download_avatar_to_tempfile(
         safe_requests_get,
     )
 
-    media_url_policy = MediaUrlSafetyPolicy(allowed_hosts_for_platform(platform))
+    media_url_policy = MediaUrlSafetyPolicy(
+        allowed_hosts_for_platform(platform),
+        allow_test_hosts=False,
+    )
     temp_path: str | None = None
     content_type = "application/octet-stream"
     total_bytes = 0

--- a/trr_backend/socials/social_season_analytics_impl.py
+++ b/trr_backend/socials/social_season_analytics_impl.py
@@ -18514,16 +18514,26 @@ def _avatar_registry_failure_status(reason: str | None) -> str:
 def _download_avatar_to_tempfile(
     source_url: str,
     *,
+    platform: str,
     headers: Mapping[str, str],
     progress_cb: Callable[[], None] | None = None,
 ) -> tuple[str, str, str]:
+    from trr_backend.socials.media_url_safety import (
+        MediaUrlSafetyPolicy,
+        allowed_hosts_for_platform,
+        safe_requests_get,
+    )
+
+    media_url_policy = MediaUrlSafetyPolicy(allowed_hosts_for_platform(platform))
     temp_path: str | None = None
     content_type = "application/octet-stream"
     total_bytes = 0
     sha256 = hashlib.sha256()
     try:
-        with requests.get(
+        with safe_requests_get(
+            requests,
             source_url,
+            policy=media_url_policy,
             timeout=(10, 30),
             headers=dict(headers),
             stream=True,
@@ -18825,6 +18835,7 @@ def _mirror_instagram_profile_pics_for_post(
         try:
             temp_path, content_type, sha256 = _download_avatar_to_tempfile(
                 source_url,
+                platform="instagram",
                 headers={
                     "user-agent": (
                         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
@@ -19046,6 +19057,7 @@ def _mirror_post_author_avatar_to_s3(
     try:
         temp_path, content_type, sha256 = _download_avatar_to_tempfile(
             source_url,
+            platform=platform,
             headers={
                 "user-agent": (
                     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "


### PR DESCRIPTION
## Summary
- enforce fail-closed media URL allowlists
- block localhost, private, and mapped-IP targets
- apply the policy to avatar mirroring and Reddit media hosts

## Advisor provenance
Replaces advisor branches 026 and 035 from a fresh origin/main base.

## Validation
- 12 focused tests passed
- Ruff and git diff --check passed

No SQL or app changes.