### PR TITLE
Make Reddit worker and OAuth runtime concurrency-safe

### DIFF
--- a/scripts/start_remote_job_workers.sh
+++ b/scripts/start_remote_job_workers.sh
@@ -79,7 +79,22 @@ start_worker() {
   local label="$1"
   shift
   echo "[remote-workers] starting ${label}: $*"
-  "$@" &
+  (
+    child_pid=""
+    trap 'if [[ -n "$child_pid" ]]; then kill -TERM "$child_pid" >/dev/null 2>&1 || true; wait "$child_pid" 2>/dev/null || true; fi; exit 143' TERM INT
+    while true; do
+      "$@" &
+      child_pid="$!"
+      wait "$child_pid"
+      local rc=$?
+      child_pid=""
+      if [[ "$rc" -eq 0 ]]; then
+        break
+      fi
+      echo "[remote-workers] ${label} exited rc=${rc}; respawning in ${RESPAWN_DELAY:-5}s"
+      sleep "${RESPAWN_DELAY:-5}"
+    done
+  ) &
   PIDS+=("$!")
 }
 

--- a/scripts/start_remote_job_workers.sh
+++ b/scripts/start_remote_job_workers.sh
@@ -85,8 +85,12 @@ start_worker() {
     while true; do
       "$@" &
       child_pid="$!"
-      wait "$child_pid"
-      local rc=$?
+      local rc
+      if wait "$child_pid"; then
+        rc=0
+      else
+        rc=$?
+      fi
       child_pid=""
       if [[ "$rc" -eq 0 ]]; then
         break

--- a/tests/repositories/test_reddit_refresh.py
+++ b/tests/repositories/test_reddit_refresh.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from contextlib import nullcontext
 from datetime import UTC, datetime, timedelta
 
@@ -50,6 +51,66 @@ def test_extract_reddit_media_urls_uses_clean_href_values_without_tag_tail() -> 
     assert reddit_refresh._extract_reddit_media_urls(body_html) == [  # noqa: SLF001
         ("https://preview.redd.it/example.jpeg?width=321&format=pjpg&auto=webp&s=abc123", "image")
     ]
+
+
+def test_reddit_http_client_reuses_cached_oauth_token(monkeypatch) -> None:
+    monkeypatch.setenv("REDDIT_CLIENT_ID", "client-id")
+    monkeypatch.setenv("REDDIT_CLIENT_SECRET", "client-secret")
+
+    class TokenResponse:
+        status_code = 200
+        content = b"{}"
+
+        def json(self) -> dict[str, object]:
+            return {"access_token": "cached-access-token", "expires_in": 3600}
+
+    class TokenSession:
+        def __init__(self) -> None:
+            self.post_calls = 0
+
+        def post(self, *_args, **_kwargs) -> TokenResponse:  # noqa: ANN002, ANN003
+            self.post_calls += 1
+            return TokenResponse()
+
+    client = reddit_refresh.RedditHttpClient()
+    session = TokenSession()
+    client.session = session
+
+    assert client._get_oauth_token() == "cached-access-token"  # noqa: SLF001
+    assert client._get_oauth_token() == "cached-access-token"  # noqa: SLF001
+    assert session.post_calls == 1
+
+
+def test_reddit_http_client_cooldown_lock_concurrency_smoke() -> None:
+    client = reddit_refresh.RedditHttpClient()
+    client._adaptive_cooldown = 0.05  # noqa: SLF001
+    errors: list[Exception] = []
+
+    def hammer_cooldown() -> None:
+        try:
+            for _ in range(50):
+                with client._state_lock:  # noqa: SLF001
+                    client._adaptive_cooldown = min(  # noqa: SLF001
+                        client._adaptive_cooldown_max,  # noqa: SLF001
+                        client._adaptive_cooldown * 2,  # noqa: SLF001
+                    )
+                with client._state_lock:  # noqa: SLF001
+                    client._adaptive_cooldown = max(  # noqa: SLF001
+                        client._adaptive_cooldown_min,  # noqa: SLF001
+                        client._adaptive_cooldown * 0.9,  # noqa: SLF001
+                    )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hammer_cooldown) for _ in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    with client._state_lock:  # noqa: SLF001
+        assert client._adaptive_cooldown_min <= client._adaptive_cooldown <= client._adaptive_cooldown_max  # noqa: SLF001
 
 
 def test_build_reddit_refresh_save_proof_counts_saved_rows(monkeypatch) -> None:

--- a/tests/repositories/test_reddit_refresh.py
+++ b/tests/repositories/test_reddit_refresh.py
@@ -2064,6 +2064,86 @@ def test_run_reddit_refresh_worker_loop_once_returns_one_when_no_work(monkeypatc
     assert result == 1
 
 
+def test_run_reddit_refresh_worker_loop_continues_after_run_failure(monkeypatch) -> None:
+    run_id = "63a7be5d-0000-4000-8000-000000000101"
+    claims = [
+        {"id": run_id, "attempt_count": 1},
+        None,
+    ]
+    claim_calls = 0
+    execute_calls: list[dict] = []
+
+    class StopLoop(Exception):
+        pass
+
+    def fake_claim_next_refresh_run(**kwargs):  # noqa: ANN001
+        nonlocal claim_calls
+        claim_calls += 1
+        return claims.pop(0)
+
+    def fake_execute_refresh_run(run_id_arg, **kwargs):  # noqa: ANN001
+        execute_calls.append({"run_id": run_id_arg, **kwargs})
+        raise RuntimeError("simulated refresh failure")
+
+    monkeypatch.setattr(reddit_refresh, "claim_next_refresh_run", fake_claim_next_refresh_run)
+    monkeypatch.setattr(reddit_refresh, "execute_refresh_run", fake_execute_refresh_run)
+    monkeypatch.setattr(reddit_refresh.time, "sleep", lambda _seconds: (_ for _ in ()).throw(StopLoop))
+
+    with pytest.raises(StopLoop):
+        reddit_refresh.run_reddit_refresh_worker_loop(worker_id="worker-1", once=False, poll_seconds=0.2)
+
+    assert claim_calls == 2
+    assert execute_calls == [
+        {
+            "run_id": run_id,
+            "preclaimed_run": {"id": run_id, "attempt_count": 1},
+            "worker_id": "worker-1",
+            "raise_on_failure": False,
+        }
+    ]
+
+
+def test_execute_refresh_run_suppresses_non_403_failure_when_requested(monkeypatch) -> None:
+    run_id = "63a7be5d-0000-4000-8000-000000000102"
+    run_row = {
+        "id": run_id,
+        "community_id": "community-1",
+        "season_id": "season-1",
+        "period_key": "season",
+        "subreddit": "bravorealhousewives",
+        "request_payload": {"mode": "sync_posts"},
+        "claim_token": "claim-token-1",
+    }
+    updates: list[dict] = []
+
+    monkeypatch.setattr(reddit_refresh.pg, "fetch_one", lambda *args, **kwargs: run_row)  # noqa: ANN002, ANN003, ARG005
+    monkeypatch.setattr(
+        reddit_refresh,
+        "_discover_window",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("simulated refresh failure")),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        reddit_refresh,
+        "_update_run",
+        lambda run_id_arg, **kwargs: updates.append({"run_id": run_id_arg, **kwargs}),  # noqa: ANN001
+    )
+    monkeypatch.setattr(reddit_refresh, "_touch_refresh_run_heartbeat", lambda **kwargs: None)
+    monkeypatch.setattr(
+        reddit_refresh,
+        "get_refresh_run",
+        lambda run_id_arg: {"run_id": run_id_arg, "status": "failed"},
+    )
+
+    result = reddit_refresh.execute_refresh_run(run_id, raise_on_failure=False)
+
+    assert result == {"run_id": run_id, "status": "failed"}
+    failed_update = next((item for item in updates if item.get("status") == "failed"), None)
+    assert failed_update is not None
+    assert failed_update["release_claim"] is True
+    assert failed_update["claim_token"] == "claim-token-1"
+    assert failed_update["error_message"] == "simulated refresh failure"
+
+
 def test_execute_refresh_run_sync_details_emits_terminal_summary(monkeypatch) -> None:
     run_id = "63a7be5d-0000-4000-8000-000000000099"
     run_row = {

--- a/tests/repositories/test_reddit_refresh.py
+++ b/tests/repositories/test_reddit_refresh.py
@@ -81,6 +81,54 @@ def test_reddit_http_client_reuses_cached_oauth_token(monkeypatch) -> None:
     assert session.post_calls == 1
 
 
+def test_reddit_http_client_coalesces_concurrent_cold_oauth_refreshes(monkeypatch) -> None:
+    monkeypatch.setenv("REDDIT_CLIENT_ID", "client-id")
+    monkeypatch.setenv("REDDIT_CLIENT_SECRET", "client-secret")
+
+    class TokenResponse:
+        status_code = 200
+        content = b"{}"
+
+        def json(self) -> dict[str, object]:
+            return {"access_token": "shared-access-token", "expires_in": 3600}
+
+    class TokenSession:
+        def __init__(self) -> None:
+            self.post_calls = 0
+            self.post_started = threading.Event()
+            self.release_post = threading.Event()
+
+        def post(self, *_args, **_kwargs) -> TokenResponse:  # noqa: ANN002, ANN003
+            self.post_calls += 1
+            self.post_started.set()
+            assert self.release_post.wait(timeout=5)
+            return TokenResponse()
+
+    client = reddit_refresh.RedditHttpClient()
+    session = TokenSession()
+    client.session = session
+    caller_count = 12
+    start = threading.Barrier(caller_count + 1)
+    tokens: list[str | None] = []
+
+    def fetch_token() -> None:
+        start.wait(timeout=5)
+        tokens.append(client._get_oauth_token())  # noqa: SLF001
+
+    threads = [threading.Thread(target=fetch_token) for _ in range(caller_count)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    assert session.post_started.wait(timeout=5)
+    session.release_post.set()
+    for thread in threads:
+        thread.join(timeout=5)
+        assert not thread.is_alive()
+
+    assert tokens == ["shared-access-token"] * caller_count
+    assert session.post_calls == 1
+
+
 def test_reddit_http_client_cooldown_lock_concurrency_smoke() -> None:
     client = reddit_refresh.RedditHttpClient()
     client._adaptive_cooldown = 0.05  # noqa: SLF001
@@ -2134,7 +2182,7 @@ def test_run_reddit_refresh_worker_loop_continues_after_run_failure(monkeypatch)
     claim_calls = 0
     execute_calls: list[dict] = []
 
-    class StopLoop(Exception):
+    class StopLoopError(Exception):
         pass
 
     def fake_claim_next_refresh_run(**kwargs):  # noqa: ANN001
@@ -2148,9 +2196,9 @@ def test_run_reddit_refresh_worker_loop_continues_after_run_failure(monkeypatch)
 
     monkeypatch.setattr(reddit_refresh, "claim_next_refresh_run", fake_claim_next_refresh_run)
     monkeypatch.setattr(reddit_refresh, "execute_refresh_run", fake_execute_refresh_run)
-    monkeypatch.setattr(reddit_refresh.time, "sleep", lambda _seconds: (_ for _ in ()).throw(StopLoop))
+    monkeypatch.setattr(reddit_refresh.time, "sleep", lambda _seconds: (_ for _ in ()).throw(StopLoopError))
 
-    with pytest.raises(StopLoop):
+    with pytest.raises(StopLoopError):
         reddit_refresh.run_reddit_refresh_worker_loop(worker_id="worker-1", once=False, poll_seconds=0.2)
 
     assert claim_calls == 2

--- a/tests/scripts/test_start_remote_job_workers.py
+++ b/tests/scripts/test_start_remote_job_workers.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_remote_worker_wrapper_respawns_after_nonzero_child_exit(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    calls_file = tmp_path / "calls.log"
+    fake_python = tmp_path / "fake-python"
+    fake_python.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'call\\n' >> "$CALLS_FILE"
+if [[ "$(wc -l < "$CALLS_FILE")" -eq 1 ]]; then
+  exit 17
+fi
+exit 0
+""",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PYTHON_BIN": str(fake_python),
+        "CALLS_FILE": str(calls_file),
+        "RESPAWN_DELAY": "0",
+        "TRR_ADMIN_OPERATION_WORKER_ENABLED": "0",
+        "TRR_REDDIT_REFRESH_WORKER_ENABLED": "1",
+        "TRR_REDDIT_REFRESH_WORKER_COUNT": "1",
+        "TRR_GOOGLE_NEWS_WORKER_ENABLED": "0",
+        "TRR_SOCIAL_INGEST_WORKER_ENABLED": "0",
+    }
+    result = subprocess.run(
+        ["bash", str(repo_root / "scripts" / "start_remote_job_workers.sh")],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert calls_file.read_text(encoding="utf-8").splitlines() == ["call", "call"]
+    assert "reddit-refresh#1 exited rc=17; respawning" in result.stdout

--- a/trr_backend/repositories/reddit_refresh.py
+++ b/trr_backend/repositories/reddit_refresh.py
@@ -1030,6 +1030,7 @@ class RedditHttpClient:
         self._oauth_token: str | None = None
         self._oauth_expires_at: float = 0.0
         self._state_lock = threading.Lock()
+        self._oauth_refresh_lock = threading.Lock()
         # Adaptive cooldown: starts at configured minimum, increases on 429s, decays on success
         self._adaptive_cooldown: float = self.page_cooldown
         self._adaptive_cooldown_min: float = self.page_cooldown
@@ -1052,33 +1053,38 @@ class RedditHttpClient:
     def _get_oauth_token(self) -> str | None:
         if not self.client_id or not self.client_secret:
             return None
-        now = time.time()
+
         with self._state_lock:
-            if self._oauth_token and now < (self._oauth_expires_at - 30):
+            if self._oauth_token and time.time() < (self._oauth_expires_at - 30):
                 return self._oauth_token
-        try:
-            response = self.session.post(
-                "https://www.reddit.com/api/v1/access_token",
-                headers={"User-Agent": self.user_agent},
-                auth=(self.client_id, self.client_secret),
-                data={"grant_type": "client_credentials"},
-                timeout=self.timeout_seconds,
-            )
-            if response.status_code >= 400:
-                logger.warning("[reddit_refresh_oauth_failed] status=%s", response.status_code)
-                return None
-            payload = response.json() if response.content else {}
-            token = str(payload.get("access_token") or "").strip()
-            expires_in = float(payload.get("expires_in") or 3600)
-            if not token:
-                return None
+
+        with self._oauth_refresh_lock:
             with self._state_lock:
-                self._oauth_token = token
-                self._oauth_expires_at = time.time() + max(60.0, expires_in)
-            return token
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("[reddit_refresh_oauth_exception] %s", exc)
-            return None
+                if self._oauth_token and time.time() < (self._oauth_expires_at - 30):
+                    return self._oauth_token
+            try:
+                response = self.session.post(
+                    "https://www.reddit.com/api/v1/access_token",
+                    headers={"User-Agent": self.user_agent},
+                    auth=(self.client_id, self.client_secret),
+                    data={"grant_type": "client_credentials"},
+                    timeout=self.timeout_seconds,
+                )
+                if response.status_code >= 400:
+                    logger.warning("[reddit_refresh_oauth_failed] status=%s", response.status_code)
+                    return None
+                payload = response.json() if response.content else {}
+                token = str(payload.get("access_token") or "").strip()
+                expires_in = float(payload.get("expires_in") or 3600)
+                if not token:
+                    return None
+                with self._state_lock:
+                    self._oauth_token = token
+                    self._oauth_expires_at = time.time() + max(60.0, expires_in)
+                return token
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[reddit_refresh_oauth_exception] %s", exc)
+                return None
 
     def get_json(self, path: str, *, params: dict[str, Any]) -> dict[str, Any]:
         supports_oauth = bool(self.client_id and self.client_secret)

--- a/trr_backend/repositories/reddit_refresh.py
+++ b/trr_backend/repositories/reddit_refresh.py
@@ -1029,6 +1029,7 @@ class RedditHttpClient:
         self.user_agent = (os.getenv("REDDIT_USER_AGENT") or "").strip() or REDDIT_USER_AGENT_DEFAULT
         self._oauth_token: str | None = None
         self._oauth_expires_at: float = 0.0
+        self._state_lock = threading.Lock()
         # Adaptive cooldown: starts at configured minimum, increases on 429s, decays on success
         self._adaptive_cooldown: float = self.page_cooldown
         self._adaptive_cooldown_min: float = self.page_cooldown
@@ -1052,8 +1053,9 @@ class RedditHttpClient:
         if not self.client_id or not self.client_secret:
             return None
         now = time.time()
-        if self._oauth_token and now < (self._oauth_expires_at - 30):
-            return self._oauth_token
+        with self._state_lock:
+            if self._oauth_token and now < (self._oauth_expires_at - 30):
+                return self._oauth_token
         try:
             response = self.session.post(
                 "https://www.reddit.com/api/v1/access_token",
@@ -1070,8 +1072,9 @@ class RedditHttpClient:
             expires_in = float(payload.get("expires_in") or 3600)
             if not token:
                 return None
-            self._oauth_token = token
-            self._oauth_expires_at = time.time() + max(60.0, expires_in)
+            with self._state_lock:
+                self._oauth_token = token
+                self._oauth_expires_at = time.time() + max(60.0, expires_in)
             return token
         except Exception as exc:  # noqa: BLE001
             logger.warning("[reddit_refresh_oauth_exception] %s", exc)
@@ -1096,10 +1099,11 @@ class RedditHttpClient:
                     )
                     if response.status_code == 429:
                         # Adaptive backoff: increase cooldown on rate limit
-                        self._adaptive_cooldown = min(
-                            self._adaptive_cooldown_max,
-                            self._adaptive_cooldown * 2,
-                        )
+                        with self._state_lock:
+                            self._adaptive_cooldown = min(
+                                self._adaptive_cooldown_max,
+                                self._adaptive_cooldown * 2,
+                            )
                         retry_after = response.headers.get("Retry-After")
                         delay = self.rate_limit_delay
                         if retry_after:
@@ -1125,12 +1129,15 @@ class RedditHttpClient:
                         )
                     payload = response.json() if response.content else {}
                     # Adaptive cooldown: use current adaptive value, decay toward minimum on success
-                    if self._adaptive_cooldown > 0:
-                        time.sleep(self._adaptive_cooldown)
-                    self._adaptive_cooldown = max(
-                        self._adaptive_cooldown_min,
-                        self._adaptive_cooldown * 0.9,
-                    )
+                    with self._state_lock:
+                        current_cooldown = self._adaptive_cooldown
+                    if current_cooldown > 0:
+                        time.sleep(current_cooldown)
+                    with self._state_lock:
+                        self._adaptive_cooldown = max(
+                            self._adaptive_cooldown_min,
+                            self._adaptive_cooldown * 0.9,
+                        )
                     return payload if isinstance(payload, dict) else {}
                 except RedditRefreshError:
                     raise

--- a/trr_backend/repositories/reddit_refresh.py
+++ b/trr_backend/repositories/reddit_refresh.py
@@ -3779,6 +3779,7 @@ def execute_refresh_run(
     *,
     preclaimed_run: dict[str, Any] | None = None,
     worker_id: str | None = None,
+    raise_on_failure: bool = True,
 ) -> dict[str, Any]:
     run = (
         dict(preclaimed_run)
@@ -4342,7 +4343,9 @@ def execute_refresh_run(
             claim_token=claim_token,
             release_claim=True,
         )
-        raise
+        if raise_on_failure:
+            raise
+        return get_refresh_run(run_id)
 
 
 def run_reddit_refresh_worker_loop(
@@ -4376,7 +4379,19 @@ def run_reddit_refresh_worker_loop(
             run_id[:8] if run_id else None,
             _safe_int(claimed.get("attempt_count")),
         )
-        execute_refresh_run(run_id, preclaimed_run=claimed, worker_id=normalized_worker)
+        try:
+            execute_refresh_run(
+                run_id,
+                preclaimed_run=claimed,
+                worker_id=normalized_worker,
+                raise_on_failure=False,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "[reddit_refresh_worker_run_error] worker_id=%s run_id=%s",
+                normalized_worker,
+                run_id[:8] if run_id else None,
+            )
         if once:
             logger.info("[reddit_refresh_worker_once_complete] worker_id=%s run_id=%s", normalized_worker, run_id[:8])
             return 0


### PR DESCRIPTION
## Summary
- preserve worker respawn after nonzero child exit under set -e
- serialize cold OAuth refresh and double-check the token cache
- add real respawn and concurrent-token regression harnesses

## Advisor provenance
Replaces revised advisors 036 and 047.

## Validation
- 51 focused tests passed
- shell syntax, Ruff, and git diff --check passed

No SQL or app changes.