### PR TITLE
Fix YouTube, Twitter, and SocialBlade scrape correctness

### DIFF
--- a/tests/socials/test_socialblade_scraper.py
+++ b/tests/socials/test_socialblade_scraper.py
@@ -20,6 +20,7 @@ from trr_backend.socials.socialblade.scraper import (
     _parse_metric_number,
     _scrape_socialblade_in_context,
     _socialblade_page_is_logged_in,
+    _socialblade_payload_needs_login_retry,
     _socialblade_profile_url,
     scrape_socialblade,
 )
@@ -705,6 +706,51 @@ def test_scrape_socialblade_logs_in_and_retries_when_history_is_short(
     assert payload["history_source"] == "authenticated_api"
     assert payload["daily_channel_metrics_60day"]["row_count"] == 60
     assert calls == [{"cf_clearance": "stale"}, {"cf_clearance": "fresh", "session": "logged-in"}]
+
+
+def test_authenticated_30_day_socialblade_payload_does_not_need_login_retry() -> None:
+    payload = {
+        "history_source": "page_trpc_capture",
+        "daily_channel_metrics_60day": {
+            "period": "Last 30 Days",
+            "row_count": 30,
+            "data": [],
+        },
+        "daily_total_followers_chart": {
+            "total_data_points": 30,
+            "data": [],
+        },
+        "runtime_metadata": {
+            "capture_control_updates": {
+                "last60Days": "selected",
+                "daily": "selected",
+                "total": "selected",
+            },
+        },
+    }
+
+    assert _socialblade_payload_needs_login_retry(payload) is False
+
+
+def test_unauthenticated_30_day_socialblade_payload_still_needs_login_retry() -> None:
+    payload = {
+        "history_source": "table_fallback",
+        "daily_channel_metrics_60day": {
+            "period": "Last 30 Days",
+            "row_count": 30,
+            "data": [],
+        },
+        "daily_total_followers_chart": {
+            "total_data_points": 30,
+            "data": [],
+        },
+    }
+
+    assert _socialblade_payload_needs_login_retry(payload) is True
+
+
+def test_socialblade_payload_without_metrics_still_needs_login_retry() -> None:
+    assert _socialblade_payload_needs_login_retry({"history_source": "page_trpc_capture"}) is True
 
 
 def test_scrape_socialblade_marks_seeded_modal_table_result_degraded_when_history_is_short(

--- a/tests/socials/twitter/test_twitter_direct_scrape.py
+++ b/tests/socials/twitter/test_twitter_direct_scrape.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 import inspect
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any

--- a/tests/socials/twitter/test_twitter_direct_scrape.py
+++ b/tests/socials/twitter/test_twitter_direct_scrape.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import inspect
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -10,6 +11,7 @@ from fastapi import HTTPException
 
 import trr_backend.socials.twitter.direct_scrape as direct_scrape
 from trr_backend.socials.twitter import Tweet
+from trr_backend.socials.twitter.scraper import TwitterScrapeConfig, TwitterScraper
 
 
 def _tweet(
@@ -307,6 +309,52 @@ def test_fetch_quotes_re_raises_http_exception_from_auth_loader() -> None:
         )
 
     assert exc_info.value.status_code == 429
+
+
+def test_syndication_filter_treats_naive_window_bounds_as_utc(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Response:
+        status_code = 200
+
+        def __init__(self, entries: list[dict[str, Any]]) -> None:
+            self.text = (
+                '<script id="__NEXT_DATA__" type="application/json">'
+                + json.dumps({"props": {"pageProps": {"timeline": {"entries": entries}}}})
+                + "</script>"
+            )
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def _entry(tweet_id: str, created_at: str) -> dict[str, Any]:
+        return {
+            "content": {
+                "tweet": {
+                    "id_str": tweet_id,
+                    "created_at": created_at,
+                    "full_text": "#RHOSLC",
+                    "user": {"screen_name": "bravo", "name": "Bravo"},
+                }
+            }
+        }
+
+    scraper = TwitterScraper()
+    scraper.session = SimpleNamespace(
+        get=lambda *_args, **_kwargs: _Response(
+            [
+                _entry("before-window", "Sat Jan 31 23:59:59 +0000 2026"),
+                _entry("start-boundary", "Sun Feb 01 00:00:00 +0000 2026"),
+                _entry("end-boundary", "Mon Feb 02 00:00:00 +0000 2026"),
+            ]
+        )
+    )
+    monkeypatch.setattr(scraper, "_rate_limit", lambda *_args, **_kwargs: None)
+
+    tweets = scraper._scrape_syndication(
+        "bravo",
+        TwitterScrapeConfig(query="RHOSLC", date_start=datetime(2026, 2, 1), date_end=datetime(2026, 2, 1)),
+    )
+
+    assert [tweet.tweet_id for tweet in tweets] == ["start-boundary"]
 
 
 def test_direct_scrape_keeps_shared_catalog_and_legacy_repository_out_of_direct_module() -> None:

--- a/tests/socials/youtube/test_scraper.py
+++ b/tests/socials/youtube/test_scraper.py
@@ -35,6 +35,14 @@ def _build_video(video_id: str, *, surface: str, published_at: int) -> YouTubeVi
     )
 
 
+def test_config_treats_naive_date_start_as_utc() -> None:
+    config = YouTubeScrapeConfig(channel_handle="bravo", date_start=datetime(2026, 5, 1))
+
+    assert config.date_start is not None
+    assert config.date_start.tzinfo is UTC
+    assert config.start_timestamp == datetime(2026, 5, 1, tzinfo=UTC).timestamp()
+
+
 def test_apply_surface_guaranteed_limit_overrides_small_cap_when_both_surfaces_present() -> None:
     scraper = YouTubeScraper()
     videos = [

--- a/tests/socials/youtube/test_scraper.py
+++ b/tests/socials/youtube/test_scraper.py
@@ -352,6 +352,44 @@ def test_parse_video_renderer_uses_header_avatar_fallback_when_renderer_avatar_m
     assert parsed.user_avatar_url == "https://yt3.googleusercontent.com/avatar=s1024-c-k"
 
 
+def test_parse_video_renderer_reads_runs_form_view_count() -> None:
+    scraper = YouTubeScraper()
+    config = YouTubeScrapeConfig(channel_handle="bravo", keywords=[])
+    renderer = {
+        "videoId": "abc1234",
+        "title": {"runs": [{"text": "Bravo clip"}]},
+        "descriptionSnippet": {"runs": [{"text": "episode"}]},
+        "viewCountText": {"runs": [{"text": "1,234"}, {"text": " views"}]},
+        "publishedTimeText": {"simpleText": "1 day ago"},
+        "ownerText": {"runs": [{"text": "Bravo"}]},
+        "thumbnail": {"thumbnails": [{"url": "https://img.test/thumb.jpg"}]},
+    }
+
+    parsed = scraper._parse_video_renderer(renderer, config)  # noqa: SLF001
+
+    assert parsed is not None
+    assert parsed.views == 1234
+
+
+def test_parse_video_renderer_reads_simple_text_view_count() -> None:
+    scraper = YouTubeScraper()
+    config = YouTubeScrapeConfig(channel_handle="bravo", keywords=[])
+    renderer = {
+        "videoId": "abc1234",
+        "title": {"runs": [{"text": "Bravo clip"}]},
+        "descriptionSnippet": {"runs": [{"text": "episode"}]},
+        "viewCountText": {"simpleText": "5,678 views"},
+        "publishedTimeText": {"simpleText": "1 day ago"},
+        "ownerText": {"runs": [{"text": "Bravo"}]},
+        "thumbnail": {"thumbnails": [{"url": "https://img.test/thumb.jpg"}]},
+    }
+
+    parsed = scraper._parse_video_renderer(renderer, config)  # noqa: SLF001
+
+    assert parsed is not None
+    assert parsed.views == 5678
+
+
 def test_scrape_progress_reports_non_zero_shorts_initial_pages(monkeypatch) -> None:
     scraper = YouTubeScraper()
     progress_events: list[dict[str, int | str]] = []

--- a/tests/socials/youtube/test_scraper.py
+++ b/tests/socials/youtube/test_scraper.py
@@ -1091,3 +1091,53 @@ def test_fetch_comment_replies_parses_nested_comment_view_model(monkeypatch) -> 
     assert replies[0].comment_id == "reply-1"
     assert replies[0].is_reply is True
     assert replies[0].parent_comment_id == "parent-1"
+
+
+def test_fetch_comment_replies_stops_when_continuation_token_does_not_advance(monkeypatch) -> None:
+    scraper = YouTubeScraper()
+    calls: list[str] = []
+
+    def _fake_fetch_comment_continuation(token: str, *_args, **_kwargs):
+        calls.append(token)
+        return {
+            "onResponseReceivedActions": [
+                {
+                    "appendContinuationItemsAction": {
+                        "continuationItems": [
+                            {
+                                "commentRenderer": {
+                                    "commentId": "reply-1",
+                                    "contentText": {"runs": [{"text": "reply text"}]},
+                                    "authorText": {"simpleText": "Viewer"},
+                                    "authorEndpoint": {"browseEndpoint": {"browseId": "UCV"}},
+                                    "voteCount": {"simpleText": "1"},
+                                    "publishedTimeText": {"runs": [{"text": "1 day ago"}]},
+                                }
+                            },
+                            {
+                                "continuationItemRenderer": {
+                                    "continuationEndpoint": {"continuationCommand": {"token": token}}
+                                }
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(scraper, "_rate_limit", lambda _delay, **_kw: None)
+    monkeypatch.setattr(scraper, "_fetch_comment_continuation", _fake_fetch_comment_continuation)
+
+    replies = scraper._fetch_comment_replies(
+        "reply-token",
+        "abc123",
+        "https://www.youtube.com/watch?v=abc123",
+        "parent-1",
+        delay=0.0,
+    )
+
+    assert calls == ["reply-token"]
+    assert len(replies) == 1
+    assert replies[0].comment_id == "reply-1"
+    assert replies[0].is_reply is True
+    assert replies[0].parent_comment_id == "parent-1"

--- a/trr_backend/socials/socialblade/scraper.py
+++ b/trr_backend/socials/socialblade/scraper.py
@@ -759,9 +759,8 @@ def _socialblade_payload_needs_login_retry(payload: dict[str, Any] | None) -> bo
         chart_points = 0
     history_source = str(payload.get("history_source") or "").strip()
     period = str(metrics.get("period") or "").strip()
-    if (
-        history_source not in _SOCIALBLADE_AUTHENTICATED_HISTORY_SOURCES
-        and re.search(r"\b(?:14|30|31)\s+days\b", period, re.IGNORECASE)
+    if history_source not in _SOCIALBLADE_AUTHENTICATED_HISTORY_SOURCES and re.search(
+        r"\b(?:14|30|31)\s+days\b", period, re.IGNORECASE
     ):
         return True
     if chart_points > row_count:

--- a/trr_backend/socials/socialblade/scraper.py
+++ b/trr_backend/socials/socialblade/scraper.py
@@ -102,6 +102,9 @@ _SOCIALBLADE_RANGE_OPTIONS = (
 _SOCIALBLADE_CHART_INTERVAL_OPTIONS = ("Daily", "Weekly", "Monthly")
 _SOCIALBLADE_CHART_METRIC_OPTIONS = ("Gained", "Total", "Averages")
 _SOCIALBLADE_AUTHENTICATED_HISTORY_LIMIT = 60
+_SOCIALBLADE_AUTHENTICATED_HISTORY_SOURCES = frozenset(
+    {"authenticated_api", "page_trpc_capture", "page_trpc_capture_short"}
+)
 _SOCIALBLADE_DAILY_TOTAL_CHART_LIMIT = 1096
 _PLATFORM_ROUTE_SEGMENTS = {
     "instagram": "user",
@@ -754,8 +757,12 @@ def _socialblade_payload_needs_login_retry(payload: dict[str, Any] | None) -> bo
         chart_points = int(chart.get("total_data_points") or 0) if isinstance(chart, dict) else 0
     except (TypeError, ValueError):
         chart_points = 0
+    history_source = str(payload.get("history_source") or "").strip()
     period = str(metrics.get("period") or "").strip()
-    if re.search(r"\b(?:14|30|31)\s+days\b", period, re.IGNORECASE):
+    if (
+        history_source not in _SOCIALBLADE_AUTHENTICATED_HISTORY_SOURCES
+        and re.search(r"\b(?:14|30|31)\s+days\b", period, re.IGNORECASE)
+    ):
         return True
     if chart_points > row_count:
         return False

--- a/trr_backend/socials/twitter/scraper.py
+++ b/trr_backend/socials/twitter/scraper.py
@@ -1738,9 +1738,9 @@ class TwitterScraper:
 
             # Check date range (end bound is exclusive).
             if tweet.created_at > 0:
-                if tweet.created_at < config.date_start.timestamp():
+                if tweet.created_at < self._window_bound_timestamp(config.date_start):
                     continue
-                if tweet.created_at >= config.date_end.timestamp():
+                if tweet.created_at >= self._window_bound_timestamp(config.date_end):
                     continue
 
             tweets.append(tweet)

--- a/trr_backend/socials/youtube/scraper.py
+++ b/trr_backend/socials/youtube/scraper.py
@@ -4274,8 +4274,19 @@ class YouTubeScraper:
     ) -> list[YouTubeComment]:
         """Fetch replies to a comment."""
         replies = []
+        seen_tokens: set[str] = set()
+        max_reply_pages = 200
+        pages = 0
 
         while continuation_token:
+            if continuation_token in seen_tokens:
+                break
+            seen_tokens.add(continuation_token)
+            pages += 1
+            if pages > max_reply_pages:
+                logger.warning("[youtube_reply_pagination_capped] pages=%s parent_id=%s", pages, parent_id)
+                break
+
             self._rate_limit(delay, fast_mode=fast_mode)
             data = self._fetch_comment_continuation(continuation_token, delay)
             if not data:
@@ -4322,6 +4333,8 @@ class YouTubeScraper:
             except (KeyError, TypeError):
                 break
 
+            if not next_continuation or next_continuation == continuation_token:
+                break
             continuation_token = next_continuation
 
         return replies

--- a/trr_backend/socials/youtube/scraper.py
+++ b/trr_backend/socials/youtube/scraper.py
@@ -120,6 +120,10 @@ class YouTubeScrapeConfig:
                 "YouTubeScrapeConfig fast_mode enabled: delay=%.2fs",
                 self.delay_seconds,
             )
+        if self.date_start is not None and self.date_start.tzinfo is None:
+            self.date_start = self.date_start.replace(tzinfo=UTC)
+        if self.date_end is not None and self.date_end.tzinfo is None:
+            self.date_end = self.date_end.replace(tzinfo=UTC)
 
     @property
     def start_timestamp(self) -> float:

--- a/trr_backend/socials/youtube/scraper.py
+++ b/trr_backend/socials/youtube/scraper.py
@@ -1203,9 +1203,10 @@ class YouTubeScraper:
                 description = "".join(str(r.get("text") or "") for r in desc_runs if isinstance(r, dict))
 
         # Extract view count
-        view_text = renderer.get("viewCountText", {}).get("simpleText", "0")
+        view_count_text = renderer.get("viewCountText", {})
+        view_text = view_count_text.get("simpleText") or ""
         if not view_text:
-            runs = renderer.get("viewCountText", {}).get("runs", [])
+            runs = view_count_text.get("runs", [])
             if isinstance(runs, list):
                 view_text = "".join(str(item.get("text", "")) for item in runs if isinstance(item, dict))
         views = self._parse_view_count(view_text)


### PR DESCRIPTION
## Summary
- terminate repeated YouTube reply pagination safely
- restore run-form view counts and UTC-normalized windows
- preserve Twitter interaction accounting
- retry authenticated SocialBlade history capture

## Advisor provenance
Replaces advisors 039, 043, 044, and 045 from a fresh origin/main base.

## Validation
- 70 focused tests passed
- Ruff and git diff --check passed

No SQL or app changes.