### PR TITLE
Validate dynamic Screenalytics update columns

### DIFF
--- a/tests/repositories/test_screenalytics_runs.py
+++ b/tests/repositories/test_screenalytics_runs.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+from trr_backend.repositories import screenalytics_runs
+
+
+def test_screenalytics_update_run_rejects_non_identifier_column() -> None:
+    with pytest.raises(ValueError, match="Invalid SQL identifier"):
+        screenalytics_runs.update_run("run-1", {"status = 'x'; --": "y"})
+
+
+def test_screenalytics_update_run_accepts_safe_columns(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _execute_returning(sql: str, params: list[object]) -> list[dict[str, object]]:
+        captured.update(sql=sql, params=params)
+        return [{"id": "run-1", "status": "complete"}]
+
+    monkeypatch.setattr(screenalytics_runs.pg, "execute_returning", _execute_returning)
+
+    result = screenalytics_runs.update_run("run-1", {"status": "complete", "result_ingest_error": None})
+
+    assert result == {"id": "run-1", "status": "complete"}
+    assert captured["sql"] == (
+        "UPDATE ml.screentime_runs SET status = %s, result_ingest_error = %s WHERE id = %s RETURNING *"
+    )
+    assert captured["params"] == ["complete", None, "run-1"]

--- a/trr_backend/repositories/screenalytics_runs.py
+++ b/trr_backend/repositories/screenalytics_runs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
@@ -9,6 +10,8 @@ from uuid import UUID
 from psycopg2.extras import Json
 
 from trr_backend.db import pg
+
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 class ScreenalyticsRepositoryError(RuntimeError):
@@ -25,6 +28,14 @@ def _normalize(value: Any) -> Any:
     if isinstance(value, UUID):
         return str(value)
     return value
+
+
+def _validate_update_columns(payload: dict[str, Any]) -> dict[str, Any]:
+    """Reject dynamic update keys that are not safe SQL identifiers."""
+    for column in payload:
+        if not _SQL_IDENTIFIER_RE.fullmatch(column):
+            raise ValueError(f"Invalid SQL identifier: {column}")
+    return payload
 
 
 def create_video_asset(payload: dict[str, Any]) -> dict[str, Any]:
@@ -194,6 +205,7 @@ def mark_result_ingest_status(
 def update_run(run_id: str, payload: dict[str, Any]) -> dict[str, Any] | None:
     if not payload:
         return get_run(run_id)
+    payload = _validate_update_columns(payload)
 
     assignments = []
     params: list[Any] = []


### PR DESCRIPTION
## Summary
- reject unsafe dynamic Screenalytics update identifiers
- keep validation locally owned instead of importing a private helper
- add focused repository coverage

## Validation
- 2 focused tests passed
- Ruff check and format check passed
- git diff --check passed

No SQL, app, or Modal changes.