### PR TITLE
Improve backend CI caching and repository hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "0.9.27"
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements.lock.txt
+            requirements.modal.*.lock.txt
 
       - name: Verify requirements lock freshness
         run: |
@@ -83,6 +87,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "0.9.27"
+          enable-cache: true
+          cache-dependency-glob: requirements.lock.txt
 
       - name: Install dependencies
         run: uv pip sync --system requirements.lock.txt
@@ -108,6 +114,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "0.9.27"
+          enable-cache: true
+          cache-dependency-glob: requirements.lock.txt
 
       - name: Determine changed Python files
         id: changed
@@ -166,6 +174,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "0.9.27"
+          enable-cache: true
+          cache-dependency-glob: requirements.lock.txt
 
       - name: Install dependencies
         run: |
@@ -190,6 +200,11 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "0.9.27"
+          enable-cache: true
+          cache-dependency-glob: |
+            requirements.modal.lean.lock.txt
+            requirements.modal.browser.lock.txt
+            requirements.modal.vision.lock.txt
 
       # Mirrors the base-lockfile freshness check for the three Modal lockfiles.
       # Non-blocking until confirmed reproducible under the pinned uv version.
@@ -229,6 +244,8 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "0.9.27"
+          enable-cache: true
+          cache-dependency-glob: requirements.lock.txt
 
       - name: Install dependencies
         run: uv pip sync --system requirements.lock.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
           version: "0.9.27"
           enable-cache: true
           cache-dependency-glob: requirements.lock.txt
+          ignore-nothing-to-cache: true
 
       - name: Determine changed Python files
         id: changed

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,11 @@ out
 .playwright-mcp
 artifacts/
 
+# Duplicate root wrappers for canonical scripts under scripts/
+/backfill_tmdb_show_details.py
+/resolve_tmdb_ids_via_find.py
+/test_connection.py
+
 # Runtime lock files used to coordinate local/background jobs.
 .locks/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,19 @@
 # TRR-BACKEND INSTRUCTIONS
 
-## Startup
-- Start from this file, ../AGENTS.md, the active user request, and live backend files.
-- Do not read saved notes, wiki pages, sessions, handoffs, patterns, or decisions on boot.
-- Treat old plans and saved notes as stale until revalidated against current repo state, branch, tests, and user intent.
+Inherit `../AGENTS.md`; it is authoritative for shared workspace policy.
 
 ## Scope
 - Backend-only instructions for /Users/thomashulihan/Projects/TRR/TRR-Backend.
-- If routing, ownership, or policy scope is unclear, use ../AGENTS.md as the workspace authority.
 
-## Cross-Repo Work
-- If a change crosses the app boundary, update the current shared contract docs under /Users/thomashulihan/Projects/TRR/docs/ as needed.
-- Coordinate app follow-through in the same session when backend API/schema behavior changes.
+## Cross-Boundary Triggers
+- When API, schema, auth, or shared worker behavior changes, update the current contract under `../docs/` and complete the app follow-through in the same session.
+- Keep backend-first ordering for shared contracts.
 
 ## Non-Negotiable Rules
-- Keep schema, API, auth, and worker-contract changes aligned with ../AGENTS.md.
-- Validate live-runtime assumptions against code, tests, or current runtime state before treating them as fixed.
-
-## Debugging Discipline
-- If the same command or workflow fails twice with the same substantive error, stop retrying blindly. Capture the exact command, full error, relevant stack trace/logs, and recent changes.
-- Inspect local evidence first: source code, config, lockfiles, versions, tests, runtime state, and existing project patterns.
-- If the cause is still unclear, or the failure involves third-party tooling, APIs, packages, browser/runtime behavior, or time-sensitive docs, research current primary sources such as official docs, release notes, and issue trackers. Identify 3-5 plausible causes or fixes before choosing one.
-- Apply the smallest evidence-backed fix one change at a time, then rerun the failing command or workflow to verify. If the best fix is risky or ambiguous, explain the options before editing.
+- Keep schema, API, auth, worker, scraper, and job contracts aligned.
+- Validate live-runtime assumptions against code, tests, or current runtime state.
+- Follow the root Modal completion rule for Modal-affecting changes.
 
 ## Validation
-- Run backend-local validation or tests touched by the change.
-- Re-read ../AGENTS.md when workspace startup, MCP routing, or cross-repo policy is involved.
+- Run the smallest relevant backend checks from the existing `Makefile`, `pytest.ini`, or targeted test modules.
+- When SQL ownership changes, validate the SQL path and report its status as required by `../AGENTS.md`.

--- a/backfill_tmdb_show_details.py
+++ b/backfill_tmdb_show_details.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-from __future__ import annotations
-
-from scripts.backfill.backfill_tmdb_show_details import main
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/resolve_tmdb_ids_via_find.py
+++ b/resolve_tmdb_ids_via_find.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-from __future__ import annotations
-
-from scripts.sync.resolve_tmdb_ids_via_find import main
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/test_connection.py
+++ b/test_connection.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-from __future__ import annotations
-
-from scripts.legacy.test_connection import test_connection
-
-if __name__ == "__main__":
-    test_connection()


### PR DESCRIPTION
## Summary
- enable Python dependency caching in CI
- remove duplicate tracked root wrappers
- align backend AGENTS inheritance and ignore rules
- leave cast/vision dependency manifests and locks to their owning PR

## Validation
- repo-hygiene test and command passed
- CI YAML parsed
- git diff --check passed

No runtime or SQL changes.