### PR TITLE
Split DB lanes and bound Instagram catalog admission

### DIFF
--- a/tests/db/test_connection_resolution.py
+++ b/tests/db/test_connection_resolution.py
@@ -116,7 +116,42 @@ def test_transaction_url_is_first_for_explicit_flight_test(
 
     candidates = connection.resolve_database_url_candidates()
 
-    assert candidates == (transaction_pooler, session_pooler)
+    assert candidates == (
+        transaction_pooler,
+        connection.derive_supavisor_transaction_url(session_pooler),
+    )
+
+
+def test_transaction_lane_derives_url_from_validated_session_pooler(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_db_env: None,
+) -> None:
+    session_pooler = (
+        "postgresql://postgres.session:p%40ss@aws-1-us-east-1.pooler.supabase.com:5432/postgres?sslmode=require"
+    )
+    monkeypatch.setenv("TRR_DB_RUNTIME_LANE", "transaction")
+    monkeypatch.setenv("TRR_DB_TRANSACTION_FLIGHT_TEST", "1")
+    monkeypatch.setenv("TRR_DB_SESSION_URL", session_pooler)
+
+    details = connection.resolve_database_url_candidate_details()
+
+    assert details[0]["url"] == session_pooler.replace(":5432/", ":6543/")
+    assert details[0]["source"] == "TRR_DB_SESSION_URL:derived_transaction"
+    assert details[0]["connection_class"] == "transaction"
+    assert connection.resolve_session_database_url_candidate_details()[0]["url"] == session_pooler
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "postgresql://postgres:secret@example.com:5432/postgres",
+        "postgresql://postgres:secret@aws-1-us-east-1.pooler.supabase.com:6543/postgres",
+        "https://aws-1-us-east-1.pooler.supabase.com:5432/postgres",
+    ),
+)
+def test_transaction_url_derivation_rejects_non_session_supavisor_urls(url: str) -> None:
+    with pytest.raises(ValueError, match="Supavisor session URL"):
+        connection.derive_supavisor_transaction_url(url)
 
 
 def test_derived_direct_never_produced_at_runtime(

--- a/tests/db/test_pg_pool.py
+++ b/tests/db/test_pg_pool.py
@@ -350,6 +350,33 @@ def test_db_read_connection_uses_social_control_pool_sizing(monkeypatch: pytest.
     assert fake_pool.putconn_calls == 1
 
 
+def test_session_control_pool_uses_session_candidates_and_one_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_pool = _FakePool()
+    created: list[tuple[int, int, str]] = []
+    session_dsn = "postgresql://postgres.ref:pw@aws-1-us-east-1.pooler.supabase.com:5432/postgres"
+
+    def _pool_factory(*, minconn, maxconn, **kwargs):
+        created.append((minconn, maxconn, kwargs["dsn"]))
+        return fake_pool
+
+    monkeypatch.setenv("TRR_SESSION_CONTROL_DB_POOL_MINCONN", "5")
+    monkeypatch.setenv("TRR_SESSION_CONTROL_DB_POOL_MAXCONN", "5")
+    monkeypatch.setattr(
+        pg,
+        "resolve_session_database_url_candidate_details",
+        lambda: (_detail(session_dsn),),
+    )
+    monkeypatch.setattr(pg, "ThreadedConnectionPool", _pool_factory)
+
+    with pg.db_read_connection(label="session-control", pool_name="session_control"):
+        pass
+
+    assert created == [(1, 1, session_dsn)]
+    assert pg.current_pool_dsn(pool_name="session_control") == session_dsn
+
+
 def test_db_read_connection_discards_closed_connection_on_return(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -386,6 +413,24 @@ def test_advisory_session_lock_uses_one_connection_for_lock_and_unlock(
         "select pg_try_advisory_lock(%s) as locked",
         "select pg_advisory_unlock(%s)",
     ]
+
+
+def test_advisory_session_lock_redirects_legacy_pool_to_session_control(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_pool = _FakeThreadedPool()
+    selected_pools: list[str] = []
+
+    def _get_pool(*, pool_name: str = "default"):
+        selected_pools.append(pool_name)
+        return fake_pool
+
+    monkeypatch.setattr(pg, "_get_pool", _get_pool)
+
+    with pg.advisory_session_lock(lock_key=123, label="test", pool_name="social_control"):
+        pass
+
+    assert selected_pools == ["session_control"]
 
 
 def test_advisory_session_lock_raises_when_lock_unavailable(
@@ -539,6 +584,8 @@ def test_is_database_service_unavailable_error_detects_pool_exhaustion_and_init_
         is True
     )
     assert pg.is_database_service_unavailable_error(RuntimeError("Database pool initialization failed: boom")) is True
+    assert pg.is_database_service_unavailable_error(RuntimeError("FATAL: EMAXCONNSESSION")) is True
+    assert pg.is_database_service_unavailable_error(RuntimeError("FATAL: MaxClientsInSessionMode")) is True
     assert pg.is_database_service_unavailable_error(RuntimeError("other failure")) is False
 
 
@@ -713,8 +760,8 @@ def test_resolve_pool_sizing_clamps_modal_session_pooler_overrides_without_pytes
 
     assert sizing["requested_minconn"] == 4
     assert sizing["requested_maxconn"] == 16
-    assert sizing["minconn"] == 2
-    assert sizing["maxconn"] == 2
+    assert sizing["minconn"] == 1
+    assert sizing["maxconn"] == 1
     assert sizing["session_pooler_override_clamped"] is False
     assert sizing["modal_session_pooler_override_clamped"] is True
     assert sizing["maxconn_source"] == "clamped:modal_session_pooler_ceiling"
@@ -808,8 +855,8 @@ def test_resolve_pool_sizing_clamps_modal_session_pooler_overrides(monkeypatch: 
 
     assert sizing["requested_minconn"] == 4
     assert sizing["requested_maxconn"] == 16
-    assert sizing["minconn"] == 2
-    assert sizing["maxconn"] == 2
+    assert sizing["minconn"] == 1
+    assert sizing["maxconn"] == 1
     assert sizing["modal_session_pooler_override_clamped"] is True
     assert sizing["minconn_source"] == "clamped:modal_session_pooler_ceiling"
     assert sizing["maxconn_source"] == "clamped:modal_session_pooler_ceiling"
@@ -830,7 +877,7 @@ def test_resolve_pool_sizing_keeps_local_clamp_outside_modal(monkeypatch: pytest
     assert sizing["session_pooler_override_clamped"] is True
 
 
-def test_fetch_one_retries_once_on_ssl_connection_closed_fault(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_one_retries_ssl_fault_without_resetting_shared_pool(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {"fetch": 0, "reset": 0}
 
     @contextmanager
@@ -855,7 +902,7 @@ def test_fetch_one_retries_once_on_ssl_connection_closed_fault(monkeypatch: pyte
 
     assert result == {"ok": True}
     assert calls["fetch"] == 2
-    assert calls["reset"] == 1
+    assert calls["reset"] == 0
 
 
 def test_get_connection_with_retry_reraises_last_pool_error_after_retries_exhausted(
@@ -876,7 +923,7 @@ def test_get_connection_with_retry_reraises_last_pool_error_after_retries_exhaus
         pg._get_connection_with_retry(label="fetch_one")
 
 
-def test_fetch_all_retries_once_on_closed_cursor_fault(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_all_retries_closed_cursor_without_resetting_shared_pool(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {"fetch": 0, "reset": 0}
 
     @contextmanager
@@ -901,10 +948,10 @@ def test_fetch_all_retries_once_on_closed_cursor_fault(monkeypatch: pytest.Monke
 
     assert result == [{"ok": True}]
     assert calls["fetch"] == 2
-    assert calls["reset"] == 1
+    assert calls["reset"] == 0
 
 
-def test_fetch_one_retries_once_on_closed_pool_fault(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_one_retries_closed_pool_fault_without_global_reset(monkeypatch: pytest.MonkeyPatch) -> None:
     calls = {"fetch": 0, "reset": 0}
 
     @contextmanager
@@ -929,7 +976,7 @@ def test_fetch_one_retries_once_on_closed_pool_fault(monkeypatch: pytest.MonkeyP
 
     assert result == {"ok": True}
     assert calls["fetch"] == 2
-    assert calls["reset"] == 1
+    assert calls["reset"] == 0
 
 
 def test_db_connection_does_not_mask_errors_when_pool_closes_during_putconn(
@@ -951,7 +998,10 @@ def test_db_connection_does_not_mask_errors_when_pool_closes_during_putconn(
     assert fake_pool.putconn_calls == 1
 
 
-def test_db_connection_retries_pool_acquire_on_pool_exhaustion(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_db_connection_retries_pool_acquire_without_warning_spam(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     fake_pool = _FakePoolExhaustThenSuccess(failures_before_success=2)
     monkeypatch.setattr(
         pg,
@@ -967,6 +1017,7 @@ def test_db_connection_retries_pool_acquire_on_pool_exhaustion(monkeypatch: pyte
 
     assert fake_pool.getconn_calls == 3
     assert fake_pool.putconn_calls == 1
+    assert "acquire_failed" not in caplog.text
 
 
 def test_reset_pool_rotates_active_pool_without_closing_checked_out_connections(
@@ -1173,6 +1224,11 @@ def test_local_pool_pressure_summary_does_not_expose_pool_details(monkeypatch: p
         "resolve_database_url_candidate_details",
         lambda: (_detail("postgresql://db.example.com/postgres"),),
     )
+    monkeypatch.setattr(
+        pg,
+        "resolve_session_database_url_candidate_details",
+        lambda: (_detail("postgresql://db.example.com/postgres"),),
+    )
 
     summary = pg.local_pool_pressure_summary()
 
@@ -1189,6 +1245,11 @@ def test_local_pool_pressure_snapshot_reports_named_application_names(monkeypatc
         "resolve_database_url_candidate_details",
         lambda: (_detail("postgresql://db.example.com/postgres"),),
     )
+    monkeypatch.setattr(
+        pg,
+        "resolve_session_database_url_candidate_details",
+        lambda: (_detail("postgresql://db.example.com/postgres"),),
+    )
 
     snapshot = pg.local_pool_pressure_snapshot()
 
@@ -1197,6 +1258,7 @@ def test_local_pool_pressure_snapshot_reports_named_application_names(monkeypatc
     assert application_names["social_profile"] == "trr-backend:social_profile"
     assert application_names["social_control"] == "trr-backend:social_control"
     assert application_names["health"] == "trr-backend:health"
+    assert application_names["session_control"] == "trr-backend:session_control"
 
 
 def test_build_pool_for_non_session_urls_keeps_default_pool_size(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/db/test_pg_pool.py
+++ b/tests/db/test_pg_pool.py
@@ -1218,6 +1218,36 @@ def test_resolve_application_name_rejects_secret_like_values(monkeypatch: pytest
     assert resolved["application_name_source"] == "default:pool"
 
 
+def test_fresh_session_capacity_probe_honors_configured_limit_above_ten(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ProbeConnection(_FakeConnection):
+        def close(self) -> None:
+            self.closed = True
+
+    connections: list[_ProbeConnection] = []
+
+    def _connect(**_kwargs: object) -> _ProbeConnection:
+        connection = _ProbeConnection()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(
+        pg,
+        "resolve_session_database_url_candidate_details",
+        lambda: (_detail("postgresql://db.example.com/postgres"),),
+    )
+    monkeypatch.setattr(pg.psycopg2, "connect", _connect)
+
+    result = pg.probe_fresh_session_capacity(requested_sessions=15, max_probe_sessions=15)
+
+    assert result["available"] is True
+    assert result["requested_sessions"] == 15
+    assert result["reserved_sessions"] == 15
+    assert len(connections) == 15
+    assert all(connection.closed for connection in connections)
+
+
 def test_local_pool_pressure_summary_does_not_expose_pool_details(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         pg,

--- a/tests/db/test_pg_timeout_settings.py
+++ b/tests/db/test_pg_timeout_settings.py
@@ -114,3 +114,8 @@ class TestStatementTimeoutDetection:
         """A statement timeout error must NOT be classified as a transient transport error."""
         err = Exception("canceling statement due to statement timeout")
         assert _is_transient_transport_error(err) is False
+
+    def test_psycopg_connect_timeout_is_transient(self) -> None:
+        """A direct-endpoint timeout can fall through to the next configured candidate."""
+        err = Exception("connection to server at db.example.test, port 5432 failed: timeout expired")
+        assert _is_transient_transport_error(err) is True

--- a/tests/repositories/test_social_control_plane_budget.py
+++ b/tests/repositories/test_social_control_plane_budget.py
@@ -108,6 +108,36 @@ def test_instagram_db_session_worker_budget_uses_canonical_env_with_legacy_fallb
     assert budget.instagram_db_session_worker_budget() == 10
 
 
+def test_instagram_db_session_pool_usage_probes_up_to_configured_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.db import pg
+
+    captured: dict[str, int] = {}
+
+    def _probe(*, requested_sessions: int, max_probe_sessions: int) -> dict[str, object]:
+        captured["requested_sessions"] = requested_sessions
+        captured["max_probe_sessions"] = max_probe_sessions
+        return {
+            "available": True,
+            "reason": "fresh_session_reservation_succeeded",
+            "requested_sessions": requested_sessions,
+            "reserved_sessions": requested_sessions,
+            "target": {},
+            "error": None,
+        }
+
+    monkeypatch.setenv(budget.INSTAGRAM_DB_SESSION_POOL_LIMIT_ENV, "15")
+    monkeypatch.setattr(pg, "probe_fresh_session_capacity", _probe)
+
+    usage = budget._instagram_db_session_pool_usage(requested_sessions=15)
+
+    assert captured == {"requested_sessions": 15, "max_probe_sessions": 15}
+    assert usage["available"] is True
+    assert usage["requested_sessions"] == 15
+    assert usage["reserved_sessions"] == 15
+
+
 def test_instagram_db_session_capacity_counts_active_and_dispatched_workers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/repositories/test_social_control_plane_budget.py
+++ b/tests/repositories/test_social_control_plane_budget.py
@@ -97,6 +97,86 @@ def test_default_budget_decision_is_normal_without_live_reads() -> None:
     }
 
 
+def test_instagram_db_session_worker_budget_uses_canonical_env_with_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(budget.INSTAGRAM_DB_SESSION_WORKER_BUDGET_ENV, raising=False)
+    monkeypatch.setenv(budget.LEGACY_INSTAGRAM_COMMENTS_DB_SESSION_BUDGET_ENV, "7")
+    assert budget.instagram_db_session_worker_budget() == 7
+
+    monkeypatch.setenv(budget.INSTAGRAM_DB_SESSION_WORKER_BUDGET_ENV, "10")
+    assert budget.instagram_db_session_worker_budget() == 10
+
+
+def test_instagram_db_session_capacity_counts_active_and_dispatched_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend import modal_dispatch
+    from trr_backend.db import pg
+
+    captured: dict[str, object] = {}
+    lock_conn = object()
+
+    def _fetch_all(sql: str, params=None, *, conn=None, pool_name: str = "default"):
+        captured["sql"] = sql
+        captured["conn"] = conn
+        captured["pool_name"] = pool_name
+        return [
+            *[
+                {
+                    "job_id": f"active-{index}",
+                    "status": "running",
+                    "worker_id": f"worker-{index}",
+                    "claimed_at": "now",
+                    "remote_invocation_id": None,
+                }
+                for index in range(4)
+            ],
+            *[
+                {
+                    "job_id": f"dispatched-{index}",
+                    "status": "queued",
+                    "worker_id": None,
+                    "claimed_at": None,
+                    "remote_invocation_id": f"call-{index}",
+                }
+                for index in range(4)
+            ],
+        ]
+
+    monkeypatch.setenv(budget.INSTAGRAM_DB_SESSION_WORKER_BUDGET_ENV, "10")
+    monkeypatch.setattr(pg, "fetch_all", _fetch_all)
+    monkeypatch.setattr(modal_dispatch, "inspect_modal_function_call", lambda _call_id: {"status": "running"})
+    monkeypatch.setattr(
+        budget,
+        "_instagram_db_session_pool_usage",
+        lambda **_kwargs: {
+            "available": True,
+            "limit": 15,
+            "reserved_sessions": 3,
+            "probe_reason": "fresh_session_reservation_succeeded",
+            "read_error": None,
+        },
+    )
+
+    capacity = budget.get_instagram_db_session_capacity(requested_workers=3, conn=lock_conn)
+
+    assert capacity["worker_budget"] == 10
+    assert capacity["active_db_jobs"] == 4
+    assert capacity["dispatched_unclaimed_jobs"] == 4
+    assert capacity["active_workers"] == 8
+    assert capacity["remaining_workers"] == 2
+    assert capacity["requested_workers"] == 3
+    assert capacity["blocked"] is True
+    assert capacity["available"] is True
+    assert capacity["read_error"] is None
+    assert captured["conn"] is lock_conn
+    assert captured["pool_name"] == "social_control"
+    assert "remote_invocation_id" in str(captured["sql"])
+    assert "shared_account_posts" in str(captured["sql"])
+    assert "comments_scrapling" in str(captured["sql"])
+
+
 def test_runbook_live_apply_cap_clamps_overrides_to_two_workers() -> None:
     decision = budget.build_budget_decision(
         lane=LANE,

--- a/tests/repositories/test_social_control_plane_budget.py
+++ b/tests/repositories/test_social_control_plane_budget.py
@@ -272,9 +272,7 @@ def test_account_lane_pause_precedes_global_budget_pressure() -> None:
         backfill_health=_health(queue={"queue_enabled": True, "queue_depth": 500}),
         queue_status=_queue(by_status={"queued": 500, "running": 10}),
         benchmark_overrides={
-            "account_lane_pauses": [
-                {"lane": LANE, "account": ACCOUNT, "paused": True, "reason": "operator_hold"}
-            ]
+            "account_lane_pauses": [{"lane": LANE, "account": ACCOUNT, "paused": True, "reason": "operator_hold"}]
         },
         include_live=False,
         now=NOW,

--- a/tests/test_modal_jobs.py
+++ b/tests/test_modal_jobs.py
@@ -321,10 +321,7 @@ def test_inject_modal_runtime_defaults_keeps_safety_clamps_pinned(
 
 
 def test_operator_tunable_runtime_default_keys_exist_in_canonical_defaults() -> None:
-    assert (
-        modal_jobs._OPERATOR_TUNABLE_RUNTIME_DEFAULT_KEYS
-        <= modal_jobs._CANONICAL_MODAL_RUNTIME_DEFAULTS.keys()
-    )
+    assert modal_jobs._OPERATOR_TUNABLE_RUNTIME_DEFAULT_KEYS <= modal_jobs._CANONICAL_MODAL_RUNTIME_DEFAULTS.keys()
 
 
 def test_inject_modal_runtime_defaults_clears_object_storage_profile_when_static_creds_present(

--- a/tests/test_modal_jobs.py
+++ b/tests/test_modal_jobs.py
@@ -290,6 +290,43 @@ def test_inject_modal_runtime_defaults_overrides_explicit_env(
     assert os.environ["TRR_DB_POOL_MAXCONN"] == "2"
 
 
+def test_inject_modal_runtime_defaults_preserves_operator_tunable_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_PROXY_PROVIDER", "none")
+
+    modal_jobs._inject_modal_runtime_defaults()
+
+    assert os.environ["SOCIAL_INSTAGRAM_COMMENTS_PROXY_PROVIDER"] == "none"
+
+
+def test_inject_modal_runtime_defaults_applies_operator_tunable_default_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("SOCIALBLADE_PROXY_PROVIDER", raising=False)
+
+    modal_jobs._inject_modal_runtime_defaults()
+
+    assert os.environ["SOCIALBLADE_PROXY_PROVIDER"] == "decodo"
+
+
+def test_inject_modal_runtime_defaults_keeps_safety_clamps_pinned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TRR_MODAL_SOCIAL_COMMENTS_JOB_CONCURRENCY_LIMIT", "999")
+
+    modal_jobs._inject_modal_runtime_defaults()
+
+    assert os.environ["TRR_MODAL_SOCIAL_COMMENTS_JOB_CONCURRENCY_LIMIT"] == "4"
+
+
+def test_operator_tunable_runtime_default_keys_exist_in_canonical_defaults() -> None:
+    assert (
+        modal_jobs._OPERATOR_TUNABLE_RUNTIME_DEFAULT_KEYS
+        <= modal_jobs._CANONICAL_MODAL_RUNTIME_DEFAULTS.keys()
+    )
+
+
 def test_inject_modal_runtime_defaults_clears_object_storage_profile_when_static_creds_present(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/trr_backend/db/connection.py
+++ b/trr_backend/db/connection.py
@@ -12,7 +12,7 @@ import os
 import subprocess
 import sys
 from functools import lru_cache
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +102,25 @@ def classify_connection_class(url: str) -> str:
     return "other"
 
 
+def derive_supavisor_transaction_url(session_url: str) -> str:
+    """Derive the matching Supavisor transaction-pool URL from a session URL."""
+    parsed = urlsplit(str(session_url or "").strip())
+    try:
+        port = parsed.port
+    except ValueError as error:
+        raise ValueError("Supavisor session URL must include a valid port") from error
+    if (
+        parsed.scheme not in {"postgres", "postgresql"}
+        or not (parsed.hostname or "").strip().lower().endswith("pooler.supabase.com")
+        or port != 5432
+    ):
+        raise ValueError("Supavisor session URL must use pooler.supabase.com:5432")
+    host_and_auth, separator, _port = parsed.netloc.rpartition(":")
+    if not separator or not host_and_auth:
+        raise ValueError("Supavisor session URL must include port 5432")
+    return urlunsplit(parsed._replace(netloc=f"{host_and_auth}:6543"))
+
+
 def _env_truthy(name: str) -> bool:
     return (os.getenv(name) or "").strip().lower() in {"1", "true", "yes", "on"}
 
@@ -133,13 +152,9 @@ def resolve_database_url_candidate_details() -> tuple[dict[str, str | int | None
     """
     Resolve candidate database URLs in priority order.
 
-    Priority order:
-    1. TRR_DB_DIRECT_URL
-    2. TRR_DB_TRANSACTION_URL only when TRR_DB_RUNTIME_LANE=transaction and
-       TRR_DB_TRANSACTION_FLIGHT_TEST=1
-    3. TRR_DB_SESSION_URL
-    4. TRR_DB_URL
-    5. TRR_DB_FALLBACK_URL (optional operator-provided fallback)
+    Local/direct resolution is unchanged. In the explicit transaction runtime
+    lane, only transaction-class candidates are returned; a missing explicit
+    transaction URL is derived from a validated Supavisor session URL.
     """
 
     def _append_candidate(
@@ -159,12 +174,58 @@ def resolve_database_url_candidate_details() -> tuple[dict[str, str | int | None
     seen: set[str] = set()
 
     _append_candidate(candidates, seen, os.getenv(DIRECT_DB_ENV), source=DIRECT_DB_ENV)
-    if resolve_runtime_connection_lane() == "transaction" and transaction_flight_test_enabled():
-        _append_candidate(candidates, seen, os.getenv(TRANSACTION_DB_ENV), source=TRANSACTION_DB_ENV)
-    _append_candidate(candidates, seen, os.getenv(SESSION_DB_ENV), source=SESSION_DB_ENV)
-    _append_candidate(candidates, seen, os.getenv(CANONICAL_DB_ENV), source=CANONICAL_DB_ENV)
-    _append_candidate(candidates, seen, os.getenv(FALLBACK_DB_ENV), source=FALLBACK_DB_ENV)
+    transaction_lane = resolve_runtime_connection_lane() == "transaction" and transaction_flight_test_enabled()
+    if transaction_lane:
+        explicit_transaction_url = (os.getenv(TRANSACTION_DB_ENV) or "").strip()
+        if explicit_transaction_url:
+            _append_candidate(
+                candidates,
+                seen,
+                explicit_transaction_url,
+                source=TRANSACTION_DB_ENV,
+            )
+        for env_name in (SESSION_DB_ENV, CANONICAL_DB_ENV, FALLBACK_DB_ENV):
+            source_url = (os.getenv(env_name) or "").strip()
+            if not source_url:
+                continue
+            if classify_connection_class(source_url) == "transaction":
+                _append_candidate(candidates, seen, source_url, source=env_name)
+                continue
+            if classify_connection_class(source_url) != "session":
+                continue
+            _append_candidate(
+                candidates,
+                seen,
+                derive_supavisor_transaction_url(source_url),
+                source=f"{env_name}:derived_transaction",
+            )
+    else:
+        _append_candidate(candidates, seen, os.getenv(SESSION_DB_ENV), source=SESSION_DB_ENV)
+        _append_candidate(candidates, seen, os.getenv(CANONICAL_DB_ENV), source=CANONICAL_DB_ENV)
+        _append_candidate(candidates, seen, os.getenv(FALLBACK_DB_ENV), source=FALLBACK_DB_ENV)
 
+    return tuple(candidates)
+
+
+def resolve_session_database_url_candidate_details() -> tuple[dict[str, str | int | None], ...]:
+    """Resolve candidates suitable for session-scoped locks and pacing."""
+    candidates: list[dict[str, str | int | None]] = []
+    seen: set[str] = set()
+
+    def _append(value: str | None, *, source: str, allow_direct: bool = False) -> None:
+        url = str(value or "").strip()
+        if not url or url in seen:
+            return
+        connection_class = classify_connection_class(url)
+        if connection_class != "session" and not (allow_direct and connection_class in {"direct", "local"}):
+            return
+        candidates.append({"url": url, **describe_database_url_target(url, source=source)})
+        seen.add(url)
+
+    _append(os.getenv(DIRECT_DB_ENV), source=DIRECT_DB_ENV, allow_direct=True)
+    _append(os.getenv(SESSION_DB_ENV), source=SESSION_DB_ENV)
+    _append(os.getenv(CANONICAL_DB_ENV), source=CANONICAL_DB_ENV)
+    _append(os.getenv(FALLBACK_DB_ENV), source=FALLBACK_DB_ENV)
     return tuple(candidates)
 
 
@@ -192,10 +253,10 @@ def log_database_resolution_summary() -> None:
     )
     winner_source = str(winner["source"])
     winner_connection_class = str(winner["connection_class"])
-    if winner_connection_class in {"direct", "transaction"}:
+    if winner_connection_class == "direct":
         logger.warning(
             "[db-resolution] non_default_connection_class connection_class=%s "
-            "source=%s; default runtime lane is session via pooler.supabase.com:5432",
+            "source=%s; direct connections are reserved for local development",
             winner_connection_class,
             winner_source,
         )
@@ -218,12 +279,9 @@ def resolve_database_url() -> str:
     """
     Resolve the database URL using a prioritized lookup.
 
-    Priority order:
-    1. TRR_DB_DIRECT_URL - explicit local direct database lane
-    2. TRR_DB_TRANSACTION_URL - only during an explicit transaction-mode flight test
-    3. TRR_DB_SESSION_URL - preferred explicit session-mode URL
-    4. TRR_DB_URL - compatibility/canonical runtime database URL
-    5. TRR_DB_FALLBACK_URL - Optional operator-provided fallback
+    Local uses the explicit direct lane. Deployed transaction mode uses an
+    explicit or safely derived transaction-pool URL. Session-mode resolution
+    remains available for compatibility and dedicated session-control pools.
 
     Returns:
         Database connection URL string.
@@ -240,14 +298,15 @@ def resolve_database_url() -> str:
         "For remote/production:\n"
         "  Set TRR_DB_SESSION_URL or TRR_DB_URL to your Supabase session-pooler connection string.\n"
         "  Optionally set TRR_DB_FALLBACK_URL for controlled failover.\n"
-        "  Transaction-mode flight tests require TRR_DB_TRANSACTION_URL, "
-        "TRR_DB_RUNTIME_LANE=transaction, and TRR_DB_TRANSACTION_FLIGHT_TEST=1.\n"
+        "  Transaction runtime requires TRR_DB_RUNTIME_LANE=transaction and "
+        "TRR_DB_TRANSACTION_FLIGHT_TEST=1. Set TRR_DB_TRANSACTION_URL or provide "
+        "a valid Supavisor session URL that can be safely derived.\n"
         "  Example: postgresql://postgres.<project>:<password>@<host>:5432/postgres\n\n"
         "For local development:\n"
         "  Set TRR_DB_DIRECT_URL to your direct Postgres connection string.\n\n"
         "Available environment variables (checked in order):\n"
         "  - TRR_DB_DIRECT_URL (explicit local direct DB lane)\n"
-        "  - TRR_DB_TRANSACTION_URL (explicit flight-test env only)\n"
+        "  - TRR_DB_TRANSACTION_URL (optional explicit transaction runtime URL)\n"
         "  - TRR_DB_SESSION_URL (preferred session runtime env)\n"
         "  - TRR_DB_URL (compatibility/canonical runtime env)\n"
         "  - TRR_DB_FALLBACK_URL (optional runtime fallback)\n"

--- a/trr_backend/db/pg.py
+++ b/trr_backend/db/pg.py
@@ -294,10 +294,14 @@ def database_service_unavailable_detail(error: Exception) -> dict[str, Any]:
     }
 
 
-def probe_fresh_session_capacity(*, requested_sessions: int = 1) -> dict[str, Any]:
+def probe_fresh_session_capacity(
+    *,
+    requested_sessions: int = 1,
+    max_probe_sessions: int = 10,
+) -> dict[str, Any]:
     """Reserve fresh Supavisor session slots briefly without initializing a named pool."""
 
-    safe_requested = max(0, min(int(requested_sessions), 10))
+    safe_requested = max(0, min(int(requested_sessions), max(0, int(max_probe_sessions))))
     candidates = resolve_session_database_url_candidate_details()
     candidate = candidates[0] if candidates else {}
     target = {

--- a/trr_backend/db/pg.py
+++ b/trr_backend/db/pg.py
@@ -11,6 +11,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlparse
 
+import psycopg2
 from psycopg2.extensions import (
     TRANSACTION_STATUS_ACTIVE,
     TRANSACTION_STATUS_IDLE,
@@ -23,6 +24,7 @@ from psycopg2.pool import PoolError, ThreadedConnectionPool
 
 from trr_backend.db.connection import (
     resolve_database_url_candidate_details,
+    resolve_session_database_url_candidate_details,
 )
 from trr_backend.observability import (
     record_postgres_pool_acquire_duration,
@@ -39,7 +41,7 @@ DEFAULT_POOL_MAXCONN = 24
 DEFAULT_SESSION_POOLER_MINCONN = 1
 DEFAULT_SESSION_POOLER_MAXCONN = 2
 DEFAULT_MODAL_SESSION_POOLER_MINCONN = 1
-DEFAULT_MODAL_SESSION_POOLER_MAXCONN = 2
+DEFAULT_MODAL_SESSION_POOLER_MAXCONN = 1
 DEFAULT_MODAL_NAMED_SESSION_POOLER_MAXCONN = 1
 LOCAL_SESSION_POOLER_MAX_CEILING = 8
 DEFAULT_POOL_ACQUIRE_ATTEMPTS = 8
@@ -95,6 +97,8 @@ def _pool_size_env_names(pool_name: str) -> tuple[str, str]:
         return "TRR_SOCIAL_PROFILE_DB_POOL_MINCONN", "TRR_SOCIAL_PROFILE_DB_POOL_MAXCONN"
     if pool_name == "social_control":
         return "TRR_SOCIAL_CONTROL_DB_POOL_MINCONN", "TRR_SOCIAL_CONTROL_DB_POOL_MAXCONN"
+    if pool_name == "session_control":
+        return "TRR_SESSION_CONTROL_DB_POOL_MINCONN", "TRR_SESSION_CONTROL_DB_POOL_MAXCONN"
     if pool_name == "social_progress":
         return "TRR_SOCIAL_PROGRESS_DB_POOL_MINCONN", "TRR_SOCIAL_PROGRESS_DB_POOL_MAXCONN"
     if pool_name == "health":
@@ -103,7 +107,13 @@ def _pool_size_env_names(pool_name: str) -> tuple[str, str]:
 
 
 def _known_pool_names() -> tuple[str, ...]:
-    return ("default", "social_profile", "social_control", "social_progress", "health")
+    return ("default", "social_profile", "social_control", "social_progress", "health", "session_control")
+
+
+def _database_candidates_for_pool(pool_name: str) -> tuple[dict[str, str | int | None], ...]:
+    if pool_name == "session_control":
+        return resolve_session_database_url_candidate_details()
+    return resolve_database_url_candidate_details()
 
 
 def _session_pooler_warning_maxconn(pool_name: str) -> int:
@@ -242,9 +252,11 @@ def is_database_service_unavailable_error(error: Exception) -> bool:
     if isinstance(error, DatabaseServiceUnavailableError):
         return True
     message = _error_message(error)
+    reason = _database_service_unavailable_reason(message)
     return (
         _is_pool_exhausted_error(error)
         or _is_statement_timeout_error(error)
+        or reason in {"session_pool_capacity", "pool_capacity", "pool_initialization"}
         or "database pool initialization failed" in message
     )
 
@@ -282,6 +294,85 @@ def database_service_unavailable_detail(error: Exception) -> dict[str, Any]:
     }
 
 
+def probe_fresh_session_capacity(*, requested_sessions: int = 1) -> dict[str, Any]:
+    """Reserve fresh Supavisor session slots briefly without initializing a named pool."""
+
+    safe_requested = max(0, min(int(requested_sessions), 10))
+    candidates = resolve_session_database_url_candidate_details()
+    candidate = candidates[0] if candidates else {}
+    target = {
+        "source": candidate.get("source"),
+        "host_class": candidate.get("host_class"),
+        "connection_class": candidate.get("connection_class"),
+        "port": candidate.get("port"),
+    }
+    if safe_requested == 0:
+        return {
+            "available": True,
+            "blocked": False,
+            "reason": "no_session_slots_requested",
+            "requested_sessions": 0,
+            "reserved_sessions": 0,
+            "target": target,
+            "error": None,
+        }
+    url = str(candidate.get("url") or "").strip()
+    if not url:
+        return {
+            "available": False,
+            "blocked": True,
+            "reason": "database_configuration",
+            "requested_sessions": safe_requested,
+            "reserved_sessions": 0,
+            "target": target,
+            "error": "session_database_url_missing",
+        }
+
+    connections: list[Any] = []
+    try:
+        for _index in range(safe_requested):
+            connect_kwargs: dict[str, Any] = {
+                "dsn": url,
+                "application_name": "trr-backend:session-capacity-probe",
+                "connect_timeout": min(5, DEFAULT_CONNECT_TIMEOUT_SECONDS),
+            }
+            sslmode = _sslmode_for_url(url)
+            if sslmode:
+                connect_kwargs["sslmode"] = sslmode
+            conn = psycopg2.connect(**connect_kwargs)
+            connections.append(conn)
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute("select 1")
+                cur.fetchone()
+        return {
+            "available": True,
+            "blocked": False,
+            "reason": "fresh_session_reservation_succeeded",
+            "requested_sessions": safe_requested,
+            "reserved_sessions": len(connections),
+            "target": target,
+            "error": None,
+        }
+    except Exception as exc:  # noqa: BLE001 - normalized below without leaking the DSN
+        reason = _database_service_unavailable_reason(_error_message(exc))
+        return {
+            "available": False,
+            "blocked": True,
+            "reason": reason,
+            "requested_sessions": safe_requested,
+            "reserved_sessions": len(connections),
+            "target": target,
+            "error": type(exc).__name__,
+        }
+    finally:
+        for conn in connections:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                logger.debug("fresh session capacity probe close failed", exc_info=True)
+
+
 def _is_transient_transport_error(error: Exception) -> bool:
     message = _error_message(error)
     if not message:
@@ -301,6 +392,7 @@ def _is_transient_transport_error(error: Exception) -> bool:
         "connection reset by peer",
         "connection refused",
         "connection timed out",
+        "timeout expired",
         "could not receive data from server",
         "emaxconnsession",
         "maxclientsinsessionmode",
@@ -349,6 +441,11 @@ def _resolve_pool_sizing(
     modal_runtime = _is_modal_container_runtime()
     local_or_dev_runtime = _is_local_or_dev_runtime()
     modal_session_pooler_maxconn = _modal_session_pooler_maxconn(pool_name)
+    if pool_name == "session_control":
+        minconn = 1
+        maxconn = 1
+        minconn_source = "fixed:session_control"
+        maxconn_source = "fixed:session_control"
     if session_pooler and modal_runtime and not trr_local_dev and maxconn > modal_session_pooler_maxconn:
         maxconn = modal_session_pooler_maxconn
         maxconn_source = "clamped:modal_session_pooler_ceiling"
@@ -486,7 +583,7 @@ def _pool_counts(pool: ThreadedConnectionPool | None) -> tuple[int | None, int |
 
 def _configured_pool_snapshot(pool_name: str) -> dict[str, Any]:
     minconn_env_name, maxconn_env_name = _pool_size_env_names(pool_name)
-    candidate_details = resolve_database_url_candidate_details()
+    candidate_details = _database_candidates_for_pool(pool_name)
     candidate_detail = candidate_details[0] if candidate_details else None
     if candidate_detail is None:
         return {
@@ -628,7 +725,7 @@ def _log_checkout(
         }
     in_use, available = _pool_counts(pool)
     acquire_duration_seconds = max(0.0, time.perf_counter() - acquire_started_at)
-    logger.info(
+    logger.debug(
         "[db-pool] checkout id=%s label=%s acquire_ms=%.1f backend_pid=%s tx_status=%s in_use=%s available=%s",
         checkout_id,
         label,
@@ -657,7 +754,7 @@ def _log_return(
             started_at = metadata.get("started_at")
     held_ms = (time.perf_counter() - started_at) * 1000.0 if started_at is not None else None
     in_use, available = _pool_counts(pool)
-    logger.info(
+    logger.debug(
         "[db-pool] return id=%s label=%s held_ms=%s backend_pid=%s tx_status=%s in_use=%s available=%s",
         checkout_id,
         label,
@@ -770,7 +867,7 @@ def _get_pool(*, pool_name: str = "default") -> ThreadedConnectionPool:
             return active_pool
 
         init_errors: list[Exception] = []
-        candidate_details = resolve_database_url_candidate_details()
+        candidate_details = _database_candidates_for_pool(pool_name)
         for index, candidate_detail in enumerate(candidate_details):
             candidate = str(candidate_detail["url"])
             minconn_env_name, maxconn_env_name = _pool_size_env_names(pool_name)
@@ -1001,7 +1098,6 @@ def _run_with_transient_retry(operation: Callable[[], T]) -> T:
             last_error = error
             if not _should_retry_query(error, attempt=attempt):
                 raise
-            reset_pool()
     if last_error is not None:
         raise last_error
     raise RuntimeError("unreachable")
@@ -1020,7 +1116,7 @@ def _get_connection_with_retry(
         pool = _get_pool(pool_name=pool_name)
         for acquire_attempt in range(acquire_attempts):
             acquire_started_at = time.perf_counter()
-            logger.info(
+            logger.debug(
                 "[db-pool] acquire_start label=%s attempt=%s acquire_attempt=%s in_use=%s available=%s",
                 label,
                 attempt,
@@ -1044,7 +1140,9 @@ def _get_connection_with_retry(
                 return pool, conn, checkout_id
             except Exception as error:
                 last_error = error
-                logger.warning(
+                pool_exhausted = _is_pool_exhausted_error(error)
+                will_retry_pool_acquire = pool_exhausted and acquire_attempt < (acquire_attempts - 1)
+                (logger.debug if will_retry_pool_acquire else logger.warning)(
                     "[db-pool] acquire_failed label=%s attempt=%s acquire_attempt=%s error=%s in_use=%s available=%s",
                     label,
                     attempt,
@@ -1052,11 +1150,11 @@ def _get_connection_with_retry(
                     type(error).__name__,
                     *_pool_counts(pool),
                 )
-                if _is_pool_exhausted_error(error):
+                if pool_exhausted:
                     record_postgres_pool_exhausted(
                         _database_service_unavailable_reason(_error_message(error)),
                     )
-                if _is_pool_exhausted_error(error) and acquire_attempt < (acquire_attempts - 1):
+                if will_retry_pool_acquire:
                     time.sleep(acquire_sleep_seconds)
                     continue
                 if _should_retry_query(error, attempt=attempt):
@@ -1211,9 +1309,16 @@ def advisory_session_lock(
     lock_key: int,
     *,
     label: str,
-    pool_name: str = "default",
+    pool_name: str = "session_control",
 ):
     """Hold a session-scoped advisory lock on a single pooled connection."""
+    if pool_name != "session_control":
+        logger.warning(
+            "[db-pool] advisory_lock_pool_redirect label=%s requested_pool=%s selected_pool=session_control",
+            label,
+            pool_name,
+        )
+        pool_name = "session_control"
     with db_read_connection(label=label, pool_name=pool_name) as conn:
         with db_read_cursor(conn=conn, label=label) as cur:
             cur.execute("select pg_try_advisory_lock(%s) as locked", [lock_key])

--- a/trr_backend/modal_jobs.py
+++ b/trr_backend/modal_jobs.py
@@ -418,6 +418,23 @@ _CANONICAL_MODAL_RUNTIME_DEFAULTS: Final[dict[str, str]] = {
     "TRR_ADMIN_IMAGE_EXECUTION_BACKEND": "modal",
     "SOCIAL_QUEUE_ENABLED": "true",
 }
+# Operator-tunable subset of _CANONICAL_MODAL_RUNTIME_DEFAULTS. For these keys
+# the canonical literal is a DEFAULT (applied via setdefault) so an operator can
+# override it through the Modal secret or environment. Everything NOT in this set
+# stays unconditionally pinned — in particular every DB-pool size and worker/
+# container concurrency cap, which are Supavisor session-budget safety clamps
+# (see comments_db_session_budget_status). Do not add a *_DB_POOL_*,
+# *_CONCURRENCY_LIMIT, or SOCIAL_WORKER_POOL_* key here without the DB-session-
+# budget analysis.
+_OPERATOR_TUNABLE_RUNTIME_DEFAULT_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "SOCIAL_INSTAGRAM_COMMENTS_PROXY_PROVIDER",
+        "SOCIALBLADE_PROXY_PROVIDER",
+        "SOCIAL_THREADS_POSTS_PROXY_PROVIDER",
+        "SOCIAL_INSTAGRAM_COMMENTS_COAUTHOR_GRAPHQL_PAGE_SIZE",
+        "SOCIAL_INSTAGRAM_COMMENTS_COAUTHOR_GRAPHQL_CHILD_PAGE_SIZE",
+    }
+)
 
 
 def _build_lean_image_base(*, image_factory: object | None = None):
@@ -680,7 +697,10 @@ def _resolve_modal_secrets() -> list[modal.Secret]:
 
 def _inject_modal_runtime_defaults() -> None:
     for key, value in _CANONICAL_MODAL_RUNTIME_DEFAULTS.items():
-        os.environ[key] = value
+        if key in _OPERATOR_TUNABLE_RUNTIME_DEFAULT_KEYS:
+            os.environ.setdefault(key, value)
+        else:
+            os.environ[key] = value
     if (os.getenv("OBJECT_STORAGE_ACCESS_KEY_ID") or "").strip() and (
         os.getenv("OBJECT_STORAGE_SECRET_ACCESS_KEY") or ""
     ).strip():

--- a/trr_backend/socials/control_plane/budget.py
+++ b/trr_backend/socials/control_plane/budget.py
@@ -18,9 +18,7 @@ STATE_NORMAL: LaneBudgetState = "normal"
 STATE_REDUCED: LaneBudgetState = "reduced"
 STATE_PAUSED: LaneBudgetState = "paused"
 STATE_IDENTITY_BLOCKED: LaneBudgetState = "identity_blocked"
-LANE_STATES: frozenset[str] = frozenset(
-    {STATE_NORMAL, STATE_REDUCED, STATE_PAUSED, STATE_IDENTITY_BLOCKED}
-)
+LANE_STATES: frozenset[str] = frozenset({STATE_NORMAL, STATE_REDUCED, STATE_PAUSED, STATE_IDENTITY_BLOCKED})
 
 DEFAULT_LANE = "instagram_backfill"
 DEFAULT_PLATFORM = "instagram"
@@ -128,9 +126,7 @@ def instagram_db_session_worker_budget() -> int:
 
 
 def instagram_db_session_pool_limit() -> int:
-    raw = str(
-        os.getenv(INSTAGRAM_DB_SESSION_POOL_LIMIT_ENV) or DEFAULT_INSTAGRAM_DB_SESSION_POOL_LIMIT
-    ).strip()
+    raw = str(os.getenv(INSTAGRAM_DB_SESSION_POOL_LIMIT_ENV) or DEFAULT_INSTAGRAM_DB_SESSION_POOL_LIMIT).strip()
     try:
         return max(1, int(raw))
     except ValueError:
@@ -260,13 +256,9 @@ def get_instagram_db_session_capacity(
     draining_remote_calls = len(dict.fromkeys(draining_remote_call_ids))
     occupied = active_db_jobs + dispatched_unclaimed_jobs + draining_remote_calls
     effective_requested = _to_int(
-        requested_workers
-        if backend_effective_requested_workers is None
-        else backend_effective_requested_workers
+        requested_workers if backend_effective_requested_workers is None else backend_effective_requested_workers
     )
-    raw_requested = _to_int(
-        effective_requested if raw_requested_workers is None else raw_requested_workers
-    )
+    raw_requested = _to_int(effective_requested if raw_requested_workers is None else raw_requested_workers)
     if active_workers is None:
         session_pool_usage = _instagram_db_session_pool_usage(requested_sessions=effective_requested)
     remaining = max(0, budget - occupied)
@@ -280,10 +272,7 @@ def get_instagram_db_session_capacity(
         )
     )
     blocked = worker_budget_blocked or session_pool_blocked
-    capacity_available = bool(
-        read_error is None
-        and (effective_requested == 0 or session_pool_usage.get("available"))
-    )
+    capacity_available = bool(read_error is None and (effective_requested == 0 or session_pool_usage.get("available")))
     capacity_read_error = read_error or (
         str(session_pool_usage.get("read_error") or "session_capacity_probe_failed")
         if effective_requested > 0 and not session_pool_usage.get("available")
@@ -465,9 +454,7 @@ def _resolve_limits(benchmark_overrides: Mapping[str, Any] | None) -> dict[str, 
     limits = dict(DEFAULT_LIMITS)
     override_payload = _metadata_dict(benchmark_overrides)
     nested_limits = _metadata_dict(override_payload.get("limits"))
-    cap4_canary_enabled = bool(
-        override_payload.get("enable_cap4_canary") or nested_limits.get("enable_cap4_canary")
-    )
+    cap4_canary_enabled = bool(override_payload.get("enable_cap4_canary") or nested_limits.get("enable_cap4_canary"))
     for source in (override_payload, nested_limits):
         for key, default in DEFAULT_LIMITS.items():
             if key in source:
@@ -644,9 +631,7 @@ def _identity_blocker_from_worker_auth(backfill_health: Mapping[str, Any], platf
         "platform": platform,
         "instagram_authenticated": False,
         "reason": (
-            worker_auth.get("instagram_auth_reason")
-            or worker_auth.get("reason")
-            or "instagram_identity_unavailable"
+            worker_auth.get("instagram_auth_reason") or worker_auth.get("reason") or "instagram_identity_unavailable"
         ),
         "detail": worker_auth.get("instagram_auth_detail"),
     }
@@ -932,9 +917,7 @@ def _auth_failure_pressure(
 ) -> dict[str, Any]:
     runs = _list_of_dicts(backfill_health.get("runs"))
     matching_runs = [
-        run
-        for run in runs
-        if _matches_platform(run, platform) and _matches_account(run, account, unknown_matches=True)
+        run for run in runs if _matches_platform(run, platform) and _matches_account(run, account, unknown_matches=True)
     ]
     max_rate = 0.0
     total_failures = 0

--- a/trr_backend/socials/control_plane/budget.py
+++ b/trr_backend/socials/control_plane/budget.py
@@ -139,7 +139,10 @@ def _instagram_db_session_pool_usage(*, requested_sessions: int) -> dict[str, An
     from trr_backend.db import pg
 
     limit = instagram_db_session_pool_limit()
-    probe = pg.probe_fresh_session_capacity(requested_sessions=requested_sessions)
+    probe = pg.probe_fresh_session_capacity(
+        requested_sessions=requested_sessions,
+        max_probe_sessions=limit,
+    )
     available = bool(probe.get("available"))
     reason = str(probe.get("reason") or "").strip() or None
     return {

--- a/trr_backend/socials/control_plane/budget.py
+++ b/trr_backend/socials/control_plane/budget.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from datetime import UTC, datetime
@@ -28,6 +29,11 @@ INSTAGRAM_BACKFILL_RUNBOOK_VERSION = "v4"
 INSTAGRAM_BACKFILL_LIVE_APPLY_WORKER_CAP = 2
 INSTAGRAM_BACKFILL_CANARY_WORKER_CAP = 4
 INSTAGRAM_BACKFILL_MINIMUM_SAMPLE_FLOOR = 25
+INSTAGRAM_DB_SESSION_WORKER_BUDGET_ENV = "SOCIAL_INSTAGRAM_DB_SESSION_WORKER_BUDGET"
+LEGACY_INSTAGRAM_COMMENTS_DB_SESSION_BUDGET_ENV = "SOCIAL_INSTAGRAM_COMMENTS_DB_SESSION_BUDGET"
+DEFAULT_INSTAGRAM_DB_SESSION_WORKER_BUDGET = 10
+INSTAGRAM_DB_SESSION_POOL_LIMIT_ENV = "SOCIAL_INSTAGRAM_DB_SESSION_POOL_LIMIT"
+DEFAULT_INSTAGRAM_DB_SESSION_POOL_LIMIT = 15
 
 ACTIVE_QUEUE_STATUSES: tuple[str, ...] = ("queued", "pending", "running", "retrying")
 
@@ -101,6 +107,235 @@ DEFAULT_LIMITS: dict[str, Any] = {
     "proxy_usd_reduced_threshold": None,
     "proxy_usd_paused_threshold": None,
 }
+
+
+def instagram_db_session_worker_budget() -> int:
+    """Return the combined Instagram Modal-worker budget.
+
+    The comments-only variable remains a compatibility fallback while deployed
+    environments move to the canonical combined-worker name.
+    """
+
+    raw = str(
+        os.getenv(INSTAGRAM_DB_SESSION_WORKER_BUDGET_ENV)
+        or os.getenv(LEGACY_INSTAGRAM_COMMENTS_DB_SESSION_BUDGET_ENV)
+        or DEFAULT_INSTAGRAM_DB_SESSION_WORKER_BUDGET
+    ).strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_INSTAGRAM_DB_SESSION_WORKER_BUDGET
+
+
+def instagram_db_session_pool_limit() -> int:
+    raw = str(
+        os.getenv(INSTAGRAM_DB_SESSION_POOL_LIMIT_ENV) or DEFAULT_INSTAGRAM_DB_SESSION_POOL_LIMIT
+    ).strip()
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_INSTAGRAM_DB_SESSION_POOL_LIMIT
+
+
+def _instagram_db_session_pool_usage(*, requested_sessions: int) -> dict[str, Any]:
+    """Prove requested session headroom with short-lived fresh reservations."""
+
+    from trr_backend.db import pg
+
+    limit = instagram_db_session_pool_limit()
+    probe = pg.probe_fresh_session_capacity(requested_sessions=requested_sessions)
+    available = bool(probe.get("available"))
+    reason = str(probe.get("reason") or "").strip() or None
+    return {
+        "available": available,
+        "source": "fresh_session_reservation",
+        "limit": limit,
+        "observed_sessions": None,
+        "remaining_sessions": None,
+        "at_capacity": reason == "session_pool_capacity",
+        "application_name": "trr-backend:session-capacity-probe",
+        "requested_sessions": _to_int(probe.get("requested_sessions")),
+        "reserved_sessions": _to_int(probe.get("reserved_sessions")),
+        "probe_reason": reason,
+        "probe_target": _metadata_dict(probe.get("target")),
+        "read_error": None if available else reason or str(probe.get("error") or "session_capacity_probe_failed"),
+    }
+
+
+def get_instagram_db_session_capacity(
+    *,
+    requested_workers: int = 0,
+    raw_requested_workers: int | None = None,
+    backend_effective_requested_workers: int | None = None,
+    active_workers: int | None = None,
+    conn: Any | None = None,
+) -> dict[str, Any]:
+    """Return the canonical Instagram DB-session capacity snapshot."""
+
+    budget = instagram_db_session_worker_budget()
+    read_error: str | None = None
+    active_db_job_ids: list[str] = []
+    dispatched_unclaimed_job_ids: list[str] = []
+    draining_remote_call_ids: list[str] = []
+    nonterminal_remote_call_ids: list[str] = []
+    session_pool_usage: dict[str, Any] = {
+        "available": False,
+        "source": "not_checked_active_worker_override",
+        "limit": instagram_db_session_pool_limit(),
+        "observed_sessions": None,
+        "remaining_sessions": None,
+        "at_capacity": None,
+        "application_name": None,
+        "read_error": None,
+    }
+    if active_workers is None:
+        try:
+            from trr_backend.db import pg
+            from trr_backend.modal_dispatch import inspect_modal_function_call
+
+            rows = pg.fetch_all(
+                """
+                select
+                  id::text as job_id,
+                  lower(coalesce(status, '')) as status,
+                  nullif(trim(coalesce(worker_id, '')), '') as worker_id,
+                  claimed_at,
+                  nullif(metadata #>> '{dispatch,remote_invocation_id}', '') as remote_invocation_id,
+                  lower(coalesce(metadata #>> '{dispatch,remote_invocation_status}', 'unknown'))
+                    as remote_invocation_status
+                from social.scrape_jobs
+                where lower(coalesce(platform, '')) = 'instagram'
+                  and lower(coalesce(config->>'stage', metadata->>'stage', job_type, '')) in (
+                    'comments',
+                    'comments_scrapling',
+                    'shared_account_discovery',
+                    'shared_account_posts'
+                  )
+                  and (
+                    status in ('queued', 'pending', 'retrying', 'running', 'claimed', 'dispatched', 'processing')
+                    or (
+                      status in ('completed', 'failed', 'cancelled')
+                      and coalesce(completed_at, heartbeat_at, started_at, claimed_at, created_at)
+                        >= now() - interval '2 hours'
+                      and nullif(metadata #>> '{dispatch,remote_invocation_id}', '') is not null
+                      and lower(coalesce(metadata #>> '{dispatch,remote_invocation_status}', 'unknown'))
+                        not in ('completed', 'failed', 'cancelled', 'terminated', 'error')
+                    )
+                  )
+                """,
+                conn=conn,
+                pool_name="social_control",
+            )
+            inspections: dict[str, dict[str, Any]] = {}
+            for row in rows:
+                call_id = str(row.get("remote_invocation_id") or "").strip()
+                if call_id and call_id not in inspections:
+                    inspections[call_id] = inspect_modal_function_call(call_id)
+
+            for row in rows:
+                job_id = str(row.get("job_id") or "").strip()
+                status = _normalize_text(row.get("status"))
+                call_id = str(row.get("remote_invocation_id") or "").strip()
+                inspection_status = _normalize_text(_metadata_dict(inspections.get(call_id)).get("status"))
+                remote_nonterminal = bool(call_id) and inspection_status not in {"completed", "failed"}
+                if remote_nonterminal and call_id not in nonterminal_remote_call_ids:
+                    nonterminal_remote_call_ids.append(call_id)
+
+                claimed = bool(str(row.get("worker_id") or "").strip() or row.get("claimed_at"))
+                if status in {"running", "claimed", "processing"} or (status == "dispatched" and claimed):
+                    if job_id:
+                        active_db_job_ids.append(job_id)
+                elif status in {"queued", "pending", "retrying", "dispatched"} and remote_nonterminal:
+                    if job_id:
+                        dispatched_unclaimed_job_ids.append(job_id)
+                elif remote_nonterminal:
+                    draining_remote_call_ids.append(call_id)
+        except Exception as exc:  # noqa: BLE001 - diagnostics stay available during DB pressure
+            read_error = f"{type(exc).__name__}: {exc}"
+    else:
+        active_db_job_ids = [f"active-worker-{index + 1}" for index in range(_to_int(active_workers))]
+
+    active_db_jobs = len(active_db_job_ids)
+    dispatched_unclaimed_jobs = len(dispatched_unclaimed_job_ids)
+    draining_remote_calls = len(dict.fromkeys(draining_remote_call_ids))
+    occupied = active_db_jobs + dispatched_unclaimed_jobs + draining_remote_calls
+    effective_requested = _to_int(
+        requested_workers
+        if backend_effective_requested_workers is None
+        else backend_effective_requested_workers
+    )
+    raw_requested = _to_int(
+        effective_requested if raw_requested_workers is None else raw_requested_workers
+    )
+    if active_workers is None:
+        session_pool_usage = _instagram_db_session_pool_usage(requested_sessions=effective_requested)
+    remaining = max(0, budget - occupied)
+    worker_budget_blocked = read_error is None and effective_requested > remaining
+    session_pool_remaining = session_pool_usage.get("remaining_sessions")
+    session_pool_blocked = bool(
+        effective_requested > 0
+        and (
+            not session_pool_usage.get("available")
+            or _to_int(session_pool_usage.get("reserved_sessions")) < effective_requested
+        )
+    )
+    blocked = worker_budget_blocked or session_pool_blocked
+    capacity_available = bool(
+        read_error is None
+        and (effective_requested == 0 or session_pool_usage.get("available"))
+    )
+    capacity_read_error = read_error or (
+        str(session_pool_usage.get("read_error") or "session_capacity_probe_failed")
+        if effective_requested > 0 and not session_pool_usage.get("available")
+        else None
+    )
+    block_reason = (
+        "instagram_db_session_pool_capacity_exceeded"
+        if session_pool_blocked and session_pool_usage.get("probe_reason") == "session_pool_capacity"
+        else "instagram_db_session_pool_probe_failed"
+        if session_pool_blocked
+        else "instagram_db_session_worker_budget_exceeded"
+        if worker_budget_blocked
+        else None
+    )
+    return {
+        "worker_budget": budget,
+        "safe_combined_worker_limit": budget,
+        "safe_limit": budget,
+        "active_workers": occupied,
+        "occupied_workers": occupied,
+        "active_db_jobs": active_db_jobs,
+        "active_db_job_ids": active_db_job_ids,
+        "dispatched_unclaimed_jobs": dispatched_unclaimed_jobs,
+        "dispatched_unclaimed_job_ids": dispatched_unclaimed_job_ids,
+        "nonterminal_remote_calls": len(nonterminal_remote_call_ids),
+        "nonterminal_remote_call_ids": nonterminal_remote_call_ids,
+        "draining_remote_calls": draining_remote_calls,
+        "draining_remote_call_ids": list(dict.fromkeys(draining_remote_call_ids)),
+        "remaining_workers": remaining,
+        "remaining_slots": remaining,
+        "raw_requested_workers": raw_requested,
+        "backend_effective_requested_workers": effective_requested,
+        "requested_workers": effective_requested,
+        "session_pool": {
+            **session_pool_usage,
+            "requested_sessions": effective_requested,
+            "blocked": session_pool_blocked,
+        },
+        "session_pool_available": bool(session_pool_usage.get("available")),
+        "session_pool_limit": _to_int(session_pool_usage.get("limit")),
+        "session_pool_observed_sessions": session_pool_usage.get("observed_sessions"),
+        "session_pool_remaining_sessions": session_pool_remaining,
+        "session_pool_requested_sessions": effective_requested,
+        "session_pool_reserved_sessions": _to_int(session_pool_usage.get("reserved_sessions")),
+        "session_pool_at_capacity": session_pool_usage.get("at_capacity"),
+        "session_pool_blocked": session_pool_blocked,
+        "session_pool_read_error": session_pool_usage.get("read_error"),
+        "blocked": blocked,
+        "block_reason": block_reason,
+        "available": capacity_available,
+        "read_error": capacity_read_error,
+    }
 
 
 def instagram_backfill_runbook_metadata(*, state: str = "active", cap4_canary_active: bool = False) -> dict[str, Any]:
@@ -1170,11 +1405,19 @@ __all__ = [
     "INSTAGRAM_BACKFILL_LIVE_APPLY_WORKER_CAP",
     "INSTAGRAM_BACKFILL_MINIMUM_SAMPLE_FLOOR",
     "INSTAGRAM_BACKFILL_RUNBOOK_VERSION",
+    "DEFAULT_INSTAGRAM_DB_SESSION_POOL_LIMIT",
+    "DEFAULT_INSTAGRAM_DB_SESSION_WORKER_BUDGET",
+    "INSTAGRAM_DB_SESSION_POOL_LIMIT_ENV",
+    "INSTAGRAM_DB_SESSION_WORKER_BUDGET_ENV",
+    "LEGACY_INSTAGRAM_COMMENTS_DB_SESSION_BUDGET_ENV",
     "STATE_IDENTITY_BLOCKED",
     "STATE_NORMAL",
     "STATE_PAUSED",
     "STATE_REDUCED",
     "build_budget_decision",
     "get_budget_decision",
+    "get_instagram_db_session_capacity",
+    "instagram_db_session_pool_limit",
+    "instagram_db_session_worker_budget",
     "instagram_backfill_runbook_metadata",
 ]


### PR DESCRIPTION
## Summary
- separate transaction and session-control database lanes
- use a one-connection control pool and fresh capacity probes
- bound Instagram catalog admission and dispatch concurrency
- harden Modal DB-lane readiness and deploy tooling

## Advisor provenance
Includes advisor 025 operator override semantics.

## Validation
- 85 focused tests passed
- Ruff and git diff checks passed

## Stack
Foundation of the social recovery stack. SQL pooling migration remains out of scope. Modal follow-through is required after merge.