### PR TITLE
Persist Instagram auth cooldown and recover incomplete comments

### DIFF
--- a/supabase/migrations/20260710123000_instagram_comments_shared_cooldown.sql
+++ b/supabase/migrations/20260710123000_instagram_comments_shared_cooldown.sql
@@ -1,0 +1,19 @@
+begin;
+
+alter table if exists social.ig_comment_rate_pace
+  add column if not exists cooldown_until timestamptz;
+
+-- Clear only capacity failures that were previously misclassified as Instagram
+-- authentication blocks. Checkpoints and scrape-job history are untouched.
+update social.account_auth_cooldown
+set cooldown_until = null,
+    consecutive_auth_failures = 0,
+    last_error_code = null,
+    blocker_kind = 'auth',
+    updated_at = now()
+where lower(btrim(platform)) = 'instagram'
+  and lower(btrim(blocker_kind)) = 'auth'
+  and lower(btrim(last_error_code)) = 'database_capacity';
+
+commit;
+

--- a/supabase/migrations/20260710123000_instagram_comments_shared_cooldown.sql
+++ b/supabase/migrations/20260710123000_instagram_comments_shared_cooldown.sql
@@ -16,4 +16,3 @@ where lower(btrim(platform)) = 'instagram'
   and lower(btrim(last_error_code)) = 'database_capacity';
 
 commit;
-

--- a/tests/api/routers/test_socials_comments_recovery.py
+++ b/tests/api/routers/test_socials_comments_recovery.py
@@ -1,0 +1,193 @@
+"""Tests for comments recovery admin endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+from uuid import uuid4
+
+import jwt
+import pytest
+from fastapi import BackgroundTasks
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+
+def _make_admin_token(secret: str, subject: str = "admin-1") -> str:
+    now = datetime.now(tz=UTC)
+    payload = {
+        "sub": subject,
+        "iat": int(now.timestamp()),
+        "nbf": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=5)).timestamp()),
+        "role": "admin",
+        "email": "admin@example.com",
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    secret = "test-secret-32-bytes-minimum-abcdef"
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", secret)
+    return {"Authorization": f"Bearer {_make_admin_token(secret)}"}
+
+
+def test_post_social_account_comments_run_resume_route(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    run_id = uuid4()
+    expected = {"run_id": str(run_id), "status": "running"}
+
+    with patch(
+        "trr_backend.socials.pipelines.comments.instagram.resume_social_account_comments_run",
+        return_value=expected,
+    ) as resume_mock:
+        response = client.post(
+            f"/api/v1/admin/socials/profiles/instagram/bravotv/comments/runs/{run_id}/resume",
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    resume_mock.assert_called_once_with(
+        platform="instagram",
+        account_handle="bravotv",
+        run_id=str(run_id),
+        initiated_by="admin@example.com",
+    )
+
+
+@pytest.mark.parametrize(
+    ("exception", "expected_status", "expected_code"),
+    [
+        pytest.param(
+            "conflict",
+            409,
+            "SOCIAL_COMMENTS_RUN_ACTIVE",
+            id="conflict",
+        ),
+        pytest.param(
+            "auth_repair_failed",
+            503,
+            "SOCIAL_INSTAGRAM_COMMENTS_AUTH_REPAIR_FAILED",
+            id="auth-repair-failed",
+        ),
+        pytest.param(
+            "validation",
+            400,
+            "SOCIAL_COMMENTS_RUN_INVALID_STATE",
+            id="validation",
+        ),
+    ],
+)
+def test_post_social_account_comments_run_resume_route_errors(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    exception: str,
+    expected_status: int,
+    expected_code: str,
+) -> None:
+    from trr_backend.repositories.social_season_analytics import (
+        SocialIngestConflictError,
+        SocialIngestValidationError,
+    )
+
+    run_id = uuid4()
+    error: Exception
+    if exception == "conflict":
+        error = SocialIngestConflictError(expected_code, "Comments run is already active.")
+    else:
+        error = SocialIngestValidationError(expected_code, "Comments run cannot be resumed.")
+
+    with patch(
+        "trr_backend.socials.pipelines.comments.instagram.resume_social_account_comments_run",
+        side_effect=error,
+    ):
+        response = client.post(
+            f"/api/v1/admin/socials/profiles/instagram/bravotv/comments/runs/{run_id}/resume",
+            headers=auth_headers,
+        )
+
+    assert response.status_code == expected_status
+    assert response.json()["detail"]["code"] == expected_code
+
+
+def test_post_social_account_comments_run_repair_auth_requires_confirmation(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    run_id = uuid4()
+
+    with (
+        patch(
+            "trr_backend.socials.pipelines.comments.instagram.request_social_account_comments_run_auth_repair",
+        ) as request_mock,
+        patch.object(BackgroundTasks, "add_task") as add_task_mock,
+    ):
+        response = client.post(
+            f"/api/v1/admin/socials/profiles/instagram/bravotv/comments/runs/{run_id}/repair-auth",
+            headers=auth_headers,
+            json={},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] == "INSTAGRAM_AUTH_REFRESH_CONFIRMATION_REQUIRED"
+    request_mock.assert_not_called()
+    add_task_mock.assert_not_called()
+
+
+def test_post_social_account_comments_run_repair_auth_schedules_background_task(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    run_id = uuid4()
+    expected: dict[str, Any] = {
+        "run_id": str(run_id),
+        "status": "accepted",
+        "repair_status": "running",
+    }
+
+    with (
+        patch(
+            "trr_backend.socials.pipelines.comments.instagram.request_social_account_comments_run_auth_repair",
+            return_value=expected,
+        ) as request_mock,
+        patch(
+            "trr_backend.socials.pipelines.comments.instagram.execute_social_account_comments_run_auth_repair",
+        ) as execute_mock,
+        patch.object(BackgroundTasks, "add_task") as add_task_mock,
+    ):
+        response = client.post(
+            f"/api/v1/admin/socials/profiles/instagram/bravotv/comments/runs/{run_id}/repair-auth",
+            headers=auth_headers,
+            json={
+                "operator_confirmation": "I UNDERSTAND INSTAGRAM AUTH RISK",
+                "allow_cookie_refresh": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == expected
+    request_mock.assert_called_once_with(
+        platform="instagram",
+        account_handle="bravotv",
+        run_id=str(run_id),
+        initiated_by="admin@example.com",
+    )
+    add_task_mock.assert_called_once_with(
+        execute_mock,
+        platform="instagram",
+        account_handle="bravotv",
+        run_id=str(run_id),
+        initiated_by="admin@example.com",
+        allow_cookie_refresh=True,
+    )

--- a/tests/db/test_instagram_comments_shared_cooldown_sql.py
+++ b/tests/db/test_instagram_comments_shared_cooldown_sql.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+MIGRATION = (
+    Path(__file__).parents[2]
+    / "supabase/migrations/20260710123000_instagram_comments_shared_cooldown.sql"
+)
+
+
+def test_shared_cooldown_migration_is_additive_and_cleanup_is_guarded() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8").lower()
+
+    assert "add column if not exists cooldown_until timestamptz" in sql
+    assert "lower(btrim(platform)) = 'instagram'" in sql
+    assert "lower(btrim(blocker_kind)) = 'auth'" in sql
+    assert "lower(btrim(last_error_code)) = 'database_capacity'" in sql
+    assert "delete from" not in sql
+    assert "social.scrape_jobs" not in sql
+    assert "blocker_kind = 'checkpoint'" not in sql
+

--- a/tests/db/test_instagram_comments_shared_cooldown_sql.py
+++ b/tests/db/test_instagram_comments_shared_cooldown_sql.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-MIGRATION = (
-    Path(__file__).parents[2]
-    / "supabase/migrations/20260710123000_instagram_comments_shared_cooldown.sql"
-)
+MIGRATION = Path(__file__).parents[2] / "supabase/migrations/20260710123000_instagram_comments_shared_cooldown.sql"
 
 
 def test_shared_cooldown_migration_is_additive_and_cleanup_is_guarded() -> None:
@@ -18,4 +15,3 @@ def test_shared_cooldown_migration_is_additive_and_cleanup_is_guarded() -> None:
     assert "delete from" not in sql
     assert "social.scrape_jobs" not in sql
     assert "blocker_kind = 'checkpoint'" not in sql
-

--- a/tests/repositories/test_comments_rebalance_cas.py
+++ b/tests/repositories/test_comments_rebalance_cas.py
@@ -9,6 +9,61 @@ import pytest
 import trr_backend.socials.pipelines.comments.instagram as comments_pipeline
 
 
+def test_session_advisory_lock_connection_uses_requested_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = object()
+    calls: list[tuple[str, str]] = []
+
+    @contextmanager
+    def db_connection(*, label: str, pool_name: str):
+        calls.append((label, pool_name))
+        yield connection
+
+    monkeypatch.setattr(comments_pipeline.pg, "db_connection", db_connection)
+
+    with comments_pipeline._session_advisory_lock_connection(
+        label="comments-lock",
+        pool_name="session_control",
+    ) as (lock_conn, discard_state):
+        assert lock_conn is connection
+        assert discard_state == {"discarded": False, "preserve_outcome": False}
+
+    assert calls == [("comments-lock", "session_control")]
+
+
+def test_session_advisory_lock_discard_closes_connection_and_preserves_completed_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Connection:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    connection = Connection()
+
+    @contextmanager
+    def db_connection(*, label: str, pool_name: str):  # noqa: ARG001
+        yield connection
+        raise RuntimeError("closed connection cannot commit")
+
+    monkeypatch.setattr(comments_pipeline.pg, "db_connection", db_connection)
+
+    with comments_pipeline._session_advisory_lock_connection(
+        label="comments-lock",
+        pool_name="session_control",
+    ) as (lock_conn, discard_state):
+        comments_pipeline._discard_session_advisory_lock_connection(
+            lock_conn,
+            discard_state=discard_state,
+            preserve_outcome=True,
+        )
+
+    assert connection.closed is True
+    assert discard_state == {"discarded": True, "preserve_outcome": True}
+
+
 @pytest.fixture
 def failed_rebalance_conn(monkeypatch: pytest.MonkeyPatch) -> object:
     conn = object()

--- a/tests/repositories/test_comments_rebalance_cas.py
+++ b/tests/repositories/test_comments_rebalance_cas.py
@@ -1,0 +1,441 @@
+"""Focused CAS and idempotency coverage for Instagram comments rebalancing."""
+
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+import trr_backend.socials.pipelines.comments.instagram as comments_pipeline
+
+
+@pytest.fixture
+def failed_rebalance_conn(monkeypatch: pytest.MonkeyPatch) -> object:
+    conn = object()
+
+    @contextmanager
+    def db_connection(**_kwargs: Any):
+        yield conn
+
+    monkeypatch.setattr(comments_pipeline.pg, "db_connection", db_connection)
+    monkeypatch.setattr(
+        comments_pipeline._core,
+        "_increment_run_counters_on_job_create_batch",
+        lambda **_kwargs: None,
+    )
+    return conn
+
+
+def _slow_source_row(*, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "run_id": "run-1",
+        "job_id": "slow-job-1",
+        "source_scope": "bravo",
+        "initiated_by": "test",
+        "started_at": datetime.now(UTC) - timedelta(hours=2),
+        "config": {
+            "account": "bravotv",
+            "source_scope": "bravo",
+            "stage": comments_pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+            "comments_shard_count": 4,
+            "target_source_ids": [f"P{index}" for index in range(1, 13)],
+        },
+        "metadata": metadata or {"stage_counters": {"posts": 0}},
+    }
+
+
+def test_slow_rebalance_does_not_create_children_after_cas_miss(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    update_calls: list[str] = []
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_SLOW_SHARD_REBALANCE_ENABLED", "1")
+    monkeypatch.setattr(comments_pipeline.pg, "fetch_all", lambda *_args, **_kwargs: [_slow_source_row()])
+
+    def cas_miss(query: str, *_args: Any, **_kwargs: Any) -> None:
+        update_calls.append(query)
+        return None
+
+    monkeypatch.setattr(comments_pipeline.pg, "fetch_one", cas_miss)
+    monkeypatch.setattr(
+        comments_pipeline,
+        "_create_job",
+        lambda *_args, **_kwargs: pytest.fail("a CAS miss must not create retry children"),
+    )
+
+    payload = comments_pipeline.rebalance_slow_instagram_comments_shards(
+        run_id="run-1",
+        slow_elapsed_seconds=60,
+        slow_posts_per_minute=0.25,
+        min_remaining_targets=3,
+        max_retry_shard_size=3,
+        dispatch_immediately=False,
+    )
+
+    assert payload["created_job_ids"] == []
+    assert payload["rebalanced_source_job_ids"] == []
+    assert payload["skipped_sources"] == [{"job_id": "slow-job-1", "reason": "source_status_changed"}]
+    assert "and status = 'running'" in update_calls[0]
+
+
+@pytest.mark.parametrize("remote_status", ["pending", "unknown"])
+def test_slow_rebalance_skips_active_remote_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    remote_status: str,
+) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_SLOW_SHARD_REBALANCE_ENABLED", "1")
+    monkeypatch.setattr(
+        comments_pipeline.pg,
+        "fetch_all",
+        lambda *_args, **_kwargs: [
+            _slow_source_row(
+                metadata={
+                    "dispatch": {
+                        "remote_invocation_id": "fc-active",
+                        "remote_invocation_status": remote_status,
+                    },
+                    "stage_counters": {"posts": 0},
+                }
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        comments_pipeline.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: pytest.fail("active remote dispatch must not be cancelled"),
+    )
+    monkeypatch.setattr(
+        comments_pipeline,
+        "_create_job",
+        lambda *_args, **_kwargs: pytest.fail("active remote dispatch must not be split"),
+    )
+
+    payload = comments_pipeline.rebalance_slow_instagram_comments_shards(
+        run_id="run-1",
+        slow_elapsed_seconds=60,
+        slow_posts_per_minute=0.25,
+        min_remaining_targets=3,
+        max_retry_shard_size=3,
+        dispatch_immediately=False,
+    )
+
+    assert payload["created_job_ids"] == []
+    assert payload["skipped_sources"] == [
+        {
+            "job_id": "slow-job-1",
+            "reason": "remote_invocation_active",
+            "remote_invocation_status": remote_status,
+        }
+    ]
+
+
+def test_failed_rebalance_does_not_create_children_after_claim_cas_miss(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_rebalance_conn: object,
+) -> None:
+    source_row = {
+        "job_id": "failed-job",
+        "run_id": "run-1",
+        "status": "failed",
+        "source_scope": "bravo",
+        "initiated_by": "test",
+        "config": {
+            "account": "bravotv",
+            "stage": comments_pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+        },
+        "metadata": {"retry_rebalance": {"remaining_target_source_ids": ["A", "B", "C"]}},
+    }
+    calls = 0
+
+    def fetch_one(query: str, *_args: Any, **_kwargs: Any) -> dict[str, Any] | None:
+        nonlocal calls
+        assert _kwargs["conn"] is failed_rebalance_conn
+        calls += 1
+        if query.lstrip().lower().startswith("select"):
+            return source_row
+        return None
+
+    monkeypatch.setattr(comments_pipeline.pg, "fetch_one", fetch_one)
+    monkeypatch.setattr(
+        comments_pipeline._core,
+        "_create_job",
+        lambda *_args, **_kwargs: pytest.fail("a failed-source CAS miss must not create retry children"),
+    )
+
+    payload = comments_pipeline.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=2,
+    )
+
+    assert calls == 2
+    assert payload == {
+        "created_job_ids": [],
+        "failed_job_id": "failed-job",
+        "reason": "source_status_changed",
+    }
+
+
+def test_failed_rebalance_skips_unknown_remote_dispatch_before_claim(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_rebalance_conn: object,
+) -> None:
+    source_row = {
+        "job_id": "failed-job",
+        "run_id": "run-1",
+        "status": "failed",
+        "source_scope": "bravo",
+        "initiated_by": "test",
+        "config": {
+            "account": "bravotv",
+            "stage": comments_pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+        },
+        "metadata": {
+            "dispatch": {
+                "remote_invocation_id": "fc-unknown",
+                "remote_invocation_status": "unknown",
+            },
+            "retry_rebalance": {"remaining_target_source_ids": ["A", "B", "C"]},
+        },
+    }
+    monkeypatch.setattr(comments_pipeline.pg, "fetch_one", lambda *_args, **_kwargs: source_row)
+    monkeypatch.setattr(
+        comments_pipeline._core,
+        "_create_job",
+        lambda *_args, **_kwargs: pytest.fail("unknown remote dispatch must not create retry children"),
+    )
+
+    payload = comments_pipeline.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=2,
+    )
+
+    assert payload == {
+        "created_job_ids": [],
+        "failed_job_id": "failed-job",
+        "reason": "remote_invocation_active",
+        "remote_invocation_status": "unknown",
+    }
+
+
+def test_failed_rebalance_claim_is_idempotent_across_repeated_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_rebalance_conn: object,
+) -> None:
+    source_state: dict[str, Any] = {
+        "status": "failed",
+        "metadata": {
+            "dispatch": {
+                "remote_invocation_id": "fc-completed",
+                "remote_invocation_status": "completed",
+            },
+            "retry_rebalance": {"remaining_target_source_ids": ["A", "B", "C"]},
+        },
+    }
+    created_jobs: list[dict[str, Any]] = []
+    claim_queries: list[str] = []
+    source_row = {
+        "job_id": "failed-job",
+        "run_id": "run-1",
+        "status": "failed",
+        "platform": "instagram",
+        "source_scope": "bravo",
+        "initiated_by": "test",
+        "config": {
+            "account": "bravotv",
+            "stage": comments_pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+            "comments_shard_count": 4,
+        },
+        "metadata": {"retry_rebalance": {"remaining_target_source_ids": ["A", "B", "C"]}},
+    }
+
+    def fetch_one(query: str, *_args: Any, **_kwargs: Any) -> dict[str, Any] | None:
+        assert _kwargs["conn"] is failed_rebalance_conn
+        if query.lstrip().lower().startswith("select"):
+            if source_state["status"] == "failed":
+                return {**source_row, "status": "failed", "metadata": source_state["metadata"]}
+            return {
+                **source_row,
+                "status": "cancelled",
+                "metadata": source_state["metadata"],
+            }
+        claim_queries.append(query)
+        if source_state["status"] != "failed" or source_state["metadata"].get("comments_retry_rebalance_claimed_at"):
+            return None
+        source_state["status"] = "cancelled"
+        source_state["metadata"] = {
+            **source_state["metadata"],
+            "comments_retry_rebalance_claimed_at": "claimed-at",
+            "comments_retry_rebalance_group_id": "retry-group",
+            "comments_retry_rebalance_shard_count": 2,
+        }
+        return {"id": "failed-job"}
+
+    monkeypatch.setattr(comments_pipeline.pg, "fetch_one", fetch_one)
+    monkeypatch.setattr(
+        comments_pipeline.pg,
+        "fetch_all",
+        lambda *_args, **kwargs: [
+            {
+                "job_id": f"retry-{index}",
+                "retry_index": job["config"]["comments_retry_rebalance_index"],
+            }
+            for index, job in enumerate(created_jobs, start=1)
+            if kwargs["conn"] is failed_rebalance_conn
+        ],
+    )
+    monkeypatch.setattr(
+        comments_pipeline._core,
+        "_create_job",
+        lambda *_args, **kwargs: (
+            created_jobs.append(dict(kwargs))
+            or ("retry-" + str(len(created_jobs)) if kwargs["conn"] is failed_rebalance_conn else "")
+        ),
+    )
+
+    first = comments_pipeline.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=2,
+    )
+    second = comments_pipeline.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=2,
+    )
+
+    assert first["created_job_ids"] == ["retry-1", "retry-2"]
+    assert second == {
+        "created_job_ids": [],
+        "failed_job_id": "failed-job",
+        "retry_group_id": "retry-group",
+        "reason": "already_rebalanced",
+    }
+    assert len(created_jobs) == 2
+    assert source_state["status"] == "cancelled"
+    assert "metadata->>'comments_retry_rebalance_claimed_at' is null" in claim_queries[0]
+
+
+@pytest.mark.parametrize("existing_indexes", [[], [1]])
+def test_failed_rebalance_resumes_claimed_zero_or_partial_children_without_duplicates(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_rebalance_conn: object,
+    existing_indexes: list[int],
+) -> None:
+    child_indexes = set(existing_indexes)
+    created_indexes: list[int] = []
+    source_row = {
+        "job_id": "failed-job",
+        "run_id": "run-1",
+        "status": "cancelled",
+        "source_scope": "bravo",
+        "initiated_by": "test",
+        "config": {
+            "account": "bravotv",
+            "stage": comments_pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+        },
+        "metadata": {
+            "retry_rebalance": {"remaining_target_source_ids": ["A", "B", "C", "D", "E"]},
+            "comments_retry_rebalance_claimed_at": "claimed-at",
+            "comments_retry_rebalance_group_id": "retry-group",
+            "comments_retry_rebalance_shard_count": 3,
+        },
+    }
+
+    def fetch_one(query: str, *_args: Any, **kwargs: Any) -> dict[str, Any]:
+        assert kwargs["conn"] is failed_rebalance_conn
+        assert query.lstrip().lower().startswith("select")
+        return source_row
+
+    def fetch_all(_query: str, *_args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        assert kwargs["conn"] is failed_rebalance_conn
+        return [{"job_id": f"retry-{index}", "retry_index": str(index)} for index in sorted(child_indexes)]
+
+    def create_job(*_args: Any, **kwargs: Any) -> str:
+        assert kwargs["conn"] is failed_rebalance_conn
+        assert kwargs["track_run_counters"] is False
+        index = int(kwargs["config"]["comments_retry_rebalance_index"])
+        assert index not in child_indexes
+        child_indexes.add(index)
+        created_indexes.append(index)
+        return f"retry-{index}"
+
+    monkeypatch.setattr(comments_pipeline.pg, "fetch_one", fetch_one)
+    monkeypatch.setattr(comments_pipeline.pg, "fetch_all", fetch_all)
+    monkeypatch.setattr(comments_pipeline._core, "_create_job", create_job)
+
+    first = comments_pipeline.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=1,
+    )
+    second = comments_pipeline.rebalance_failed_instagram_comments_shard(
+        failed_job_id="failed-job",
+        max_retry_shard_size=1,
+    )
+
+    assert first["created_job_ids"] == [f"retry-{index}" for index in range(1, 4) if index not in existing_indexes]
+    assert first["resumed_from_claimed_source"] is True
+    assert second == {
+        "created_job_ids": [],
+        "failed_job_id": "failed-job",
+        "retry_group_id": "retry-group",
+        "reason": "already_rebalanced",
+    }
+    assert child_indexes == {1, 2, 3}
+    assert created_indexes == [index for index in range(1, 4) if index not in existing_indexes]
+
+
+@pytest.mark.parametrize("remote_status", ["running", "unknown"])
+def test_waiting_rebalance_keeps_active_remote_dispatch_recoverable(
+    monkeypatch: pytest.MonkeyPatch,
+    remote_status: str,
+) -> None:
+    targets = [f"P{index}" for index in range(1, 26)]
+    monkeypatch.setattr(
+        comments_pipeline.pg,
+        "fetch_all",
+        lambda *_args, **_kwargs: [
+            {
+                "run_id": "run-1",
+                "job_id": "queued-dispatched-1",
+                "status": "queued",
+                "priority": 120,
+                "source_scope": "bravo",
+                "initiated_by": "test",
+                "config": {
+                    "account": "bravotv",
+                    "source_scope": "bravo",
+                    "stage": comments_pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                    "target_source_ids": targets,
+                },
+                "metadata": {
+                    "dispatch": {
+                        "remote_invocation_id": "fc-active",
+                        "remote_invocation_status": remote_status,
+                    }
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        comments_pipeline.pg,
+        "fetch_one",
+        lambda *_args, **_kwargs: pytest.fail("active remote dispatch must not be cancelled"),
+    )
+    monkeypatch.setattr(
+        comments_pipeline,
+        "_create_job",
+        lambda *_args, **_kwargs: pytest.fail("active remote dispatch must not be split"),
+    )
+
+    payload = comments_pipeline.rebalance_waiting_instagram_comments_shards(
+        run_id="run-1",
+        max_waiting_shard_size=10,
+        dispatch_immediately=False,
+    )
+
+    assert payload["created_job_ids"] == []
+    assert payload["skipped_sources"] == [
+        {
+            "job_id": "queued-dispatched-1",
+            "reason": "remote_invocation_active",
+            "remote_invocation_status": remote_status,
+        }
+    ]
+

--- a/tests/repositories/test_comments_rebalance_cas.py
+++ b/tests/repositories/test_comments_rebalance_cas.py
@@ -438,4 +438,3 @@ def test_waiting_rebalance_keeps_active_remote_dispatch_recoverable(
             "remote_invocation_status": remote_status,
         }
     ]
-

--- a/tests/socials/instagram/comments_scrapling/test_collaborator_target_metadata.py
+++ b/tests/socials/instagram/comments_scrapling/test_collaborator_target_metadata.py
@@ -131,6 +131,11 @@ def test_load_comment_target_metadata_uses_catalog_collaborator_fallback(
     assert "instagram_account_catalog_post_collaborators" in captured["sql"]
     assert "instagram_account_catalog_posts" in captured["sql"]
     assert "ltrim(lower(coalesce(nullif(m.collaborator_handle, ''), '')), '@') = %s" in captured["sql"]
+    assert "to_jsonb" not in captured["sql"]
+    assert "when ltrim(lower(coalesce(nullif(p.source_account, ''), '')), '@') = %s then 4" in captured["sql"]
+    assert "then 3" in captured["sql"]
+    assert "else 1" in captured["sql"]
+    assert "5 as profile_match_rank" in captured["sql"]
     assert captured["params"][0] == ["ABC123"]
     assert captured["params"][-2:] == ["thetraitorsus", "thetraitorsus"]
 

--- a/tests/socials/instagram/comments_scrapling/test_expected_count_degraded.py
+++ b/tests/socials/instagram/comments_scrapling/test_expected_count_degraded.py
@@ -110,15 +110,15 @@ def test_db_unavailable_error_degrades_map_and_continues(monkeypatch):
 
 def test_non_db_error_propagates(monkeypatch):
     # A non-DB error (a real bug) must NOT be swallowed by the narrowed except.
-    class _Boom(RuntimeError):
+    class _BoomError(RuntimeError):
         pass
 
     def _raise_boom(**_kwargs):
-        raise _Boom("attribute bug")
+        raise _BoomError("attribute bug")
 
     monkeypatch.setattr(jr, "_load_expected_comment_counts", _raise_boom)
 
-    with pytest.raises(_Boom):
+    with pytest.raises(_BoomError):
         try:
             jr._load_expected_comment_counts(
                 repo=SimpleNamespace(),
@@ -127,3 +127,33 @@ def test_non_db_error_propagates(monkeypatch):
             )
         except pg.DatabaseServiceUnavailableError:  # pragma: no cover - never hit
             pass
+
+
+def test_expected_count_query_preserves_requested_order_and_coauthor_max(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _fake_fetch_all(sql: str, params: list[object]):
+        captured["sql"] = " ".join(sql.split()).lower()
+        captured["params"] = params
+        return [
+            {"shortcode": "B", "reported_comments": 9},
+            {"shortcode": "A", "reported_comments": 0},
+        ]
+
+    monkeypatch.setattr(jr.pg, "fetch_all", _fake_fetch_all)
+    repo = SimpleNamespace(_instagram_reported_comments_sql=lambda alias: f"{alias}.comments_count")
+
+    counts = _load_expected_comment_counts(
+        repo=repo,
+        account_handle="@thetraitorsus",
+        target_source_ids=["B", "A", "B"],
+    )
+
+    sql = str(captured["sql"])
+    assert counts == {"B": 9, "A": 0}
+    assert captured["params"] == [["B", "A"]]
+    assert "with ordinality" in sql
+    assert "max((p.comments_count)::bigint)" in sql
+    assert "left join shortcode_max" in sql
+    assert "order by r.sort_order" in sql
+    assert "source_account" not in sql

--- a/tests/socials/instagram/comments_scrapling/test_fetcher_status_only.py
+++ b/tests/socials/instagram/comments_scrapling/test_fetcher_status_only.py
@@ -21,6 +21,7 @@ from trr_backend.socials.instagram.comments_scrapling.fetcher import (
     _extract_rendered_dom_snapshot_comments,
     _extract_rendered_permalink_comments,
     _public_comments_coverage_metadata,
+    _public_relay_block_reason_from_response,
     _target_metadata_indicates_coauthor,
 )
 from trr_backend.socials.instagram.scraper import InstagramComment
@@ -85,7 +86,7 @@ def test_public_comments_coverage_stays_partial_on_exhausted_relay_with_display_
 
     assert metadata["classification"] == "public_partial"
     assert metadata["target_gap_count"] == 25_956
-    assert metadata["fallback_blocked_reason"] == "public_comments_partial_requires_approval"
+    assert metadata["fallback_blocked_reason"] == "public_comments_partial_public_recovery_pending"
 
 
 def test_public_comments_coverage_complete_when_effective_target_is_met() -> None:
@@ -100,6 +101,27 @@ def test_public_comments_coverage_complete_when_effective_target_is_met() -> Non
     assert metadata["classification"] == "public_complete"
     assert metadata["effective_target_count"] == 100
     assert metadata["fallback_blocked_reason"] is None
+
+
+def test_public_relay_nested_graphql_rate_limit_code_is_blocking() -> None:
+    response = httpx.Response(
+        200,
+        request=httpx.Request("POST", "https://www.instagram.com/graphql/query/"),
+    )
+    payload = {
+        "data": {
+            "comments": {
+                "errors": [
+                    {
+                        "message": "Please wait a few minutes before you try again.",
+                        "extensions": {"code": 1675004},
+                    }
+                ]
+            }
+        }
+    }
+
+    assert _public_relay_block_reason_from_response(response, payload=payload) == "http_429"
 
 
 def test_status_only_payload_with_expected_comments_is_not_hidden_comments() -> None:
@@ -918,6 +940,44 @@ def test_public_relay_child_hydration_skips_zero_count_parents_by_default(monkey
     assert metadata["parent_attempts"] == 0
     assert metadata["parents_skipped_without_reply_gap"] == 2
     assert public_client.post.await_count == 0
+
+
+def test_public_relay_child_hydration_does_not_downgrade_after_rate_limit(monkeypatch) -> None:
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_COMMENTS_COAUTHOR_GRAPHQL_CHILD_PAGE_SIZE", "50")
+    fetcher = _build_fetcher()
+    fetcher._pace_api_requests = AsyncMock(return_value=True)
+    parent = _comment("parent-1", username="alpha", reply_count=1)
+    public_client = MagicMock()
+    public_client.post = AsyncMock(
+        return_value=httpx.Response(
+            429,
+            text="too many requests",
+            request=httpx.Request("POST", "https://www.instagram.com/graphql/query/"),
+        )
+    )
+
+    with patch(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher._post_child_comments_graphql_doc_attempts",
+        return_value=[("ChildCommentsQuery", "doc-1")],
+    ):
+        metadata = asyncio.run(
+            fetcher._fetch_public_relay_child_comments_for_status_only(
+                public_client=public_client,
+                shortcode="ABC123",
+                post_url="https://www.instagram.com/p/ABC123/",
+                media_id="123",
+                comments=[parent],
+                graphql_headers={},
+                common_body={},
+                target_count=2,
+                max_comments=0,
+            )
+        )
+
+    assert metadata["reason"] == "http_429"
+    assert metadata["block_reason"] == "http_429"
+    assert public_client.post.await_count == 1
+    assert "graphql_child_relay_page_size_downgrade" not in fetcher.runtime_metadata["retry_reason_counts"]
 
 
 def test_coauthor_relay_prefers_authenticated_session_for_parent_comments() -> None:

--- a/tests/socials/instagram/comments_scrapling/test_job_runner_cancellation.py
+++ b/tests/socials/instagram/comments_scrapling/test_job_runner_cancellation.py
@@ -48,6 +48,8 @@ def _patch_common_runner_dependencies(monkeypatch: pytest.MonkeyPatch, jr: Any, 
     # stub must return a real UTC datetime rather than ``None``.
     monkeypatch.setattr(repo, "_now_utc", lambda: datetime(2026, 4, 28, tzinfo=UTC))
     monkeypatch.setattr(jr, "_load_expected_comment_counts", lambda **_kwargs: {})
+    monkeypatch.setattr(jr, "_load_public_replay_guard_rows", lambda **_kwargs: {})
+    monkeypatch.setattr(jr, "_completion_residual_gap_targets_from_health", lambda **_kwargs: [])
 
 
 def test_comments_job_runner_checks_cancellation_after_warmup_before_opening_persist_conn(

--- a/tests/socials/instagram/comments_scrapling/test_job_runner_concurrency.py
+++ b/tests/socials/instagram/comments_scrapling/test_job_runner_concurrency.py
@@ -165,6 +165,8 @@ def _patch_runner(
     monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_kwargs: fetcher)
     monkeypatch.setattr(jr, "_load_expected_comment_counts", lambda **_kwargs: {})
     monkeypatch.setattr(jr, "_load_comment_target_metadata", lambda **_kwargs: {})
+    monkeypatch.setattr(jr, "_load_public_replay_guard_rows", lambda **_kwargs: {})
+    monkeypatch.setattr(jr, "_completion_residual_gap_targets_from_health", lambda **_kwargs: [])
     monkeypatch.setattr(jr, "_load_persisted_replies_by_parent", lambda **_kwargs: {})
     monkeypatch.setattr(jr, "_insert_instagram_post_comments_audit", lambda **_kwargs: None)
     monkeypatch.setattr(jr.pg, "fetch_one", fake_fetch_one)

--- a/tests/socials/instagram/comments_scrapling/test_job_runner_reply_only.py
+++ b/tests/socials/instagram/comments_scrapling/test_job_runner_reply_only.py
@@ -166,6 +166,8 @@ def test_incomplete_fill_uses_reply_only_when_persisted_reply_gap_exists(
     monkeypatch.setattr(jr.pg, "db_connection", fake_db_connection)
     monkeypatch.setattr(jr, "_load_expected_comment_counts", lambda **_kwargs: {"SHORT1": 1})
     monkeypatch.setattr(jr, "_load_comment_target_metadata", lambda **_kwargs: {})
+    monkeypatch.setattr(jr, "_load_public_replay_guard_rows", lambda **_kwargs: {})
+    monkeypatch.setattr(jr, "_completion_residual_gap_targets_from_health", lambda **_kwargs: [])
     monkeypatch.setattr(jr, "_load_persisted_replies_by_parent", lambda **_kwargs: {})
     monkeypatch.setattr(jr, "_load_persisted_top_level_comments_for_reply_retry", lambda **_kwargs: [persisted_parent])
     monkeypatch.setattr(jr, "_insert_instagram_post_comments_audit", lambda **_kwargs: None)

--- a/tests/socials/instagram/posts_scrapling/test_auth_block_reliability.py
+++ b/tests/socials/instagram/posts_scrapling/test_auth_block_reliability.py
@@ -282,12 +282,22 @@ def test_auth_block_rotates_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> No
             self._calls += 1
             if self._calls == 1:
                 return SimpleNamespace(
-                    auth_failed=True, fetch_failed=True, retryable=False,
-                    fetch_reason="http_401", posts=[], has_next_page=False, end_cursor=None,
+                    auth_failed=True,
+                    fetch_failed=True,
+                    retryable=False,
+                    fetch_reason="http_401",
+                    posts=[],
+                    has_next_page=False,
+                    end_cursor=None,
                 )
             return SimpleNamespace(
-                auth_failed=False, fetch_failed=False, retryable=False, fetch_reason=None,
-                posts=[{"shortcode": "ok1"}], has_next_page=False, end_cursor=None,
+                auth_failed=False,
+                fetch_failed=False,
+                retryable=False,
+                fetch_reason=None,
+                posts=[{"shortcode": "ok1"}],
+                has_next_page=False,
+                end_cursor=None,
             )
 
         async def set_api_proxy_config(self, _cfg, *, reason: str) -> None:
@@ -344,8 +354,13 @@ def test_auth_block_records_cooldown_when_budget_exhausted(monkeypatch: pytest.M
             del cursor, direction
             fetch_attempts.append(1)
             return SimpleNamespace(
-                auth_failed=True, fetch_failed=True, retryable=False,
-                fetch_reason="http_403", posts=[], has_next_page=False, end_cursor=None,
+                auth_failed=True,
+                fetch_failed=True,
+                retryable=False,
+                fetch_reason="http_403",
+                posts=[],
+                has_next_page=False,
+                end_cursor=None,
             )
 
         async def set_api_proxy_config(self, _cfg, *, reason: str) -> None:
@@ -367,8 +382,7 @@ def test_auth_block_records_cooldown_when_budget_exhausted(monkeypatch: pytest.M
     monkeypatch.setattr(
         auth_cooldown,
         "record_auth_block",
-        lambda *a, **k: recorded.append(a)
-        or SimpleNamespace(to_metadata=lambda: {"blocker_kind": "auth"}),
+        lambda *a, **k: recorded.append(a) or SimpleNamespace(to_metadata=lambda: {"blocker_kind": "auth"}),
     )
 
     job = {
@@ -415,8 +429,13 @@ def test_checkpoint_block_skips_rotation_and_records_cooldown(monkeypatch: pytes
         async def fetch_posts_page(self, _a: str, *, cursor=None, direction="forward"):  # noqa: ANN001
             del cursor, direction
             return SimpleNamespace(
-                auth_failed=True, fetch_failed=True, retryable=False,
-                fetch_reason="redirect_to_checkpoint", posts=[], has_next_page=False, end_cursor=None,
+                auth_failed=True,
+                fetch_failed=True,
+                retryable=False,
+                fetch_reason="redirect_to_checkpoint",
+                posts=[],
+                has_next_page=False,
+                end_cursor=None,
             )
 
         async def set_api_proxy_config(self, _cfg, *, reason: str) -> None:
@@ -437,8 +456,7 @@ def test_checkpoint_block_skips_rotation_and_records_cooldown(monkeypatch: pytes
     monkeypatch.setattr(
         auth_cooldown,
         "record_auth_block",
-        lambda *a, **k: recorded.append(a)
-        or SimpleNamespace(to_metadata=lambda: {"blocker_kind": "checkpoint"}),
+        lambda *a, **k: recorded.append(a) or SimpleNamespace(to_metadata=lambda: {"blocker_kind": "checkpoint"}),
     )
 
     job = {"id": "job-1", "run_id": "run-1", "config": {"account": "thetraitorsus", "stage": "posts_scrapling"}}

--- a/tests/socials/instagram/posts_scrapling/test_auth_block_reliability.py
+++ b/tests/socials/instagram/posts_scrapling/test_auth_block_reliability.py
@@ -11,12 +11,12 @@ Covers:
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
-from unittest.mock import MagicMock
 
 
 @pytest.fixture(autouse=True)
@@ -36,6 +36,59 @@ def _mock_scrapling(monkeypatch):
     mock_module.ProxyRotator = MagicMock()
     monkeypatch.setitem(__import__("sys").modules, "scrapling.fetchers", mock_module)
     return mock_module
+
+
+# ---------------------------------------------------------------------------
+# Identity-level auth cooldown helpers
+# ---------------------------------------------------------------------------
+
+
+def test_record_identity_auth_block_uses_reserved_sentinel_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.instagram import auth_cooldown
+
+    calls: list[tuple[str, str, str | None]] = []
+    expected = object()
+
+    def _record(platform: str, account_handle: str, error_code: str | None):
+        calls.append((platform, account_handle, error_code))
+        return expected
+
+    monkeypatch.setattr(auth_cooldown, "record_auth_block", _record)
+
+    result = auth_cooldown.record_identity_auth_block(
+        platform=" Instagram ",
+        error_code="http_401",
+    )
+
+    assert result is expected
+    assert calls == [("instagram", "__identity__:instagram", "http_401")]
+
+
+def test_identity_auth_cooldown_helpers_use_existing_get_and_clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.instagram import auth_cooldown
+
+    calls: list[tuple[Any, ...]] = []
+    expected = object()
+
+    def _get(platform: str, account_handle: str):
+        calls.append(("get", platform, account_handle))
+        return expected
+
+    def _clear(platform: str, account_handle: str, *, force: bool = False) -> bool:
+        calls.append(("clear", platform, account_handle, force))
+        return force
+
+    monkeypatch.setattr(auth_cooldown, "get_active_cooldown", _get)
+    monkeypatch.setattr(auth_cooldown, "clear_cooldown", _clear)
+
+    assert auth_cooldown.get_active_identity_cooldown(platform="Instagram") is expected
+    assert auth_cooldown.clear_identity_cooldown(platform="Instagram") is False
+    assert auth_cooldown.clear_identity_cooldown(platform="Instagram", force=True) is True
+    assert calls == [
+        ("get", "instagram", "__identity__:instagram"),
+        ("clear", "instagram", "__identity__:instagram", False),
+        ("clear", "instagram", "__identity__:instagram", True),
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -63,13 +116,13 @@ def test_proxy_session_key_generation_zero_is_unsuffixed() -> None:
 def test_proxy_session_key_generation_suffix_changes_key() -> None:
     from trr_backend.socials.instagram.posts_scrapling.job_runner import _posts_proxy_session_key
 
-    kwargs = dict(
-        account_handle="thetraitorsus",
-        stage="posts_scrapling",
-        config={"shard_count": 2, "shard_index": 1},
-        job_metadata={},
-        browser_account_id="thetraitorsus",
-    )
+    kwargs = {
+        "account_handle": "thetraitorsus",
+        "stage": "posts_scrapling",
+        "config": {"shard_count": 2, "shard_index": 1},
+        "job_metadata": {},
+        "browser_account_id": "thetraitorsus",
+    }
     gen0 = _posts_proxy_session_key(**kwargs, rotation_generation=0)
     gen1 = _posts_proxy_session_key(**kwargs, rotation_generation=1)
     gen2 = _posts_proxy_session_key(**kwargs, rotation_generation=2)

--- a/tests/socials/instagram/posts_scrapling/test_fetcher.py
+++ b/tests/socials/instagram/posts_scrapling/test_fetcher.py
@@ -142,7 +142,7 @@ def test_extract_page_tokens_missing_values():
     assert tokens == {}
 
 
-def test_advisory_api_pacing_uses_social_control_pool(monkeypatch):
+def test_advisory_api_pacing_uses_session_control_pool(monkeypatch):
     from trr_backend.db import pg
     from trr_backend.socials.instagram.posts_scrapling.fetcher import _try_advisory_lock_pace
 
@@ -175,7 +175,7 @@ def test_advisory_api_pacing_uses_social_control_pool(monkeypatch):
     assert result["acquired"] is True
     assert result["paced"] is True
     assert result["error"] is None
-    assert calls == [("instagram-posts-rate-limit-pace", "social_control")]
+    assert calls == [("instagram-posts-rate-limit-pace", "session_control")]
     assert any("social.ig_posts_rate_pace" in query for query in queries)
     assert not any("pg_advisory_lock" in query for query in queries)
 
@@ -247,7 +247,7 @@ def test_advisory_pacing_returns_connection_before_scheduled_sleep(monkeypatch, 
 
     @contextmanager
     def fake_db_connection(*, label: str, pool_name: str = "default"):
-        assert (label, pool_name) == ("instagram-posts-rate-limit-pace", "social_control")
+        assert (label, pool_name) == ("instagram-posts-rate-limit-pace", "session_control")
         events.append(("connect_enter", clock.current, None))
         try:
             yield object()
@@ -546,6 +546,93 @@ def test_warmup_transport_error_activates_requests_fallback(_mock_scrapling, mon
     assert fetcher.runtime_metadata["requests_fallback"]["warmup_error_class"] == "RuntimeError"
     assert created["cookies"]["sessionid"] == "existing"
     assert created["browser_account_id"] == "t"
+
+
+def test_warmup_redirect_loop_stops_after_one_document_without_graphql(_mock_scrapling, monkeypatch):
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from trr_backend.socials.instagram.posts_scrapling.fetcher import (
+        InstagramPostsScraplingFetcher,
+        InstagramPostsWarmupError,
+    )
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_POSTS_REQUESTS_FALLBACK_ENABLED", "1")
+    fetcher = InstagramPostsScraplingFetcher(
+        cookies=[],
+        raw_cookies={"sessionid": "existing", "csrftoken": "csrf"},
+        browser_account_id="t",
+    )
+    fetcher._fetcher.async_fetch = AsyncMock(
+        side_effect=RuntimeError(
+            "Page.goto: net::ERR_TOO_MANY_REDIRECTS at "
+            "https://www.instagram.com/accounts/login/?next=%2Fbravotv%2F; Exceeded 30 redirects"
+        )
+    )
+    fetcher._fetch_graphql = AsyncMock()
+
+    with pytest.raises(InstagramPostsWarmupError) as exc_info:
+        asyncio.run(fetcher.warmup("bravotv"))
+
+    assert exc_info.value.error_code == "instagram_posts_redirect_loop"
+    assert exc_info.value.retryable is False
+    assert fetcher._fetcher.async_fetch.await_count == 1
+    assert fetcher._fetcher.async_fetch.await_args.kwargs["retries"] == 1
+    fetcher._fetch_graphql.assert_not_awaited()
+    metadata = fetcher.runtime_metadata
+    assert metadata["requests_fallback"]["active"] is False
+    assert metadata["warmup_failure"] == {
+        "phase": "document_warmup",
+        "attempt_count": 1,
+        "final_origin_class": "instagram",
+        "final_path_class": "login",
+        "proxy_fingerprint": "none",
+        "error_code": "instagram_posts_redirect_loop",
+    }
+    assert "next=" not in json.dumps(metadata)
+
+
+@pytest.mark.parametrize(
+    ("final_url", "path_class"),
+    [
+        ("https://www.instagram.com/accounts/login/?next=%2Fbravotv%2F", "login"),
+        ("https://www.instagram.com/challenge/", "checkpoint"),
+        ("https://www.instagram.com/", "home"),
+    ],
+)
+def test_warmup_terminal_redirect_signals_do_not_fallback_or_fetch_graphql(
+    _mock_scrapling,
+    monkeypatch,
+    final_url,
+    path_class,
+):
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    from trr_backend.socials.instagram.posts_scrapling.fetcher import (
+        InstagramPostsScraplingFetcher,
+        InstagramPostsWarmupError,
+    )
+
+    monkeypatch.setenv("SOCIAL_INSTAGRAM_POSTS_REQUESTS_FALLBACK_ENABLED", "1")
+    fetcher = InstagramPostsScraplingFetcher(
+        cookies=[],
+        raw_cookies={"sessionid": "existing"},
+        browser_account_id="t",
+    )
+    response = MagicMock(status_code=200, text="<html></html>", cookies={})
+    response.url = final_url
+    fetcher._fetcher.async_fetch = AsyncMock(return_value=response)
+    fetcher._fetch_graphql = AsyncMock()
+
+    with pytest.raises(InstagramPostsWarmupError) as exc_info:
+        asyncio.run(fetcher.warmup("bravotv"))
+
+    assert exc_info.value.retryable is False
+    assert fetcher._fetcher.async_fetch.await_count == 1
+    fetcher._fetch_graphql.assert_not_awaited()
+    assert fetcher.runtime_metadata["requests_fallback"]["active"] is False
+    assert fetcher.runtime_metadata["warmup_failure"]["final_path_class"] == path_class
 
 
 def test_warmup_raises_no_cookie_when_no_prior_session(_mock_scrapling):

--- a/tests/socials/instagram/runtimes/test_experimental_runtimes.py
+++ b/tests/socials/instagram/runtimes/test_experimental_runtimes.py
@@ -70,4 +70,3 @@ def test_crawl4ai_runtime_rejects_unimplemented_or_unsupported_methods() -> None
         _run(runtime.fetch_posts("bravotv", limit=5))
     with pytest.raises(NotImplementedError):
         _run(runtime.fetch_post_detail("abc123"))
-

--- a/tests/socials/instagram/runtimes/test_experimental_runtimes.py
+++ b/tests/socials/instagram/runtimes/test_experimental_runtimes.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import asyncio
+import builtins
+
+import pytest
+
+from trr_backend.socials.instagram.runtimes.browser_use_runtime import BrowserUseRuntime
+from trr_backend.socials.instagram.runtimes.crawl4ai_runtime import Crawl4aiRuntime
+from trr_backend.socials.instagram.runtimes.protocol import RuntimeUnsupported
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_browser_use_healthcheck_unavailable_without_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "browser_use":
+            raise ImportError("missing browser-use")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    health = BrowserUseRuntime().healthcheck()
+
+    assert health.healthy is False
+    assert health.reason is not None
+    assert health.reason.startswith("browser_use_not_installed:")
+
+
+def test_browser_use_runtime_rejects_steady_state_methods() -> None:
+    runtime = BrowserUseRuntime()
+
+    with pytest.raises(RuntimeUnsupported):
+        _run(runtime.fetch_profile("bravotv"))
+    with pytest.raises(RuntimeUnsupported):
+        _run(runtime.fetch_posts("bravotv", limit=5))
+    with pytest.raises(RuntimeUnsupported):
+        _run(runtime.fetch_post_detail("abc123"))
+    with pytest.raises(NotImplementedError):
+        _run(runtime.recover_from_checkpoint("https://instagram.com/challenge"))
+
+
+def test_crawl4ai_healthcheck_unavailable_without_optional_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "crawl4ai":
+            raise ImportError("missing crawl4ai")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    health = Crawl4aiRuntime().healthcheck()
+
+    assert health.healthy is False
+    assert health.reason is not None
+    assert health.reason.startswith("crawl4ai_not_installed:")
+
+
+def test_crawl4ai_runtime_rejects_unimplemented_or_unsupported_methods() -> None:
+    runtime = Crawl4aiRuntime()
+
+    with pytest.raises(NotImplementedError):
+        _run(runtime.fetch_profile("bravotv"))
+    with pytest.raises(RuntimeUnsupported):
+        _run(runtime.fetch_posts("bravotv", limit=5))
+    with pytest.raises(NotImplementedError):
+        _run(runtime.fetch_post_detail("abc123"))
+

--- a/tests/socials/instagram/test_comments_target_gap_repair.py
+++ b/tests/socials/instagram/test_comments_target_gap_repair.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import trr_backend.socials.pipelines.comments.instagram as pipeline
+
+RUN_ID = "11111111-1111-1111-1111-111111111111"
+
+
+class _FakeGapRepairPg:
+    def __init__(self, *, run_config: dict[str, Any], job_rows: list[dict[str, Any]]) -> None:
+        self.run_config = run_config
+        self.job_rows = job_rows
+
+    def fetch_one(self, _sql: str, _params: list[Any]) -> dict[str, Any]:
+        return {
+            "run_id": RUN_ID,
+            "source_scope": "network",
+            "initiated_by": "test",
+            "config": self.run_config,
+            "run_metadata": {},
+        }
+
+    def fetch_all(self, _sql: str, _params: list[Any]) -> list[dict[str, Any]]:
+        return list(self.job_rows)
+
+
+def test_comments_target_gap_repair_preserves_incomplete_filter_and_date_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selector_calls: list[dict[str, Any]] = []
+    created_configs: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        pipeline,
+        "pg",
+        _FakeGapRepairPg(
+            run_config={
+                "stage": pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                "account": "BravoTV",
+                "mode": "profile",
+                "refresh_policy": "stale_or_missing",
+                "target_filter": "incomplete",
+                "incomplete_fill": True,
+                "max_posts": 5,
+                "comments_shard_count": 1,
+                "date_start": "2025-01-01T00:00:00+00:00",
+                "date_end": "2025-02-01T00:00:00+00:00",
+            },
+            job_rows=[
+                {
+                    "status": "running",
+                    "config": {
+                        "stage": pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                        "target_source_ids": ["already-assigned"],
+                    },
+                }
+            ],
+        ),
+    )
+
+    def fake_incomplete_selector(account_handle: str, **kwargs: Any) -> list[str]:
+        selector_calls.append({"account_handle": account_handle, **kwargs})
+        return ["already-assigned", "missing-target"]
+
+    monkeypatch.setattr(
+        pipeline,
+        "_instagram_social_account_incomplete_comment_target_shortcodes",
+        fake_incomplete_selector,
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_instagram_social_account_comment_target_shortcodes",
+        lambda *_args, **_kwargs: pytest.fail("generic selector should not run for target_filter=incomplete"),
+    )
+
+    def fake_create_job(_context: Any, **kwargs: Any) -> str:
+        created_configs.append(kwargs["config"])
+        return "repair-job-1"
+
+    monkeypatch.setattr(pipeline, "_create_job", fake_create_job)
+
+    result = pipeline.repair_instagram_comments_scrape_run_target_gaps(
+        run_id=RUN_ID,
+        dispatch_immediately=False,
+    )
+
+    assert result["created_job_ids"] == ["repair-job-1"]
+    assert selector_calls == [
+        {
+            "account_handle": "bravotv",
+            "limit": 5,
+            "date_start": "2025-01-01T00:00:00+00:00",
+            "date_end": "2025-02-01T00:00:00+00:00",
+        }
+    ]
+    assert created_configs[0]["target_source_ids"] == ["missing-target"]
+    assert created_configs[0]["target_filter"] == "incomplete"
+    assert created_configs[0]["date_start"] == "2025-01-01T00:00:00+00:00"
+    assert created_configs[0]["date_end"] == "2025-02-01T00:00:00+00:00"
+
+
+def test_comments_target_gap_repair_keeps_generic_selector_when_filter_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    selector_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(
+        pipeline,
+        "pg",
+        _FakeGapRepairPg(
+            run_config={
+                "stage": pipeline.INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                "account": "bravotv",
+                "mode": "profile",
+                "refresh_policy": "all_saved_posts",
+                "max_posts": 3,
+                "comments_shard_count": 1,
+            },
+            job_rows=[],
+        ),
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_instagram_social_account_incomplete_comment_target_shortcodes",
+        lambda *_args, **_kwargs: pytest.fail("incomplete selector should not run without target_filter"),
+    )
+
+    def fake_generic_selector(account_handle: str, **kwargs: Any) -> list[str]:
+        selector_calls.append({"account_handle": account_handle, **kwargs})
+        return ["missing-target"]
+
+    monkeypatch.setattr(pipeline, "_instagram_social_account_comment_target_shortcodes", fake_generic_selector)
+    monkeypatch.setattr(pipeline, "_create_job", lambda _context, **_kwargs: "repair-job-1")
+
+    result = pipeline.repair_instagram_comments_scrape_run_target_gaps(
+        run_id=RUN_ID,
+        dispatch_immediately=False,
+    )
+
+    assert result["created_job_ids"] == ["repair-job-1"]
+    assert selector_calls == [
+        {
+            "account_handle": "bravotv",
+            "limit": 3,
+            "refresh_policy": "all_saved_posts",
+            "date_start": None,
+            "date_end": None,
+        }
+    ]
+

--- a/tests/socials/instagram/test_comments_target_gap_repair.py
+++ b/tests/socials/instagram/test_comments_target_gap_repair.py
@@ -150,4 +150,3 @@ def test_comments_target_gap_repair_keeps_generic_selector_when_filter_absent(
             "date_end": None,
         }
     ]
-

--- a/tests/socials/test_cookie_refresh_flows.py
+++ b/tests/socials/test_cookie_refresh_flows.py
@@ -1229,7 +1229,5 @@ def test_threads_refresh_passes_in_protocol_validator(monkeypatch, tmp_path) -> 
         return {"sessionid": "s", "csrftoken": "c"}
 
     monkeypatch.setattr(threads_cookie_refresh_mod, "refresh_simple_login_cookies", _fake_refresh)
-    threads_cookie_refresh_mod.refresh_threads_cookies(
-        username="u", password="p", cookie_file=str(tmp_path / "t.json")
-    )
+    threads_cookie_refresh_mod.refresh_threads_cookies(username="u", password="p", cookie_file=str(tmp_path / "t.json"))
     assert captured["validator"] is threads_cookie_refresh_mod._validate_threads_cookies_in_protocol

--- a/tests/socials/test_cookie_refresh_flows.py
+++ b/tests/socials/test_cookie_refresh_flows.py
@@ -89,12 +89,14 @@ def test_instagram_cookie_validation_username_uses_public_fallback_not_login_ide
 
 def test_instagram_cookie_health_probe_disables_repair_side_effects(monkeypatch: pytest.MonkeyPatch) -> None:
     observed_env: dict[str, str | None] = {}
+    observed_kwargs: dict[str, object] = {}
 
     class _FakeInstagramScraper:
         def __init__(self, **_kwargs: object) -> None:
             self.last_retrieval_meta: dict[str, object] = {}
 
-        def fetch_posts_graphql(self, *_args: object, **_kwargs: object) -> None:
+        def fetch_posts_graphql(self, *_args: object, **kwargs: object) -> None:
+            observed_kwargs.update(kwargs)
             observed_env["auto_refresh"] = os.getenv("SOCIAL_INSTAGRAM_COOKIE_AUTO_REFRESH")
             observed_env["graphql_recovery_disabled"] = os.getenv("SOCIAL_INSTAGRAM_GRAPHQL_RECOVERY_DISABLED")
             observed_env["interactive_login"] = os.getenv("SOCIAL_INSTAGRAM_INTERACTIVE_LOGIN")
@@ -122,6 +124,8 @@ def test_instagram_cookie_health_probe_disables_repair_side_effects(monkeypatch:
         "graphql_recovery_disabled": "true",
         "interactive_login": "false",
     }
+    assert observed_kwargs["allow_browser_fallback"] is False
+    assert observed_kwargs["allow_recovery"] is False
     assert os.getenv("SOCIAL_INSTAGRAM_COOKIE_AUTO_REFRESH") == "true"
     assert os.getenv("SOCIAL_INSTAGRAM_GRAPHQL_RECOVERY_DISABLED") is None
     assert os.getenv("SOCIAL_INSTAGRAM_INTERACTIVE_LOGIN") == "1"
@@ -441,6 +445,35 @@ def test_cookie_refresh_context_allows_profileless_browser_with_override(
     assert captured["launch_kwargs"]["headless"] is True
     assert captured["context_kwargs"] == {"viewport": {"width": 100, "height": 100}}
     assert captured["browser_closed"] is True
+
+
+def test_cookie_refresh_context_closes_profileless_browser_when_new_context_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    chrome_root = tmp_path / "Chrome"
+    captured: dict[str, int] = {"close_calls": 0}
+
+    class _FakeBrowser:
+        def new_context(self, **_kwargs: object) -> object:
+            raise RuntimeError("new context failed")
+
+        def close(self) -> None:
+            captured["close_calls"] += 1
+
+    monkeypatch.setattr(browser_cookie_refresh, "_chrome_profile_base_dir", lambda: chrome_root)
+    monkeypatch.setattr(browser_cookie_refresh, "launch_browser", lambda *_args, **_kwargs: _FakeBrowser())
+
+    with pytest.raises(RuntimeError, match="new context failed"):
+        browser_cookie_refresh.open_cookie_refresh_context(
+            SimpleNamespace(chromium=object()),
+            platform="socialblade",
+            headless=True,
+            viewport={"width": 100, "height": 100},
+            require_profile=False,
+        )
+
+    assert captured["close_calls"] == 1
 
 
 def test_social_auth_refresh_rate_limit_blocks_repeated_attempts(

--- a/tests/socials/test_instagram_comments_guarded_restart.py
+++ b/tests/socials/test_instagram_comments_guarded_restart.py
@@ -25,6 +25,7 @@ class _FakePg:
 
     def __init__(self) -> None:
         self.audit_updates: list[tuple[str, list[Any]]] = []
+        self.events: list[str] = []
 
     @contextmanager
     def db_connection(self, *, label: str = "", pool_name: str = "default"):  # noqa: ARG002
@@ -39,6 +40,7 @@ class _FakePg:
         if "pg_try_advisory_lock" in sql:
             return {"locked": True}
         if "pg_advisory_unlock" in sql:
+            self.events.append("unlock")
             return {"unlocked": True}
         return {}
 
@@ -72,6 +74,7 @@ def _install_guarded_restart_fakes(
         }
 
     def _fake_cancel(*, platform: str, account_handle: str, run_id: str, cancelled_by=None, conn=None):  # noqa: ARG001
+        fake_pg.events.append("cancel")
         captured["cancel"] = {
             "platform": platform,
             "account_handle": account_handle,
@@ -81,6 +84,7 @@ def _install_guarded_restart_fakes(
         return {"run_id": run_id, "status": "cancelled", "accepted": True, "cancelled_jobs": 3}
 
     def _fake_start(platform: str, account_handle: str, **kwargs: Any):
+        fake_pg.events.append("start")
         captured["start"] = {"platform": platform, "account_handle": account_handle, **kwargs}
         return {
             "run_id": "new-run-77777777-7777-7777-7777-777777777777",
@@ -124,6 +128,7 @@ def test_guarded_restart_cancels_old_and_starts_public_relay_with_original_windo
     assert captured["cancel"]["cancelled_by"] == "comments_guarded_restart"
     assert captured["cancel"]["platform"] == "instagram"
     assert captured["cancel"]["account_handle"] == "bravotv"
+    assert captured["pg"].events == ["cancel", "unlock", "start"]
 
     # New run is public-relay only with the original window preserved and the
     # public-only worker cap / batch size forced.

--- a/tests/socials/test_instagram_comments_progress_payload.py
+++ b/tests/socials/test_instagram_comments_progress_payload.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+
 from trr_backend.socials.pipelines.comments.instagram import (
     SocialWorkerUnavailableError,
     _append_instagram_comments_public_recovery_targets_to_active_run,
@@ -890,8 +892,8 @@ def test_audit_cursor_split_force_rerun_replaces_existing_one_target_job(monkeyp
                 },
                 "metadata": {
                     "dispatch": {
-                        "remote_invocation_id": "fc-pending",
-                        "remote_invocation_status": "pending",
+                        "remote_invocation_id": "fc-completed",
+                        "remote_invocation_status": "completed",
                     }
                 },
             }
@@ -939,3 +941,62 @@ def test_audit_cursor_split_force_rerun_replaces_existing_one_target_job(monkeyp
     assert created_jobs[0]["config"]["comments_load_strategy"] == "instagram_comments_endpoint_cursor"
     assert created_jobs[0]["config"]["comments_session_scope"] == "instagram_comments_endpoint_cursor_worker"
     assert any(call["params"] and call["params"][-2] is True for call in fetch_one_calls)
+
+
+@pytest.mark.parametrize("remote_status", ["running", "unknown"])
+def test_audit_cursor_split_force_rerun_preserves_active_remote_job(monkeypatch, remote_status: str) -> None:
+    monkeypatch.setattr(
+        "trr_backend.socials.pipelines.comments.instagram.pg.fetch_all",
+        lambda *_args, **_kwargs: [
+            {
+                "run_id": "11111111-1111-1111-1111-111111111111",
+                "source_scope": "network",
+                "initiated_by": "admin",
+                "job_id": "33333333-3333-3333-3333-333333333333",
+                "status": "queued",
+                "priority": 104,
+                "target_count": 1,
+                "matched_targets": ["DTgXh94kXyo"],
+                "config": {
+                    "platform": "instagram",
+                    "account": "bravotv",
+                    "source_scope": "network",
+                    "target_source_ids": ["DTgXh94kXyo"],
+                },
+                "metadata": {
+                    "dispatch": {
+                        "remote_invocation_id": f"fc-{remote_status}",
+                        "remote_invocation_status": remote_status,
+                    }
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "trr_backend.socials.pipelines.comments.instagram.pg.fetch_one",
+        lambda *_args, **_kwargs: pytest.fail("active remote job must not be cancelled"),
+    )
+    monkeypatch.setattr(
+        "trr_backend.socials.pipelines.comments.instagram._create_job",
+        lambda *_args, **_kwargs: pytest.fail("replacement job must not be created"),
+    )
+
+    payload = _split_instagram_comments_audit_cursor_targets_into_active_run(
+        run_id="11111111-1111-1111-1111-111111111111",
+        account_handle="bravotv",
+        target_source_ids=["DTgXh94kXyo"],
+        batch_size=1,
+        initiated_by="audit-cursor-retry",
+        dispatch_immediately=True,
+        force_rerun_existing=True,
+    )
+
+    assert payload["created_target_job_ids"] == []
+    assert payload["cancelled_source_job_ids"] == []
+    assert payload["skipped_sources"] == [
+        {
+            "job_id": "33333333-3333-3333-3333-333333333333",
+            "reason": "remote_invocation_active",
+            "remote_invocation_status": remote_status,
+        }
+    ]

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -9800,9 +9800,7 @@ def test_fetch_comments_swaps_cursor_direction_when_min_id_repeats(monkeypatch) 
 
 def test_fetch_comments_both_cursor_directions_exhausted_stays_non_retryable() -> None:
     fetcher = _build_fetcher()
-    fetcher._parser._parse_comment = MagicMock(
-        side_effect=[_comment("c1"), _comment("c2"), _comment("c3")]
-    )
+    fetcher._parser._parse_comment = MagicMock(side_effect=[_comment("c1"), _comment("c2"), _comment("c3")])
     fetcher._fetch_json_response = AsyncMock(
         side_effect=[
             {

--- a/tests/socials/test_instagram_comments_scrapling_retry.py
+++ b/tests/socials/test_instagram_comments_scrapling_retry.py
@@ -3373,18 +3373,80 @@ def test_advisory_api_pacing_stops_when_cooldown_exceeds_deadline(tmp_path: Path
     assert sleep_mock.call_args.args[0] == pytest.approx(0.01, abs=0.01)
 
 
-def test_advisory_api_pacing_uses_social_control_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_advisory_api_pacing_uses_session_control_pool_and_waits_after_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from trr_backend.db import pg
 
     calls: list[tuple[str, str]] = []
+    state = {"in_connection": False}
 
     class FakeCursor:
-        def execute(self, _sql: str, _params: Any = None) -> None:
-            return None
+        sql = ""
 
-        def fetchone(self) -> list[float]:
-            # Reservation upsert returns remaining-seconds; 0 ⇒ no wait.
-            return [0.0]
+        def execute(self, sql: str, _params: Any = None) -> None:
+            self.sql = sql
+
+        def fetchone(self) -> dict[str, float]:
+            if "cooldown_until - now()" in self.sql:
+                return {"cooldown_seconds": 3.0}
+            assert "coalesce(p.cooldown_until, now())" in self.sql
+            return {"wait_seconds": 2.0}
+
+    @contextmanager
+    def fake_db_connection(*, label: str, pool_name: str = "default"):
+        calls.append((label, pool_name))
+        state["in_connection"] = True
+        try:
+            yield object()
+        finally:
+            state["in_connection"] = False
+
+    @contextmanager
+    def fake_db_cursor(*, conn: Any = None, label: str = "write-cursor"):
+        del conn, label
+        yield FakeCursor()
+
+    monkeypatch.setattr(pg, "db_connection", fake_db_connection)
+    monkeypatch.setattr(pg, "db_cursor", fake_db_cursor)
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher._wait_for_global_api_cooldown",
+        lambda **_kwargs: True,
+    )
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.time.sleep",
+        lambda seconds: (sleep_calls.append(seconds), assert_not_in_connection(state)),
+    )
+
+    result = _try_advisory_lock_pace(key="advisory-pool", delay_seconds=0.0, deadline=None)
+
+    assert result["acquired"] is True
+    assert result["paced"] is True
+    assert result["error"] is None
+    assert calls == [
+        ("instagram-comments-rate-limit-pace", "session_control"),
+        ("instagram-comments-rate-limit-cooldown-read", "session_control"),
+    ]
+    assert sleep_calls == [2.0, 3.0]
+
+
+def assert_not_in_connection(state: dict[str, bool]) -> None:
+    assert state["in_connection"] is False
+
+
+def test_record_global_api_cooldown_extends_db_deadline_and_keeps_file_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from trr_backend.db import pg
+
+    calls: list[tuple[str, str]] = []
+    executed: list[tuple[str, Any]] = []
+
+    class FakeCursor:
+        def execute(self, sql: str, params: Any = None) -> None:
+            executed.append((sql, params))
 
     @contextmanager
     def fake_db_connection(*, label: str, pool_name: str = "default"):
@@ -3398,13 +3460,67 @@ def test_advisory_api_pacing_uses_social_control_pool(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(pg, "db_connection", fake_db_connection)
     monkeypatch.setattr(pg, "db_cursor", fake_db_cursor)
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.tempfile.gettempdir",
+        lambda: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.time.monotonic",
+        lambda: 100.0,
+    )
 
-    result = _try_advisory_lock_pace(key="advisory-pool", delay_seconds=0.0, deadline=None)
+    _record_global_api_cooldown(key="proxy-isolated-key", delay_seconds=5.0)
 
-    assert result["acquired"] is True
-    assert result["paced"] is True
-    assert result["error"] is None
-    assert calls == [("instagram-comments-rate-limit-pace", "social_control")]
+    assert calls == [("instagram-comments-rate-limit-cooldown", "session_control")]
+    assert len(executed) == 1
+    assert "greatest(" in executed[0][0]
+    assert "excluded.cooldown_until" in executed[0][0]
+    assert executed[0][1] == ("proxy-isolated-key", 5.0)
+    cooldown_file = tmp_path / "trr-instagram-comments-rate" / "proxy-isolated-key.cooldown"
+    assert float(cooldown_file.read_text(encoding="utf-8")) == 105.0
+
+
+def test_record_global_api_cooldown_falls_back_to_file_when_db_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from trr_backend.db import pg
+
+    @contextmanager
+    def unavailable_db_connection(**_kwargs: Any):
+        raise RuntimeError("database unavailable")
+        yield
+
+    monkeypatch.setattr(pg, "db_connection", unavailable_db_connection)
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.tempfile.gettempdir",
+        lambda: str(tmp_path),
+    )
+    monkeypatch.setattr(
+        "trr_backend.socials.instagram.comments_scrapling.fetcher.time.monotonic",
+        lambda: 200.0,
+    )
+
+    _record_global_api_cooldown(key="db-fallback", delay_seconds=7.0)
+
+    cooldown_file = tmp_path / "trr-instagram-comments-rate" / "db-fallback.cooldown"
+    assert float(cooldown_file.read_text(encoding="utf-8")) == 207.0
+
+
+def test_comments_auto_refill_dispatch_uses_control_plane_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.control_plane import dispatch_runtime
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    calls: list[dict[str, object]] = []
+
+    def fake_dispatch(*, run_id=None, limit=None):
+        calls.append({"run_id": run_id, "limit": limit})
+        return {"dispatched_job_ids": ["job-1"]}
+
+    monkeypatch.setattr(dispatch_runtime, "dispatch_due_social_jobs", fake_dispatch)
+
+    assert jr._dispatch_due_social_jobs(run_id="run-1", limit=4) == {"dispatched_job_ids": ["job-1"]}
+    assert calls == [{"run_id": "run-1", "limit": 4}]
 
 
 # ---------------------------------------------------------------------------
@@ -5394,6 +5510,26 @@ def test_comments_job_runner_skips_duplicate_public_replay_after_auth_block(
         "auth_blocked_existing_public_coverage_skipped"
     )
     assert metadata["post_latency"]["samples"][0]["public_replay_guard"]["saved_comment_count"] == 124
+
+
+def test_public_replay_guard_accepts_legacy_and_recovery_pending_reasons(monkeypatch: pytest.MonkeyPatch) -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+
+    captured: dict[str, object] = {}
+
+    def fake_fetch_all(sql: str, params: list[object]) -> list[dict[str, object]]:
+        captured["sql"] = " ".join(sql.split())
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(jr.pg, "fetch_all", fake_fetch_all)
+
+    assert jr._load_public_replay_guard_rows(target_source_ids=["ABC123"]) == {}
+    assert "fallback_blocked_reason" in str(captured["sql"])
+    assert {
+        "public_comments_partial_requires_approval",
+        "public_comments_partial_public_recovery_pending",
+    } <= set(captured["params"][-1])
 
 
 def test_comments_job_runner_blocks_browser_session_invalidation_before_rendered_fallback(
@@ -8656,7 +8792,7 @@ def test_job_runner_keeps_one_comment_relay_recovery_gap_incomplete(
     assert sample["stored_total_comments"] == 32
 
 
-def test_job_runner_keeps_high_coverage_transient_gap_incomplete(
+def test_job_runner_retries_saved_public_partial_with_remaining_gap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from trr_backend.repositories import social_season_analytics as repo
@@ -8713,6 +8849,7 @@ def test_job_runner_keeps_high_coverage_transient_gap_incomplete(
                 reported_comment_count=876,
                 request_count=14,
                 retryable=True,
+                public_block_signal="http_429",
             )
 
         async def aclose(self) -> None:
@@ -8728,6 +8865,11 @@ def test_job_runner_keeps_high_coverage_transient_gap_incomplete(
     monkeypatch.setattr(jr, "select_comments_proxy", lambda *, session_key=None: None)
     monkeypatch.setattr(jr, "resolve_comments_scrapling_session", lambda **_: fake_session)
     monkeypatch.setattr(jr, "InstagramCommentsScraplingFetcher", lambda **_: _FakeFetcher())
+    monkeypatch.setattr(
+        jr,
+        "_enqueue_auto_public_recovery_targets",
+        lambda **_kwargs: pytest.fail("saved partial coverage must not enqueue another job"),
+    )
     monkeypatch.setattr(repo, "_touch_job_heartbeat", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_emit_job_progress", lambda *a, **k: None)
     monkeypatch.setattr(repo, "_finalize_run_status", lambda *a, **k: None)
@@ -8752,6 +8894,7 @@ def test_job_runner_keeps_high_coverage_transient_gap_incomplete(
             "account": "bravotv",
             "target_source_ids": ["SHORT1"],
             "fetch_replies": True,
+            "comments_load_strategy": "public_relay",
         },
         "attempt_count": 1,
         "max_attempts": 3,
@@ -8759,7 +8902,7 @@ def test_job_runner_keeps_high_coverage_transient_gap_incomplete(
 
     with patch(
         "trr_backend.socials.instagram.comments_scrapling.job_runner.pg.fetch_one",
-        side_effect=_active_comments_job_fetch_one("completed"),
+        side_effect=_active_comments_job_fetch_one("retrying"),
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
@@ -8771,16 +8914,53 @@ def test_job_runner_keeps_high_coverage_transient_gap_incomplete(
     # leak the plan closes.
     assert reconcile_calls == []
     assert finish_calls[-1]["status"] == "retrying"
+    assert finish_calls[-1]["last_error_code"] == "instagram_comments_public_retryable"
     metadata = finish_calls[-1]["metadata"]
     assert metadata["incomplete_target_source_ids"] == ["SHORT1"]
     assert metadata["incomplete_fetch_reasons"] == {"SHORT1": "http_429"}
+    assert metadata["runtime_metadata"]["completion_status"] == "public_comments_blocked_retryable"
+    assert metadata["runtime_metadata"]["retry_target_source_ids"] == ["SHORT1"]
     sample = metadata["post_latency"]["samples"][0]
     assert sample["completion_reason"] == "incomplete_fetch"
     assert sample["operator_status"] == "incomplete_retryable"
     assert sample["stored_total_comments"] == 847
 
 
-def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
+def test_auto_public_recovery_appends_explicit_targets_without_audit_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from trr_backend.socials.instagram.comments_scrapling import job_runner as jr
+    from trr_backend.socials.pipelines.comments import instagram as comments_pipeline
+
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        comments_pipeline,
+        "_append_instagram_comments_public_recovery_targets_to_active_run",
+        lambda **kwargs: calls.append(kwargs) or {"created_target_job_count": 1},
+    )
+
+    result = jr._enqueue_auto_public_recovery_targets(
+        run_id="11111111-1111-1111-1111-111111111111",
+        source_job_id="22222222-2222-2222-2222-222222222222",
+        account_handle="bravotv",
+        source_ids=["SHORT1", "SHORT1"],
+    )
+
+    assert result == {"created_target_job_count": 1}
+    assert calls == [
+        {
+            "run_id": "11111111-1111-1111-1111-111111111111",
+            "account_handle": "bravotv",
+            "target_source_ids": ["SHORT1"],
+            "batch_size": 1,
+            "dispatch_immediately": True,
+            "initiated_by": "comments-public-auto-recovery",
+            "exclude_active_job_id": "22222222-2222-2222-2222-222222222222",
+        }
+    ]
+
+
+def test_job_runner_stops_after_first_genuine_http_429(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from trr_backend.repositories import social_season_analytics as repo
@@ -8790,6 +8970,7 @@ def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
     finish_calls: list[dict[str, Any]] = []
     config_update_calls: list[dict[str, Any]] = []
     persist_calls: list[str] = []
+    fetch_calls: list[str] = []
 
     def fake_persist(*, shortcode: str, **_kwargs: Any) -> PersistedInstagramComments:
         persist_calls.append(shortcode)
@@ -8813,14 +8994,16 @@ def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
             return None
 
         async def fetch_comments_for_shortcode(self, shortcode: str, **_kwargs: Any) -> InstagramCommentsFetchResult:
+            fetch_calls.append(shortcode)
             if shortcode == "SHORT2":
                 return InstagramCommentsFetchResult(
-                    comments=[],
+                    comments=[object()],
                     fetch_failed=True,
                     auth_failed=False,
                     fetch_reason="http_429",
                     request_count=3,
                     retryable=True,
+                    public_block_signal="http_429",
                 )
             return InstagramCommentsFetchResult(
                 comments=[object()],
@@ -8868,6 +9051,7 @@ def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
             "account": "bravotv",
             "target_source_ids": ["SHORT1", "SHORT2", "SHORT3"],
             "fetch_replies": True,
+            "comments_load_strategy": "public_relay",
             "comments_shard_index": 1,
             "comments_shard_count": 2,
             "comments_shard_target_count": 3,
@@ -8882,21 +9066,18 @@ def test_job_runner_retries_only_remaining_posts_after_hard_retryable_failure(
     ):
         jr.run_instagram_comments_scrapling_job(job, worker_id="test-worker")
 
-    assert persist_calls == ["SHORT1", "SHORT3"]
+    assert fetch_calls == ["SHORT1", "SHORT2"]
+    assert persist_calls == ["SHORT1", "SHORT2"]
     assert config_update_calls == [
         {
-            "target_source_ids": ["SHORT2"],
-            "comments_shard_target_count": 1,
+            "target_source_ids": ["SHORT2", "SHORT3"],
+            "comments_shard_target_count": 2,
             "comments_retry_incomplete": True,
             "comments_retry_incomplete_source_job_id": "job-1",
         }
     ]
     assert finish_calls[-1]["status"] == "retrying"
-    assert finish_calls[-1]["last_error_code"] == "instagram_comments_incomplete_retryable"
-    assert finish_calls[-1]["metadata"]["retry_rebalance"] == {
-        "remaining_target_source_ids": ["SHORT2"],
-        "eligible": True,
-    }
+    assert finish_calls[-1]["last_error_code"] == "instagram_comments_public_retryable"
 
 
 def test_job_runner_completes_one_pass_incomplete_fill_with_unresolved_targets(
@@ -9615,6 +9796,139 @@ def test_fetch_comments_swaps_cursor_direction_when_min_id_repeats(monkeypatch) 
     # Direction swap surfaced in runtime metadata.
     assert fetcher.runtime_metadata["cursor_direction_swaps"]["top_level"] == 1
     assert fetcher.runtime_metadata["retry_reason_counts"].get("pagination_repeated_cursor_swap_direction") == 1
+
+
+def test_fetch_comments_both_cursor_directions_exhausted_stays_non_retryable() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[_comment("c1"), _comment("c2"), _comment("c3")]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "comments": [{"id": "c1"}],
+                    "has_more_comments": True,
+                    "next_max_id": "max-2",
+                    "next_min_id": "min-9",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c2"}],
+                    "has_more_comments": True,
+                    "next_max_id": "max-2",
+                    "next_min_id": "min-9",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "comments": [{"id": "c3"}],
+                    "has_more_comments": False,
+                    "has_more_headload_comments": True,
+                    "next_min_id": "min-9",
+                    "next_max_id": "max-2",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+    fetcher._fetch_rendered_comments_after_revealing_hidden = AsyncMock(return_value=[])
+
+    result = asyncio.run(
+        fetcher.fetch_comments_for_shortcode(
+            "ABC123",
+            max_comments=10,
+            fetch_replies=False,
+            expected_comment_count=4,
+        )
+    )
+
+    assert [comment.comment_id for comment in result.comments] == ["c1", "c2", "c3"]
+    assert result.fetch_failed is True
+    assert result.retryable is False
+    assert result.fetch_reason == "pagination_repeated_cursor"
+    assert result.diagnostic_metadata["cursor_directions_exhausted"] is True
+
+
+def test_fetch_replies_both_cursor_directions_exhausted_stays_non_retryable() -> None:
+    fetcher = _build_fetcher()
+    fetcher._parser._parse_comment = MagicMock(
+        side_effect=[
+            _comment("r1", is_reply=True, parent_comment_id="parent-1"),
+            _comment("r2", is_reply=True, parent_comment_id="parent-1"),
+            _comment("r3", is_reply=True, parent_comment_id="parent-1"),
+        ]
+    )
+    fetcher._fetch_json_response = AsyncMock(
+        side_effect=[
+            {
+                "payload": {
+                    "child_comments": [{"id": "r1"}],
+                    "has_more_tail_child_comments": True,
+                    "next_min_child_cursor": "min-2",
+                    "next_max_child_cursor": "max-9",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "child_comments": [{"id": "r2"}],
+                    "has_more_tail_child_comments": True,
+                    "next_min_child_cursor": "min-2",
+                    "next_max_child_cursor": "max-9",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+            {
+                "payload": {
+                    "child_comments": [{"id": "r3"}],
+                    "has_more_tail_child_comments": False,
+                    "has_more_head_child_comments": True,
+                    "next_max_child_cursor": "max-9",
+                    "next_min_child_cursor": "min-2",
+                },
+                "failed": False,
+                "auth_failed": False,
+                "reason": None,
+                "retryable": False,
+            },
+        ]
+    )
+
+    result = asyncio.run(
+        fetcher._fetch_comment_replies(
+            media_id="media-1",
+            comment_id="parent-1",
+            shortcode="ABC123",
+            post_url="https://www.instagram.com/p/ABC123/",
+            expected_reply_count=4,
+        )
+    )
+
+    assert [comment.comment_id for comment in result.comments] == ["r1", "r2", "r3"]
+    assert result.fetch_failed is True
+    assert result.retryable is False
+    assert result.fetch_reason == "pagination_repeated_cursor"
+    assert result.diagnostic_metadata["cursor_directions_exhausted"] is True
+    assert result.reply_checkpoints == []
 
 
 def test_zstd_decoding_error_is_retryable_transport_error() -> None:

--- a/tests/socials/test_instagram_sessionid_redaction.py
+++ b/tests/socials/test_instagram_sessionid_redaction.py
@@ -1,0 +1,21 @@
+from trr_backend.socials.instagram.scraper import _sessionid_fingerprint
+
+
+def test_sessionid_fingerprint_is_deterministic_without_leaking_value() -> None:
+    raw = "SECRET_VALUE"
+
+    fingerprint = _sessionid_fingerprint({"sessionid": raw})
+
+    assert fingerprint == _sessionid_fingerprint({"sessionid": raw})
+    assert raw not in fingerprint
+    assert raw[:8] not in fingerprint
+
+
+def test_sessionid_fingerprint_changes_for_different_sessionids() -> None:
+    assert _sessionid_fingerprint({"sessionid": "SECRET_VALUE"}) != _sessionid_fingerprint(
+        {"sessionid": "OTHER_SECRET_VALUE"}
+    )
+
+
+def test_sessionid_fingerprint_missing_sessionid_is_none() -> None:
+    assert _sessionid_fingerprint({}) == "none"

--- a/tests/socials/test_instagram_sessionid_redaction.py
+++ b/tests/socials/test_instagram_sessionid_redaction.py
@@ -17,5 +17,5 @@ def test_sessionid_fingerprint_changes_for_different_sessionids() -> None:
     )
 
 
-def test_sessionid_fingerprint_missing_sessionid_is_none() -> None:
+def test_sessionid_fingerprint_missing_sessionid_returns_none_sentinel() -> None:
     assert _sessionid_fingerprint({}) == "none"

--- a/trr_backend/socials/browser_cookie_refresh.py
+++ b/trr_backend/socials/browser_cookie_refresh.py
@@ -293,9 +293,7 @@ def resolve_chrome_profile_selection(profile_name: str) -> ChromeProfileSelectio
     try:
         profile_entries = tuple(chrome_base.iterdir())
     except OSError as exc:
-        raise ChromeProfileNotAvailableError(
-            f"Chrome profile directory is not readable: {chrome_base}"
-        ) from exc
+        raise ChromeProfileNotAvailableError(f"Chrome profile directory is not readable: {chrome_base}") from exc
 
     for entry in profile_entries:
         prefs_file = entry / "Preferences"

--- a/trr_backend/socials/browser_cookie_refresh.py
+++ b/trr_backend/socials/browser_cookie_refresh.py
@@ -290,7 +290,14 @@ def resolve_chrome_profile_selection(profile_name: str) -> ChromeProfileSelectio
     if not normalized_profile:
         raise ChromeProfileNotAvailableError("Chrome profile name is empty")
 
-    for entry in chrome_base.iterdir():
+    try:
+        profile_entries = tuple(chrome_base.iterdir())
+    except OSError as exc:
+        raise ChromeProfileNotAvailableError(
+            f"Chrome profile directory is not readable: {chrome_base}"
+        ) from exc
+
+    for entry in profile_entries:
         prefs_file = entry / "Preferences"
         if not prefs_file.is_file():
             continue
@@ -351,7 +358,9 @@ def open_cookie_refresh_context(
         reserve_social_auth_refresh_attempt(platform)
 
     resolved_profile = resolve_social_auth_chrome_profile(platform, profile_name)
-    effective_require_profile = social_auth_requires_chrome_profile(platform) if require_profile is None else require_profile
+    effective_require_profile = (
+        social_auth_requires_chrome_profile(platform) if require_profile is None else require_profile
+    )
     profile_selection: ChromeProfileSelection | None = None
     if resolved_profile:
         try:
@@ -413,7 +422,11 @@ def open_cookie_refresh_context(
         )
 
     browser = launch_browser(playwright, headless=headless)
-    context = browser.new_context(**context_kwargs)
+    try:
+        context = browser.new_context(**context_kwargs)
+    except Exception:
+        browser.close()
+        raise
     return CookieRefreshBrowserContext(context=context, browser=browser)
 
 
@@ -639,7 +652,8 @@ def refresh_simple_login_cookies(
                     reuse_valid, reuse_reason = validator(existing_cookies)
                     if not reuse_valid:
                         logger.info(
-                            "%s Chrome-profile cookies failed in-protocol validation (%s); falling through to scripted login",
+                            "%s Chrome-profile cookies failed in-protocol validation (%s); "
+                            "falling through to scripted login",
                             spec.platform,
                             reuse_reason or "unknown",
                         )

--- a/trr_backend/socials/control_plane/backfill_health.py
+++ b/trr_backend/socials/control_plane/backfill_health.py
@@ -48,7 +48,7 @@ from trr_backend.socials.control_plane.worker_health import (
     get_worker_health,
     is_queue_enabled,
 )
-from trr_backend.socials.instagram.auth_cooldown import get_active_cooldown
+from trr_backend.socials.instagram.auth_cooldown import get_active_cooldown, get_active_identity_cooldown
 from trr_backend.socials.pipelines.account_catalog.progress import (
     get_social_account_catalog_run_progress,
 )
@@ -314,6 +314,32 @@ def _build_run_entry(target: dict[str, Any], *, recent_log_limit: int) -> dict[s
     return entry
 
 
+def _instagram_identity_auth_cooldown() -> dict[str, Any]:
+    base = {
+        "platform": "instagram",
+        "active": False,
+        "state": "inactive",
+        "last_error_code": None,
+        "cooldown_until": None,
+        "authenticated_instagram_lanes_paused": False,
+    }
+    try:
+        cooldown = get_active_identity_cooldown("instagram")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("backfill_health: identity auth cooldown read failed: %s", exc)
+        return {**base, "error": f"{type(exc).__name__}: {exc}"}
+    if cooldown is None:
+        return base
+    metadata = cooldown.to_metadata()
+    return {
+        **base,
+        **metadata,
+        "active": True,
+        "state": "active",
+        "authenticated_instagram_lanes_paused": True,
+    }
+
+
 def get_backfill_health(
     *,
     run_limit: int = _DEFAULT_RUN_LIMIT,
@@ -363,6 +389,11 @@ def get_backfill_health(
     except Exception as exc:  # noqa: BLE001
         logger.warning("backfill_health: worker auth capabilities read failed: %s", exc)
         worker_auth = {"error": f"{type(exc).__name__}: {exc}"}
+    instagram_identity_cooldown = _instagram_identity_auth_cooldown()
+    worker_auth["instagram_identity_auth_cooldown"] = instagram_identity_cooldown
+    worker_auth["authenticated_instagram_lanes_paused"] = bool(
+        instagram_identity_cooldown.get("authenticated_instagram_lanes_paused")
+    )
 
     worker_health: dict[str, Any]
     try:
@@ -424,6 +455,7 @@ def get_backfill_health(
         "totals": totals,
         "runs": run_entries,
         "cooldowns": cooldowns,
+        "instagram_identity_auth_cooldown": instagram_identity_cooldown,
         "worker_auth": worker_auth,
         "worker_health": worker_health,
         "queue": queue_section,

--- a/trr_backend/socials/instagram/auth_cooldown.py
+++ b/trr_backend/socials/instagram/auth_cooldown.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 
 _COOLDOWN_POOL_NAME = "social_control"
 _COOLDOWN_TABLE = "social.account_auth_cooldown"
+_IDENTITY_COOLDOWN_HANDLE_PREFIX = "__identity__"
 
 # Escalation curve for cooldown_until = now() + exponential_backoff_delay(n).
 # Defaults: 1st block ~60s, 2nd ~120s, 3rd ~240s, ... capped at 1h. Jitter is
@@ -110,6 +111,10 @@ def _normalize_platform(platform: str | None) -> str:
 
 def _normalize_handle(account_handle: str | None) -> str:
     return str(account_handle or "").strip().lower().lstrip("@")
+
+
+def _identity_cooldown_handle(platform: str | None = "instagram") -> str:
+    return f"{_IDENTITY_COOLDOWN_HANDLE_PREFIX}:{_normalize_platform(platform)}"
 
 
 def classify_blocker_kind(error_code: str | None) -> str:
@@ -264,6 +269,19 @@ def record_auth_block(
     return cooldown
 
 
+def record_identity_auth_block(
+    platform: str | None = "instagram",
+    error_code: str | None = None,
+) -> AccountAuthCooldown | None:
+    """Record a platform identity-level auth block via the reserved handle."""
+    normalized_platform = _normalize_platform(platform)
+    return record_auth_block(
+        normalized_platform,
+        _identity_cooldown_handle(normalized_platform),
+        error_code,
+    )
+
+
 def get_active_cooldown(
     platform: str,
     account_handle: str,
@@ -308,6 +326,17 @@ def get_active_cooldown(
         return None
 
     return _row_to_cooldown(row)
+
+
+def get_active_identity_cooldown(
+    platform: str | None = "instagram",
+) -> AccountAuthCooldown | None:
+    """Return an active identity-level cooldown for the platform, if any."""
+    normalized_platform = _normalize_platform(platform)
+    return get_active_cooldown(
+        normalized_platform,
+        _identity_cooldown_handle(normalized_platform),
+    )
 
 
 def clear_cooldown(
@@ -381,3 +410,17 @@ def clear_cooldown(
             },
         )
     return cleared
+
+
+def clear_identity_cooldown(
+    platform: str | None = "instagram",
+    *,
+    force: bool = False,
+) -> bool:
+    """Clear a platform identity-level cooldown via the reserved handle."""
+    normalized_platform = _normalize_platform(platform)
+    return clear_cooldown(
+        normalized_platform,
+        _identity_cooldown_handle(normalized_platform),
+        force=force,
+    )

--- a/trr_backend/socials/instagram/auth_runtime.py
+++ b/trr_backend/socials/instagram/auth_runtime.py
@@ -284,6 +284,7 @@ def _inspect_instagram_cookie_health(cookies: dict[str, str]) -> dict[str, Any]:
                 delay=0.0,
                 request_timeout=(10, 20),
                 allow_browser_fallback=False,
+                allow_recovery=False,
             )
         payload_data = (payload or {}).get("data") if isinstance(payload, dict) else {}
         connection = (

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -242,7 +242,12 @@ def _classify_public_block_signal(terminal_reason: str | None) -> str:
         return PUBLIC_BLOCK_SIGNAL_NONE
     if normalized == BROWSER_SESSION_INVALIDATED_REASON or _browser_session_invalidated_text(normalized):
         return PUBLIC_BLOCK_SIGNAL_SESSION_INVALIDATED
-    if "429" in normalized or "rate_limit" in normalized or "too_many_requests" in normalized:
+    if (
+        "429" in normalized
+        or "1675004" in normalized
+        or "rate_limit" in normalized
+        or "too_many_requests" in normalized
+    ):
         return PUBLIC_BLOCK_SIGNAL_HTTP_429
     if "checkpoint" in normalized:
         return PUBLIC_BLOCK_SIGNAL_CHECKPOINT
@@ -2422,21 +2427,16 @@ def _public_relay_block_reason_from_response(
         return "login_required"
 
     if isinstance(payload, Mapping):
-        payload_text = " ".join(
-            str(value or "")
-            for value in (
-                payload.get("status"),
-                payload.get("message"),
-                payload.get("error"),
-                payload.get("error_message"),
-                payload.get("description"),
-            )
-        ).strip()
+        # GraphQL errors are commonly nested under data/errors/extensions. A
+        # serialized scan keeps the classifier shape-agnostic and catches Meta's
+        # rate-limit code even when no top-level message is present.
+        payload_text = json.dumps(payload, sort_keys=True, default=str)
         normalized_payload = payload_text.lower()
         if _browser_session_invalidated_text(payload_text):
             return BROWSER_SESSION_INVALIDATED_REASON
         if (
             "429" in normalized_payload
+            or "1675004" in normalized_payload
             or "rate_limit" in normalized_payload
             or "too many requests" in normalized_payload
         ):
@@ -2544,6 +2544,28 @@ def _record_global_api_cooldown(*, key: str, delay_seconds: float) -> None:
     delay = max(0.0, float(delay_seconds or 0))
     if delay <= 0:
         return
+    try:
+        from trr_backend.db import pg
+
+        with pg.db_connection(label="instagram-comments-rate-limit-cooldown", pool_name="session_control") as conn:
+            with pg.db_cursor(conn=conn) as cur:
+                cur.execute(
+                    """
+                    insert into social.ig_comment_rate_pace as p (rate_key, last_start, cooldown_until)
+                    values (%s, now(), now() + make_interval(secs => %s))
+                    on conflict (rate_key) do update
+                       set cooldown_until = greatest(
+                           coalesce(p.cooldown_until, '-infinity'::timestamptz),
+                           excluded.cooldown_until
+                       )
+                    """,
+                    (str(key or "instagram"), delay),
+                )
+    except Exception:  # noqa: BLE001
+        logger.debug("failed to persist global api cooldown", exc_info=True)
+
+    # Container-local fallback keeps this worker safe if Postgres later becomes
+    # unavailable; the persisted row remains authoritative across containers.
     path = _global_rate_cooldown_path(key)
     cooldown_until = time.monotonic() + delay
     with open(path, "a+", encoding="utf-8") as handle:
@@ -2608,6 +2630,28 @@ def _advisory_lock_keys_for(key: str) -> tuple[int, int]:
     return _RATE_LIMIT_ADVISORY_LOCK_NAMESPACE, key_int
 
 
+def _persisted_global_api_cooldown_remaining(key: str) -> float | None:
+    try:
+        from trr_backend.db import pg
+
+        with pg.db_connection(label="instagram-comments-rate-limit-cooldown-read", pool_name="session_control") as conn:
+            with pg.db_cursor(conn=conn) as cur:
+                cur.execute(
+                    """
+                    select extract(epoch from (cooldown_until - now()))::float8 as cooldown_seconds
+                    from social.ig_comment_rate_pace
+                    where rate_key = %s
+                    """,
+                    (str(key or "instagram"),),
+                )
+                row = cur.fetchone() or {}
+                value = row.get("cooldown_seconds")
+                return max(0.0, float(value)) if value is not None else 0.0
+    except Exception:  # noqa: BLE001
+        logger.debug("failed to read persisted global api cooldown", exc_info=True)
+        return None
+
+
 def _try_advisory_lock_pace(*, key: str, delay_seconds: float, deadline: float | None) -> dict[str, Any]:
     """Cross-container minimum-spacing pace via a DB-clock slot reservation.
 
@@ -2641,7 +2685,7 @@ def _try_advisory_lock_pace(*, key: str, delay_seconds: float, deadline: float |
         return {"acquired": False, "paced": True, "wait_ms": 0, "error": f"pg_import_failed:{exc}"}
     remaining_seconds = 0.0
     try:
-        with pg.db_connection(label="instagram-comments-rate-limit-pace", pool_name="social_control") as conn:
+        with pg.db_connection(label="instagram-comments-rate-limit-pace", pool_name="session_control") as conn:
             with pg.db_cursor(conn=conn) as cur:
                 # Atomic slot reservation. The row-level lock on the upsert is the
                 # cross-container serializer; it is held only for this statement,
@@ -2653,14 +2697,19 @@ def _try_advisory_lock_pace(*, key: str, delay_seconds: float, deadline: float |
                     insert into social.ig_comment_rate_pace as p (rate_key, last_start)
                     values (%s, now())
                     on conflict (rate_key) do update
-                       set last_start = greatest(p.last_start + make_interval(secs => %s), now())
-                    returning extract(epoch from (last_start - now()))::float8
+                       set last_start = greatest(
+                           p.last_start + make_interval(secs => %s),
+                           now(),
+                           coalesce(p.cooldown_until, now())
+                       )
+                    returning extract(epoch from (last_start - now()))::float8 as wait_seconds
                     """,
                     (str(key or "instagram"), delay),
                 )
-                row = cur.fetchone()
-                if row and row[0] is not None:
-                    remaining_seconds = max(0.0, float(row[0]))
+                row = cur.fetchone() or {}
+                wait_seconds = row.get("wait_seconds")
+                if wait_seconds is not None:
+                    remaining_seconds = max(0.0, float(wait_seconds))
     except Exception as exc:  # noqa: BLE001
         return {"acquired": False, "paced": True, "wait_ms": 0, "error": str(exc)}
     # Connection returned to the pool above; wait OUTSIDE the lock so concurrent
@@ -2675,6 +2724,19 @@ def _try_advisory_lock_pace(*, key: str, delay_seconds: float, deadline: float |
                 time.sleep(deadline_remaining)
                 return {"acquired": True, "paced": False, "wait_ms": wait_ms, "error": None}
         time.sleep(remaining_seconds)
+        # A sibling can record a 429 while this reservation is waiting. Recheck
+        # after the connection is returned so an already-queued request does not
+        # leak through the newly persisted cooldown.
+        cooldown_remaining = _persisted_global_api_cooldown_remaining(key)
+        if cooldown_remaining and cooldown_remaining > 0:
+            deadline_remaining = _deadline_remaining_seconds(deadline)
+            if deadline_remaining is not None:
+                if deadline_remaining <= 0:
+                    return {"acquired": True, "paced": False, "wait_ms": wait_ms, "error": None}
+                if cooldown_remaining > deadline_remaining:
+                    time.sleep(deadline_remaining)
+                    return {"acquired": True, "paced": False, "wait_ms": wait_ms, "error": None}
+            time.sleep(cooldown_remaining)
     return {"acquired": True, "paced": True, "wait_ms": wait_ms, "error": None}
 
 
@@ -3706,6 +3768,8 @@ class InstagramCommentsScraplingFetcher:
         # falling back to terminal repeated_cursor.
         cursor_directions_attempted: set[str] = set()
         cursor_direction_swaps = 0
+        top_level_cursor_directions_exhausted = False
+        reply_cursor_directions_exhausted = False
         # 0 == unlimited: skip wall-clock cuts entirely and let cursor
         # exhaustion (repeated_cursor / no-new-rows) drive the stop.
         _comment_pagination_budget_seconds = _resolve_positive_float_env(
@@ -4184,6 +4248,9 @@ class InstagramCommentsScraplingFetcher:
                         ),
                         deadline=reply_fetch_deadline,
                     )
+                    reply_cursor_directions_exhausted = reply_cursor_directions_exhausted or bool(
+                        (replies_result.diagnostic_metadata or {}).get("cursor_directions_exhausted")
+                    )
                     if (
                         reply_tail_deadline is not None
                         and replies_result.fetch_reason == "pagination_deadline_exceeded"
@@ -4384,6 +4451,7 @@ class InstagramCommentsScraplingFetcher:
                     "min_id" in cursor_directions_attempted and "max_id" in cursor_directions_attempted
                 )
                 if both_directions_attempted:
+                    top_level_cursor_directions_exhausted = True
                     retryable = retryable and not has_gap
                 else:
                     retryable = retryable or has_gap
@@ -4443,6 +4511,9 @@ class InstagramCommentsScraplingFetcher:
             )
             reply_checkpoints.extend(
                 item for item in residual_child_metadata.get("reply_checkpoints", []) if isinstance(item, dict)
+            )
+            reply_cursor_directions_exhausted = reply_cursor_directions_exhausted or bool(
+                residual_child_metadata.get("cursor_directions_exhausted")
             )
             fetch_failed = fetch_failed or bool(residual_child_metadata.get("fetch_failed"))
             auth_failed = auth_failed or bool(residual_child_metadata.get("auth_failed"))
@@ -4748,7 +4819,10 @@ class InstagramCommentsScraplingFetcher:
                     fetch_reason = "hidden_comments_unavailable_reconciled"
                 else:
                     fetch_failed = True
-                    retryable = True
+                    retryable = not (
+                        fetch_reason == "pagination_repeated_cursor"
+                        and (top_level_cursor_directions_exhausted or reply_cursor_directions_exhausted)
+                    )
                     if not fetch_reason:
                         fetch_reason = (
                             "reply_tail_incomplete" if current_missing_reply_count > 0 else "hidden_comments_unresolved"
@@ -4851,6 +4925,9 @@ class InstagramCommentsScraplingFetcher:
             "child_replies": child_reply_count(comments),
             "challenge_stop": bool(auth_failed),
             "session_invalidated": bool(browser_session_invalidated_detected),
+            "cursor_directions_exhausted": bool(
+                top_level_cursor_directions_exhausted or reply_cursor_directions_exhausted
+            ),
             "memory_guardrail": current_memory_guardrail_metadata(),
         }
         if single_session_rendered_metadata:
@@ -4899,6 +4976,7 @@ class InstagramCommentsScraplingFetcher:
         reply_checkpoints: list[dict[str, Any]] = []
         comments_fetched = 0
         merged_reply_count = 0
+        reply_cursor_directions_exhausted = False
         diagnostic_metadata: dict[str, Any] = {}
 
         for comment in persisted_top_level_comments:
@@ -4962,6 +5040,9 @@ class InstagramCommentsScraplingFetcher:
                     resume_cursor=reply_resume_cursors_by_parent.get(comment_id),
                     resume_cursor_param=reply_resume_cursor_params_by_parent.get(comment_id),
                     deadline=reply_fetch_deadline,
+                )
+                reply_cursor_directions_exhausted = reply_cursor_directions_exhausted or bool(
+                    (replies_result.diagnostic_metadata or {}).get("cursor_directions_exhausted")
                 )
                 if (
                     reply_tail_deadline is not None
@@ -5052,7 +5133,9 @@ class InstagramCommentsScraplingFetcher:
                 }
             else:
                 fetch_failed = True
-                retryable = True
+                retryable = not (
+                    fetch_reason == "pagination_repeated_cursor" and reply_cursor_directions_exhausted
+                )
                 fetch_reason = fetch_reason or "reply_tail_incomplete"
         elif fetch_reason in {
             "pagination_deadline_exceeded",
@@ -5075,7 +5158,10 @@ class InstagramCommentsScraplingFetcher:
             retryable=retryable,
             reply_checkpoints=reply_checkpoints,
             top_level_checkpoint=None,
-            diagnostic_metadata=diagnostic_metadata,
+            diagnostic_metadata={
+                **diagnostic_metadata,
+                "cursor_directions_exhausted": reply_cursor_directions_exhausted,
+            },
         )
 
     async def _fetch_residual_child_reply_lanes(
@@ -5104,6 +5190,7 @@ class InstagramCommentsScraplingFetcher:
             "auth_failed": False,
             "retryable": False,
             "fetch_reason": None,
+            "cursor_directions_exhausted": False,
         }
         if target_count is None or flattened_comment_count(comments) >= target_count:
             return metadata
@@ -5191,6 +5278,9 @@ class InstagramCommentsScraplingFetcher:
             metadata["fetch_failed"] = bool(metadata.get("fetch_failed")) or replies_result.fetch_failed
             metadata["auth_failed"] = bool(metadata.get("auth_failed")) or replies_result.auth_failed
             metadata["retryable"] = bool(metadata.get("retryable")) or replies_result.retryable
+            metadata["cursor_directions_exhausted"] = bool(
+                metadata.get("cursor_directions_exhausted")
+            ) or bool((replies_result.diagnostic_metadata or {}).get("cursor_directions_exhausted"))
             if replies_result.fetch_reason and not metadata.get("fetch_reason"):
                 metadata["fetch_reason"] = replies_result.fetch_reason
             if replies_result.fetch_failed and replies_result.retryable and not replies_result.reply_checkpoints:
@@ -6219,6 +6309,8 @@ class InstagramCommentsScraplingFetcher:
                         attempt["location"] = _safe_location(response)
                         if await _retry_parent_relay_soft_failure("graphql_relay_http_error", response):
                             continue
+                        if attempt.get("block_reason"):
+                            break
                         if _try_page_size_downgrade("graphql_relay_http_error"):
                             continue
                         attempt.setdefault("reason", "graphql_relay_http_error")
@@ -6227,6 +6319,8 @@ class InstagramCommentsScraplingFetcher:
                     if payload is None:
                         if await _retry_parent_relay_soft_failure("graphql_relay_non_json_response", response):
                             continue
+                        if attempt.get("block_reason"):
+                            break
                         if _try_page_size_downgrade("graphql_relay_non_json_response"):
                             continue
                         attempt.setdefault("reason", "graphql_relay_non_json_response")
@@ -6238,6 +6332,8 @@ class InstagramCommentsScraplingFetcher:
                             payload_ref=payload,
                         ):
                             continue
+                        if attempt.get("block_reason"):
+                            break
                         if _try_page_size_downgrade("graphql_relay_error_payload"):
                             continue
                         attempt.setdefault("reason", "graphql_relay_error_payload")
@@ -6636,6 +6732,9 @@ class InstagramCommentsScraplingFetcher:
                     if status_code >= 400 or 300 <= status_code < 400:
                         if await _retry_child_relay_soft_failure("graphql_child_relay_http_error", response):
                             continue
+                        if metadata.get("block_reason"):
+                            stop_reason = str(metadata["block_reason"])
+                            break
                         if _try_child_page_size_downgrade("graphql_child_relay_http_error"):
                             continue
                         stop_reason = str(metadata.get("reason") or "graphql_child_relay_http_error")
@@ -6644,6 +6743,9 @@ class InstagramCommentsScraplingFetcher:
                     if payload is None:
                         if await _retry_child_relay_soft_failure("graphql_child_relay_non_json_response", response):
                             continue
+                        if metadata.get("block_reason"):
+                            stop_reason = str(metadata["block_reason"])
+                            break
                         if _try_child_page_size_downgrade("graphql_child_relay_non_json_response"):
                             continue
                         stop_reason = str(metadata.get("reason") or "graphql_child_relay_non_json_response")
@@ -6655,6 +6757,9 @@ class InstagramCommentsScraplingFetcher:
                             payload_ref=payload,
                         ):
                             continue
+                        if metadata.get("block_reason"):
+                            stop_reason = str(metadata["block_reason"])
+                            break
                         if _try_child_page_size_downgrade("graphql_child_relay_error_payload"):
                             continue
                         stop_reason = str(metadata.get("reason") or "graphql_child_relay_error_payload")
@@ -7272,6 +7377,7 @@ class InstagramCommentsScraplingFetcher:
         # declaring repeated_cursor terminal.
         cursor_directions_attempted: set[str] = set()
         cursor_direction_swaps = 0
+        cursor_directions_exhausted = False
         last_attempt_count = 0
         last_reply_cursor: str | None = None
         last_reply_cursor_param: str | None = None
@@ -7417,6 +7523,7 @@ class InstagramCommentsScraplingFetcher:
                     "min_id" in cursor_directions_attempted and "max_id" in cursor_directions_attempted
                 )
                 if both_directions_attempted:
+                    cursor_directions_exhausted = True
                     retryable = retryable and not has_gap
                 else:
                     retryable = retryable or has_gap
@@ -7499,7 +7606,10 @@ class InstagramCommentsScraplingFetcher:
             request_count=self._request_count,
             retryable=retryable,
             reply_checkpoints=reply_checkpoints,
-            diagnostic_metadata=diagnostic_metadata,
+            diagnostic_metadata={
+                **diagnostic_metadata,
+                "cursor_directions_exhausted": cursor_directions_exhausted,
+            },
         )
 
     async def _fetch_rendered_replies_for_parent_comment(

--- a/trr_backend/socials/instagram/comments_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/comments_scrapling/fetcher.py
@@ -5133,9 +5133,7 @@ class InstagramCommentsScraplingFetcher:
                 }
             else:
                 fetch_failed = True
-                retryable = not (
-                    fetch_reason == "pagination_repeated_cursor" and reply_cursor_directions_exhausted
-                )
+                retryable = not (fetch_reason == "pagination_repeated_cursor" and reply_cursor_directions_exhausted)
                 fetch_reason = fetch_reason or "reply_tail_incomplete"
         elif fetch_reason in {
             "pagination_deadline_exceeded",
@@ -5278,9 +5276,9 @@ class InstagramCommentsScraplingFetcher:
             metadata["fetch_failed"] = bool(metadata.get("fetch_failed")) or replies_result.fetch_failed
             metadata["auth_failed"] = bool(metadata.get("auth_failed")) or replies_result.auth_failed
             metadata["retryable"] = bool(metadata.get("retryable")) or replies_result.retryable
-            metadata["cursor_directions_exhausted"] = bool(
-                metadata.get("cursor_directions_exhausted")
-            ) or bool((replies_result.diagnostic_metadata or {}).get("cursor_directions_exhausted"))
+            metadata["cursor_directions_exhausted"] = bool(metadata.get("cursor_directions_exhausted")) or bool(
+                (replies_result.diagnostic_metadata or {}).get("cursor_directions_exhausted")
+            )
             if replies_result.fetch_reason and not metadata.get("fetch_reason"):
                 metadata["fetch_reason"] = replies_result.fetch_reason
             if replies_result.fetch_failed and replies_result.retryable and not replies_result.reply_checkpoints:

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -3137,9 +3137,7 @@ def _enqueue_auto_auth_fallback_targets(
 ) -> dict[str, Any]:
     from trr_backend.socials.pipelines.comments.instagram import enqueue_instagram_comments_audit_cursor_retries
 
-    targets = list(
-        dict.fromkeys(str(item or "").strip() for item in source_ids if str(item or "").strip())
-    )
+    targets = list(dict.fromkeys(str(item or "").strip() for item in source_ids if str(item or "").strip()))
     if not targets:
         return {"requested": False, "created_job_count": 0, "target_source_ids": []}
     return enqueue_instagram_comments_audit_cursor_retries(
@@ -3174,9 +3172,7 @@ def _enqueue_auto_public_recovery_targets(
         _append_instagram_comments_public_recovery_targets_to_active_run,
     )
 
-    targets = list(
-        dict.fromkeys(str(item or "").strip() for item in source_ids if str(item or "").strip())
-    )
+    targets = list(dict.fromkeys(str(item or "").strip() for item in source_ids if str(item or "").strip()))
     if not targets:
         return {"requested": False, "created_job_count": 0, "target_source_ids": []}
     return _append_instagram_comments_public_recovery_targets_to_active_run(
@@ -4690,12 +4686,8 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 # this point so they do not advance the counter spuriously.
                 posts_since_last_warmup += 1
                 normalized_result_shortcode = str(shortcode or "").strip()
-                normalized_result_fetch_reason = str(
-                    result.fetch_reason or "retryable_post_fetch_failed"
-                ).strip()
-                public_block_signal = (
-                    str(getattr(result, "public_block_signal", "none") or "none").strip().lower()
-                )
+                normalized_result_fetch_reason = str(result.fetch_reason or "retryable_post_fetch_failed").strip()
+                public_block_signal = str(getattr(result, "public_block_signal", "none") or "none").strip().lower()
                 is_genuine_public_block = public_comments_mode and public_block_signal != "none"
                 if is_genuine_public_block and normalized_result_shortcode:
                     if normalized_result_shortcode not in incomplete_target_source_ids:
@@ -5394,9 +5386,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                             )
 
                         public_recovery_targets = (
-                            retryable_incomplete_targets
-                            if _auto_public_recovery_enabled(config)
-                            else []
+                            retryable_incomplete_targets if _auto_public_recovery_enabled(config) else []
                         )
                         public_recovery_result: dict[str, Any] | None = None
                         if public_recovery_targets:

--- a/trr_backend/socials/instagram/comments_scrapling/job_runner.py
+++ b/trr_backend/socials/instagram/comments_scrapling/job_runner.py
@@ -183,6 +183,13 @@ def _comments_auto_refill_dispatch_limit(config: Mapping[str, Any]) -> int:
     return max(1, min(requested, 2000))
 
 
+def _dispatch_due_social_jobs(*, run_id: str, limit: int) -> dict[str, Any]:
+    """Refill comments jobs through the cap-aware control-plane owner."""
+    from trr_backend.socials.control_plane.dispatch_runtime import dispatch_due_social_jobs as impl
+
+    return impl(run_id=run_id, limit=limit)
+
+
 def _ramp_public_comments_worker_cap(*, run_id: str) -> dict[str, Any]:
     """Recompute the run's public-blocked ratio and ramp its active worker cap.
 
@@ -1310,16 +1317,16 @@ def _load_comment_target_metadata(
             p.id::text as materialized_post_id,
             nullif(p.source_account, '') as source_account,
             nullif(p.username, '') as username,
-            nullif(coalesce(to_jsonb(p) ->> 'owner_username', ''), '') as owner_username,
+            nullif(p.owner_username, '') as owner_username,
             coalesce(p.collaborators, '[]'::jsonb) as collaborators,
-            coalesce(to_jsonb(p) -> 'collaborators_detail', '[]'::jsonb) as collaborators_detail,
+            coalesce(p.collaborators_detail, '[]'::jsonb) as collaborators_detail,
             nullif(p.media_type, '') as media_type,
-            nullif(coalesce(to_jsonb(p) ->> 'product_type', p.raw_data ->> 'product_type', ''), '') as product_type,
+            nullif(coalesce(p.product_type, p.raw_data ->> 'product_type', ''), '') as product_type,
             'materialized'::text as profile_source_surface,
             case
               when ltrim(lower(coalesce(nullif(p.source_account, ''), '')), '@') = %s then 'profile_source_account'
               when ltrim(
-                lower(coalesce(nullif(p.username, ''), nullif(to_jsonb(p) ->> 'owner_username', ''), '')),
+                lower(coalesce(nullif(p.username, ''), nullif(p.owner_username, ''), '')),
                 '@'
               ) = %s
                 then 'owner_username'
@@ -1330,7 +1337,7 @@ def _load_comment_target_metadata(
             case
               when ltrim(lower(coalesce(nullif(p.source_account, ''), '')), '@') = %s then 4
               when ltrim(
-                lower(coalesce(nullif(p.username, ''), nullif(to_jsonb(p) ->> 'owner_username', ''), '')),
+                lower(coalesce(nullif(p.username, ''), nullif(p.owner_username, ''), '')),
                 '@'
               ) = %s then 3
               else 1
@@ -1356,12 +1363,11 @@ def _load_comment_target_metadata(
             ) as owner_username,
             coalesce(nullif(cp.collaborators, '[]'::jsonb), jsonb_build_array(m.collaborator_handle)) as collaborators,
             coalesce(
-              nullif(to_jsonb(cp) -> 'collaborators_detail', '[]'::jsonb),
               nullif(cp.raw_data -> 'collaborators_detail', '[]'::jsonb),
               jsonb_build_array(jsonb_build_object('username', m.collaborator_handle, 'source', m.collaborator_source))
             ) as collaborators_detail,
             nullif(cp.media_type, '') as media_type,
-            nullif(coalesce(to_jsonb(cp) ->> 'product_type', cp.raw_data ->> 'product_type', ''), '') as product_type,
+            nullif(coalesce(cp.raw_data ->> 'product_type', ''), '') as product_type,
             'catalog'::text as profile_source_surface,
             'catalog_collaborator'::text as profile_match_mode,
             nullif(m.collaborator_handle, '') as catalog_collaborator_handle,
@@ -1536,8 +1542,7 @@ def _load_public_replay_guard_rows(
             and a.cursor_param is null
             and (
               a.cursor_stop_reason = any(%s::text[])
-              or coalesce(a.cursor_payload ->> 'fallback_blocked_reason', '') =
-                'public_comments_partial_requires_approval'
+              or coalesce(a.cursor_payload ->> 'fallback_blocked_reason', '') = any(%s::text[])
             )
           group by a.shortcode
         )
@@ -1554,7 +1559,11 @@ def _load_public_replay_guard_rows(
           on ac.shortcode = r.shortcode
         order by r.sort_order
         """,
-        [requested, sorted(_PUBLIC_REPLAY_GUARD_AUDIT_STOP_REASONS)],
+        [
+            requested,
+            sorted(_PUBLIC_REPLAY_GUARD_AUDIT_STOP_REASONS),
+            sorted(_PUBLIC_REPLAY_GUARD_AUDIT_STOP_REASONS),
+        ],
     )
     guard_rows: dict[str, dict[str, Any]] = {}
     for row in rows:
@@ -1883,6 +1892,10 @@ def _public_blocked_pause_should_trigger(
         if ratio >= _PUBLIC_BLOCKED_PAUSE_RATIO:
             return True
     return False
+
+
+def _public_blocked_shard_should_stop(*, signal: str, consecutive: int) -> bool:
+    return signal == "http_429" or consecutive >= _PUBLIC_BLOCKED_EARLY_STOP_CONSECUTIVE
 
 
 def _recommend_public_blocked_pause(
@@ -3124,7 +3137,9 @@ def _enqueue_auto_auth_fallback_targets(
 ) -> dict[str, Any]:
     from trr_backend.socials.pipelines.comments.instagram import enqueue_instagram_comments_audit_cursor_retries
 
-    targets = [str(item or "").strip() for item in source_ids if str(item or "").strip()]
+    targets = list(
+        dict.fromkeys(str(item or "").strip() for item in source_ids if str(item or "").strip())
+    )
     if not targets:
         return {"requested": False, "created_job_count": 0, "target_source_ids": []}
     return enqueue_instagram_comments_audit_cursor_retries(
@@ -3150,27 +3165,28 @@ def _auto_public_recovery_enabled(config: Mapping[str, Any]) -> bool:
 
 def _enqueue_auto_public_recovery_targets(
     *,
+    run_id: str,
+    source_job_id: str,
     account_handle: str,
     source_ids: Sequence[str],
 ) -> dict[str, Any]:
-    from trr_backend.socials.pipelines.comments.instagram import enqueue_instagram_comments_audit_cursor_retries
+    from trr_backend.socials.pipelines.comments.instagram import (
+        _append_instagram_comments_public_recovery_targets_to_active_run,
+    )
 
-    targets = [str(item or "").strip() for item in source_ids if str(item or "").strip()]
+    targets = list(
+        dict.fromkeys(str(item or "").strip() for item in source_ids if str(item or "").strip())
+    )
     if not targets:
         return {"requested": False, "created_job_count": 0, "target_source_ids": []}
-    return enqueue_instagram_comments_audit_cursor_retries(
+    return _append_instagram_comments_public_recovery_targets_to_active_run(
+        run_id=run_id,
         account_handle=account_handle,
-        limit=len(targets),
-        shortcodes=targets,
+        target_source_ids=targets,
         batch_size=1,
-        max_comments_per_post=0,
-        comments_load_strategy="public_relay",
-        skip_launch_auth_probe=True,
-        dry_run=False,
-        attach_to_active_run=True,
         dispatch_immediately=True,
-        force_rerun_existing=True,
         initiated_by="comments-public-auto-recovery",
+        exclude_active_job_id=source_job_id,
     )
 
 
@@ -4673,9 +4689,27 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                 # mid-run-warmup post counter. Skip-paths above continued before
                 # this point so they do not advance the counter spuriously.
                 posts_since_last_warmup += 1
+                normalized_result_shortcode = str(shortcode or "").strip()
+                normalized_result_fetch_reason = str(
+                    result.fetch_reason or "retryable_post_fetch_failed"
+                ).strip()
+                public_block_signal = (
+                    str(getattr(result, "public_block_signal", "none") or "none").strip().lower()
+                )
+                is_genuine_public_block = public_comments_mode and public_block_signal != "none"
+                if is_genuine_public_block and normalized_result_shortcode:
+                    if normalized_result_shortcode not in incomplete_target_source_ids:
+                        incomplete_target_source_ids.append(normalized_result_shortcode)
+                    incomplete_fetch_reasons[normalized_result_shortcode] = normalized_result_fetch_reason
+                    if normalized_result_shortcode not in public_blocked_target_source_ids:
+                        public_blocked_target_source_ids.append(normalized_result_shortcode)
+                    public_blocked_fetch_reasons[normalized_result_shortcode] = normalized_result_fetch_reason
+                    public_blocked_genuine_signals[normalized_result_shortcode] = public_block_signal
+                    if normalized_result_shortcode not in public_blocked_genuine_target_source_ids:
+                        public_blocked_genuine_target_source_ids.append(normalized_result_shortcode)
                 if result.fetch_failed and not result.comments:
-                    normalized_incomplete_shortcode = str(shortcode or "").strip()
-                    normalized_fetch_reason = str(result.fetch_reason or "retryable_post_fetch_failed").strip()
+                    normalized_incomplete_shortcode = normalized_result_shortcode
+                    normalized_fetch_reason = normalized_result_fetch_reason
                     result_metadata = _fetch_result_diagnostic_metadata(result)
                     public_comments_metadata = _fetch_result_public_comments_metadata(result)
                     target_metadata = target_metadata_by_shortcode.get(shortcode) or {}
@@ -4693,7 +4727,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     ):
                         coauthor_status_only_target_source_ids.append(normalized_incomplete_shortcode)
                     consecutive_post_fetch_failures += 1
-                    if bool(result.retryable):
+                    if bool(result.retryable) and not is_genuine_public_block:
                         if normalized_incomplete_shortcode:
                             incomplete_target_source_ids.append(normalized_incomplete_shortcode)
                             incomplete_fetch_reasons[normalized_incomplete_shortcode] = normalized_fetch_reason
@@ -4752,7 +4786,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                             extra_metadata=progress_metadata_common(),
                         )
                         continue
-                    if public_comments_mode and normalized_fetch_reason == "public_blocked":
+                    if is_genuine_public_block:
                         # A public_blocked post stays retryable. It is appended to
                         # BOTH the incomplete-target metadata AND the public-blocked
                         # accumulators, never written as a missing-comment marker, and
@@ -4764,19 +4798,10 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                         # ordering with the fetcher. "none" => SOFT miss (retry with
                         # backoff); any other value => GENUINE source block that may
                         # gate early-stop / run-pause.
-                        public_block_signal = (
-                            str(getattr(result, "public_block_signal", "none") or "none").strip().lower()
-                        )
-                        is_genuine_public_block = public_block_signal != "none"
                         if normalized_incomplete_shortcode:
-                            incomplete_target_source_ids.append(normalized_incomplete_shortcode)
                             incomplete_fetch_reasons[normalized_incomplete_shortcode] = normalized_fetch_reason
                             zero_comment_incomplete_target_source_ids.append(normalized_incomplete_shortcode)
-                            public_blocked_target_source_ids.append(normalized_incomplete_shortcode)
                             public_blocked_fetch_reasons[normalized_incomplete_shortcode] = normalized_fetch_reason
-                            if is_genuine_public_block:
-                                public_blocked_genuine_signals[normalized_incomplete_shortcode] = public_block_signal
-                                public_blocked_genuine_target_source_ids.append(normalized_incomplete_shortcode)
                         public_blocked_checked_count += 1
                         public_blocked_recovered_comments += recovered_comments
                         if recovered_comments <= 0:
@@ -4878,13 +4903,15 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                             force=index == len(target_source_ids),
                             extra_metadata=progress_metadata_common(),
                         )
-                        # Early stop: bail out of the current shard only after enough
-                        # consecutive GENUINE-block posts (public_block_signal != none)
-                        # — a soft-empty streak no longer breaks the loop, so soft
+                        # A genuine 429 stops immediately; other genuine public
+                        # blocks retain the bounded consecutive threshold. Soft
                         # misses keep being attempted instead of abandoning the shard.
                         # The remaining targets stay retryable (resume re-adds them
                         # from public_blocked_target_source_ids).
-                        if public_blocked_genuine_consecutive_count >= _PUBLIC_BLOCKED_EARLY_STOP_CONSECUTIVE:
+                        if _public_blocked_shard_should_stop(
+                            signal=public_block_signal,
+                            consecutive=public_blocked_genuine_consecutive_count,
+                        ):
                             logger.warning(
                                 "Stopping Instagram comments shard early after %s consecutive GENUINE public-blocked "
                                 "posts: job_id=%s run_id=%s checked=%s genuine_blocked=%s last_signal=%s",
@@ -5200,6 +5227,19 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                     force=index == len(target_source_ids),
                     extra_metadata=progress_metadata_common(),
                 )
+                if is_genuine_public_block and _public_blocked_shard_should_stop(
+                    signal=public_block_signal,
+                    consecutive=public_blocked_genuine_consecutive_count,
+                ):
+                    logger.warning(
+                        "Stopping Instagram comments shard immediately after persisting partial comments from "
+                        "a GENUINE public block: job_id=%s run_id=%s shortcode=%s signal=%s",
+                        job_id,
+                        run_id,
+                        shortcode,
+                        public_block_signal,
+                    )
+                    break
 
             retryable_incomplete_targets = _retryable_incomplete_target_source_ids(
                 incomplete_target_source_ids=incomplete_target_source_ids,
@@ -5324,12 +5364,45 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
                                 },
                             )
 
+                        if has_genuine_block and attempts_remaining:
+                            logger.info(
+                                "Instagram public comments blocked; requeuing saved partial/cursor work after "
+                                "cooldown: job_id=%s attempt=%s/%s targets=%s signals=%s",
+                                job_id,
+                                attempt_count,
+                                max_attempts,
+                                retryable_incomplete_targets,
+                                sorted(unresolved_genuine_block_signals),
+                            )
+                            raise CommentsScraplingRuntimeError(
+                                "Instagram public comments blocked; retrying after cooldown.",
+                                error_code="instagram_comments_public_retryable",
+                                retryable=True,
+                                runtime_metadata={
+                                    "incomplete_target_source_ids": retryable_incomplete_targets,
+                                    "incomplete_fetch_reasons": retry_fetch_reasons,
+                                    "retry_target_source_ids": retryable_incomplete_targets,
+                                    "completion_status": "public_comments_blocked_retryable",
+                                    "current_comments_fetched": comments_fetched,
+                                    "fallback_policy": "public_retry_after_cooldown",
+                                    "auth_fallback_policy": "not_considered",
+                                    "public_block_signal_values": sorted(unresolved_genuine_block_signals),
+                                    "attempt_count": attempt_count,
+                                    "max_attempts": max_attempts,
+                                    "target_source_ids_count": len(target_source_ids),
+                                },
+                            )
+
                         public_recovery_targets = (
-                            retryable_incomplete_targets if _auto_public_recovery_enabled(config) else []
+                            retryable_incomplete_targets
+                            if _auto_public_recovery_enabled(config)
+                            else []
                         )
                         public_recovery_result: dict[str, Any] | None = None
                         if public_recovery_targets:
                             public_recovery_result = _enqueue_auto_public_recovery_targets(
+                                run_id=run_id,
+                                source_job_id=job_id,
                                 account_handle=account_handle,
                                 source_ids=public_recovery_targets,
                             )
@@ -5588,7 +5661,7 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
         auto_refill_limit = _comments_auto_refill_dispatch_limit(config)
         if auto_refill_limit > 0 and run_id:
             try:
-                dispatch_result = repo.dispatch_due_social_jobs(run_id=run_id, limit=auto_refill_limit)
+                dispatch_result = _dispatch_due_social_jobs(run_id=run_id, limit=auto_refill_limit)
                 logger.info(
                     "Auto-refilled Instagram comments workers after shard completion: job_id=%s run_id=%s "
                     "limit=%s dispatched=%s",
@@ -5714,10 +5787,13 @@ def run_instagram_comments_scrapling_job(job: dict[str, Any], *, worker_id: str 
             auth_failed_target_source_ids=[] if single_session_load_all else auth_failed_target_source_ids,
             public_blocked_target_source_ids=public_blocked_target_source_ids,
         )
-        retry_target_source_ids = retry_incomplete_targets or [
-            str(item or "").strip()
-            for item in ((retry_rebalance or {}).get("remaining_target_source_ids") or [])
-            if str(item or "").strip()
+        retry_target_source_ids = [
+            *retry_incomplete_targets,
+            *[
+                str(item or "").strip()
+                for item in ((retry_rebalance or {}).get("remaining_target_source_ids") or [])
+                if str(item or "").strip()
+            ],
         ]
         retry_target_source_ids = list(dict.fromkeys(retry_target_source_ids))
         if can_retry and retry_target_source_ids:

--- a/trr_backend/socials/instagram/constants.py
+++ b/trr_backend/socials/instagram/constants.py
@@ -86,6 +86,7 @@ def _instagram_post_is_reel(
         )
     return any(str(value or "").strip().lower() in _REEL_MARKERS for value in candidates)
 
+
 PROFILE_POSTS_DOC_IDS_ENV = "SOCIAL_INSTAGRAM_PROFILE_POSTS_DOC_IDS"
 PROFILE_POSTS_FRIENDLY_NAME = "PolarisProfilePostsQuery"
 PROFILE_POSTS_ROOT_FIELD_NAME = "xdt_api__v1__feed__user_timeline_graphql_connection"

--- a/trr_backend/socials/instagram/constants.py
+++ b/trr_backend/socials/instagram/constants.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from enum import StrEnum
 
 
@@ -38,9 +39,52 @@ COMMENTS_URL = "https://www.instagram.com/api/v1/media/{media_id}/comments/"
 COMMENT_REPLIES_URL = "https://www.instagram.com/api/v1/media/{media_id}/comments/{comment_id}/child_comments/"
 PROFILE_PAGE_URL = "https://www.instagram.com/{username}/"
 PERMALINK_URL = "https://www.instagram.com/p/{shortcode}/"
+REEL_PERMALINK_URL = "https://www.instagram.com/reels/{shortcode}/"
 COMMENT_SORT_ORDER_ENV = "SOCIAL_INSTAGRAM_COMMENTS_SORT_ORDER"
 DEFAULT_COMMENT_SORT_ORDER = "recent"
 VALID_COMMENT_SORT_ORDERS = frozenset({"popular", "recent"})
+_REEL_MARKERS = frozenset({"clip", "clips", "reel", "reels"})
+
+
+def instagram_post_permalink(
+    shortcode: str,
+    *,
+    post_format: object | None = None,
+    media_type: object | None = None,
+    explicit: object | None = None,
+    raw_data: Mapping[str, object] | None = None,
+) -> str | None:
+    explicit_url = str(explicit or "").strip()
+    if explicit_url.startswith(("http://", "https://")):
+        return explicit_url
+    normalized_shortcode = str(shortcode or "").strip().strip("/")
+    if not normalized_shortcode:
+        return None
+    if _instagram_post_is_reel(post_format=post_format, media_type=media_type, raw_data=raw_data):
+        return REEL_PERMALINK_URL.format(shortcode=normalized_shortcode)
+    return PERMALINK_URL.format(shortcode=normalized_shortcode)
+
+
+def _instagram_post_is_reel(
+    *,
+    post_format: object | None,
+    media_type: object | None,
+    raw_data: Mapping[str, object] | None,
+) -> bool:
+    candidates = [post_format, media_type]
+    if isinstance(raw_data, Mapping):
+        candidates.extend(
+            raw_data.get(key)
+            for key in (
+                "post_format",
+                "media_type",
+                "product_type",
+                "productType",
+                "productTypeName",
+                "__typename",
+            )
+        )
+    return any(str(value or "").strip().lower() in _REEL_MARKERS for value in candidates)
 
 PROFILE_POSTS_DOC_IDS_ENV = "SOCIAL_INSTAGRAM_PROFILE_POSTS_DOC_IDS"
 PROFILE_POSTS_FRIENDLY_NAME = "PolarisProfilePostsQuery"
@@ -123,6 +167,29 @@ AUTH_FATAL_MESSAGES = {
     "consent_required",
     "sentry_block",
 }
+
+GRAPHQL_AUTH_BLOCKING_ERROR_CODES = frozenset(
+    {
+        "checkpoint_required",
+        "challenge_required",
+        "login_required",
+        "redirect_login",
+        "unauthorized",
+        "forbidden",
+        "instagram_graphql_auth_required",
+        "instagram_graphql_challenge_required",
+        "instagram_graphql_checkpoint_required",
+        "instagram_graphql_cursor_auth_repair_required",
+        "instagram_graphql_cursor_forbidden",
+        "instagram_graphql_cursor_unauthorized",
+        "instagram_graphql_forbidden",
+        "instagram_graphql_login_required",
+    }
+)
+
+
+def is_instagram_graphql_auth_blocking_error(error_code: object) -> bool:
+    return str(error_code or "").strip().lower() in GRAPHQL_AUTH_BLOCKING_ERROR_CODES
 
 
 def resolve_comment_sort_order(raw_value: str | None = None) -> str | None:

--- a/trr_backend/socials/instagram/posts_control.py
+++ b/trr_backend/socials/instagram/posts_control.py
@@ -119,7 +119,7 @@ def start_instagram_posts_scrapling_scrape(
 
     lock_key = _social_account_posts_scrapling_start_lock_key(normalized_platform, normalized_account)
     lock_label = f"posts-scrapling-start-lock:instagram:{normalized_account[:48]}"
-    with pg.db_connection(label=lock_label) as lock_conn:
+    with pg.db_connection(label=lock_label, pool_name="session_control") as lock_conn:
         with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
             lock_row = pg.fetch_one_with_cursor(cur, "select pg_try_advisory_lock(%s) as locked", [lock_key]) or {}
         if not bool(lock_row.get("locked")):

--- a/trr_backend/socials/instagram/posts_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/posts_scrapling/fetcher.py
@@ -171,11 +171,7 @@ def _safe_url_classes(url: Any) -> tuple[str, str]:
         return "unknown", "unknown"
     host = str(parsed.hostname or "").strip().lower()
     origin_class = (
-        "instagram"
-        if host == "instagram.com" or host.endswith(".instagram.com")
-        else "external"
-        if host
-        else "unknown"
+        "instagram" if host == "instagram.com" or host.endswith(".instagram.com") else "external" if host else "unknown"
     )
     path = str(parsed.path or "/").strip().lower()
     if path in {"", "/"}:

--- a/trr_backend/socials/instagram/posts_scrapling/fetcher.py
+++ b/trr_backend/socials/instagram/posts_scrapling/fetcher.py
@@ -26,6 +26,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -122,6 +123,11 @@ _SPIN_R_RE = re.compile(r'"__spin_r":(?P<token>\d+)')
 _SPIN_B_RE = re.compile(r'"__spin_b":"(?P<token>[^"]+)"')
 _SPIN_T_RE = re.compile(r'"__spin_t":(?P<token>\d+)')
 _HSI_RE = re.compile(r'"hsi":"?(?P<token>\d+)"?')
+_REDIRECT_LOOP_RE = re.compile(
+    r"(?:exceeded\s+\d+\s+redirects|too[ _-]+many[ _-]+redirects|max(?:imum)?[ _-]+redirects)",
+    re.IGNORECASE,
+)
+_URL_IN_ERROR_RE = re.compile(r"https?://[^\s;<>'\"]+", re.IGNORECASE)
 
 
 @dataclass(slots=True)
@@ -146,6 +152,48 @@ _AUTHENTICATED_COOKIE_NAMES = frozenset({"sessionid", "ds_user_id"})
 def _auth_failure_text(text: str) -> bool:
     normalized = str(text or "").strip().lower()
     return any(token in normalized for token in ("login", "checkpoint", "challenge", "accounts/login"))
+
+
+def _is_redirect_loop_exception(exc: BaseException) -> bool:
+    current: BaseException | None = exc
+    for _ in range(4):
+        if isinstance(current, httpx.TooManyRedirects) or _REDIRECT_LOOP_RE.search(str(current or "")):
+            return True
+        current = current.__cause__ or current.__context__ if current is not None else None
+    return False
+
+
+def _safe_url_classes(url: Any) -> tuple[str, str]:
+    raw_url = str(url or "").strip()
+    try:
+        parsed = urlparse(raw_url)
+    except Exception:  # noqa: BLE001
+        return "unknown", "unknown"
+    host = str(parsed.hostname or "").strip().lower()
+    origin_class = (
+        "instagram"
+        if host == "instagram.com" or host.endswith(".instagram.com")
+        else "external"
+        if host
+        else "unknown"
+    )
+    path = str(parsed.path or "/").strip().lower()
+    if path in {"", "/"}:
+        path_class = "home"
+    elif "/accounts/login" in path:
+        path_class = "login"
+    elif "/checkpoint" in path or "/challenge" in path:
+        path_class = "checkpoint"
+    elif len([part for part in path.split("/") if part]) == 1:
+        path_class = "profile"
+    else:
+        path_class = "other"
+    return origin_class, path_class
+
+
+def _redirect_loop_url_classes(exc: BaseException) -> tuple[str, str]:
+    urls = _URL_IN_ERROR_RE.findall(str(exc or ""))
+    return _safe_url_classes(urls[-1].rstrip(".,)")) if urls else ("instagram", "unknown")
 
 
 def _safe_rate_limit_key(value: str) -> str:
@@ -301,7 +349,7 @@ def _try_advisory_lock_pace(*, key: str, delay_seconds: float) -> dict[str, Any]
         return _pacing_result(acquired=False, paced=True, error=f"pg_import_failed:{exc}")
     remaining_seconds = 0.0
     try:
-        with pg.db_connection(label="instagram-posts-rate-limit-pace", pool_name="social_control") as conn:
+        with pg.db_connection(label="instagram-posts-rate-limit-pace", pool_name="session_control") as conn:
             with pg.db_cursor(conn=conn) as cur:
                 cur.execute(
                     """
@@ -841,6 +889,7 @@ class InstagramPostsScraplingFetcher:
         )
         self._page_size = max(1, resolved_page_size)
         self._request_count = 0
+        self._warmup_failure_metadata: dict[str, Any] = {}
         self._warmup_cookie_delta: dict[str, str] = {}
         self._selected_proxy_fingerprint: str = proxy_config.fingerprint if proxy_config else "none"
         self._proxy_session_mode: str = proxy_config.session_mode if proxy_config else "none"
@@ -951,6 +1000,7 @@ class InstagramPostsScraplingFetcher:
             "authenticated_cookie_count": sum(1 for name in self._raw_cookies if name in _AUTHENTICATED_COOKIE_NAMES),
             "warmup_cookie_names": sorted(self._warmup_cookie_delta.keys()),
             "warmup_cookie_count": len(self._warmup_cookie_delta),
+            "warmup_failure": dict(self._warmup_failure_metadata),
             "selected_proxy_fingerprint": self._selected_proxy_fingerprint,
             "proxy_session_mode": self._proxy_session_mode,
             "proxy_identity": proxy_identity.to_metadata(),
@@ -1027,11 +1077,23 @@ class InstagramPostsScraplingFetcher:
         try:
             response = await self._fetch_page(profile_url, referer=profile_url)
         except Exception as exc:  # noqa: BLE001
+            if _is_redirect_loop_exception(exc):
+                origin_class, path_class = _redirect_loop_url_classes(exc)
+                self._record_warmup_failure(
+                    error_code="instagram_posts_redirect_loop",
+                    origin_class=origin_class,
+                    path_class=path_class,
+                )
+                self._warmup_pool_metadata.update({"miss": True, "refresh_reason": "redirect_loop"})
+                raise InstagramPostsWarmupError(
+                    "Instagram posts warmup stopped after a redirect loop.",
+                    error_code="instagram_posts_redirect_loop",
+                    retryable=False,
+                ) from exc
             if self._activate_requests_fallback("warmup_transport_failed"):
                 self._requests_fallback_metadata.update(
                     {
                         "warmup_error_class": type(exc).__name__,
-                        "warmup_error_message": str(exc)[:500],
                     }
                 )
                 return
@@ -1042,9 +1104,26 @@ class InstagramPostsScraplingFetcher:
                 retryable=True,
             ) from exc
         text = _response_text(response)
-        if _status_code(response) in {401, 403} or _auth_failure_text(text):
-            if self._activate_requests_fallback("warmup_auth_failed"):
-                return
+        response_url = getattr(response, "url", None)
+        origin_class, path_class = _safe_url_classes(
+            response_url if isinstance(response_url, str | httpx.URL) else profile_url
+        )
+        status_code = _status_code(response)
+        location = _safe_location(response) if 300 <= status_code < 400 else ""
+        _, location_path_class = _safe_url_classes(f"https://www.instagram.com{location}") if location else ("", "")
+        if location_path_class in {"login", "checkpoint", "home"}:
+            path_class = location_path_class
+        elif _auth_failure_text(text):
+            path_class = (
+                "checkpoint" if any(token in text.lower() for token in ("checkpoint", "challenge")) else "login"
+            )
+        terminal_redirect = path_class in {"login", "checkpoint", "home"}
+        if status_code in {401, 403} or _auth_failure_text(text) or terminal_redirect:
+            self._record_warmup_failure(
+                error_code="instagram_posts_warmup_auth_failed",
+                origin_class=origin_class,
+                path_class=path_class,
+            )
             self._consecutive_auth_failures += 1
             self._warmup_pool_metadata.update({"miss": True, "refresh_reason": "auth_failure"})
             raise InstagramPostsWarmupError(
@@ -1079,6 +1158,22 @@ class InstagramPostsScraplingFetcher:
                 "proxy_fingerprint": self._selected_proxy_fingerprint,
             },
         )
+
+    def _record_warmup_failure(
+        self,
+        *,
+        error_code: str,
+        origin_class: str,
+        path_class: str,
+    ) -> None:
+        self._warmup_failure_metadata = {
+            "phase": "document_warmup",
+            "attempt_count": 1,
+            "final_origin_class": str(origin_class or "unknown"),
+            "final_path_class": str(path_class or "unknown"),
+            "proxy_fingerprint": self._selected_proxy_fingerprint,
+            "error_code": error_code,
+        }
 
     def warmup_snapshot(self) -> dict[str, Any]:
         """Return enough warmup state for another posts fetcher in the same shard."""

--- a/trr_backend/socials/instagram/scraper.py
+++ b/trr_backend/socials/instagram/scraper.py
@@ -9,6 +9,7 @@ Supports:
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import math
@@ -92,6 +93,15 @@ from trr_backend.socials.instagram.request_client import InstagramRequestClient,
 from trr_backend.socials.instagram.resume_state import InstagramResumeState
 
 logger = logging.getLogger(__name__)
+
+
+def _sessionid_fingerprint(cookies: Mapping[str, Any]) -> str:
+    """Non-reversible, stable fingerprint of the sessionid for log correlation."""
+    raw = str((cookies or {}).get("sessionid") or "")
+    if not raw:
+        return "none"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+
 
 INSTAGRAM_AUTH_REPAIR_CONFIRMATION = "I UNDERSTAND INSTAGRAM AUTH RISK"
 INSTAGRAM_AUTH_REPAIR_CONFIRMATION_ENV = "SOCIAL_INSTAGRAM_AUTH_REPAIR_CONFIRMATION"
@@ -874,8 +884,8 @@ class InstagramScraper:
                 self.session.cookies.set(k, v, domain=".instagram.com")
             self._clear_profile_page_context_cache()
             logger.info(
-                "[instagram] confirmed cookie repair succeeded - sessionid=%s...",
-                fresh_cookies["sessionid"][:8],
+                "[instagram] confirmed cookie repair succeeded - sessionid_fp=%s",
+                _sessionid_fingerprint(fresh_cookies),
             )
             return {"refreshed": True, "reason": None, "cookie_file": str(cookie_path)}
         except Exception as exc:  # noqa: BLE001
@@ -968,7 +978,10 @@ class InstagramScraper:
             for k, v in fresh_cookies.items():
                 self.session.cookies.set(k, v, domain=".instagram.com")
             self._clear_profile_page_context_cache()
-            logger.info("[instagram] interactive login succeeded — sessionid=%s…", fresh_cookies["sessionid"][:8])
+            logger.info(
+                "[instagram] interactive login succeeded — sessionid_fp=%s",
+                _sessionid_fingerprint(fresh_cookies),
+            )
             return {"refreshed": True, "reason": None, "method": "interactive_chrome"}
         except Exception as exc:  # noqa: BLE001
             logger.warning("[instagram] interactive login failed: %s", exc)

--- a/trr_backend/socials/pipelines/comments/instagram.py
+++ b/trr_backend/socials/pipelines/comments/instagram.py
@@ -124,9 +124,7 @@ _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_SLOW_ELAPSED_SECONDS = 240
 _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_SLOW_POSTS_PER_MINUTE = 0.5
 _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_MIN_REMAINING_TARGETS = 10
 _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_MAX_RETRY_SHARD_SIZE = 10
-_INSTAGRAM_COMMENTS_NONTERMINAL_REMOTE_INVOCATION_STATUSES = frozenset(
-    {"pending", "running", "queued", "unknown"}
-)
+_INSTAGRAM_COMMENTS_NONTERMINAL_REMOTE_INVOCATION_STATUSES = frozenset({"pending", "running", "queued", "unknown"})
 
 
 def _sync_core_overrides() -> None:
@@ -1520,8 +1518,7 @@ def _instagram_filter_incomplete_comment_targets(
         "p.raw_data ->> 'username'",
     )
     owner_direct_array = ",\n                ".join(
-        "nullif(ltrim(lower(trim(coalesce(" + expr + ", ''))), '@'), '')"
-        for expr in owner_direct_candidates
+        "nullif(ltrim(lower(trim(coalesce(" + expr + ", ''))), '@'), '')" for expr in owner_direct_candidates
     )
     owner_collaborator_paths = (
         "p.collaborators",
@@ -2476,8 +2473,7 @@ def start_social_account_comments_scrape(
                         else "database_unavailable"
                     )
                     raise pg.DatabaseServiceUnavailableError(
-                        read_error
-                        or str(db_session_capacity.get("block_reason") or "Database capacity unavailable."),
+                        read_error or str(db_session_capacity.get("block_reason") or "Database capacity unavailable."),
                         reason=reason,
                     )
                 if db_session_capacity.get("blocked"):
@@ -3144,9 +3140,7 @@ def _split_instagram_comments_audit_cursor_targets_into_active_run(
         config = _public_comments_config_overlay(_metadata_dict(row.get("config")))
         metadata = _metadata_dict(row.get("metadata"))
         source_targets = [
-            str(target or "").strip()
-            for target in config.get("target_source_ids") or []
-            if str(target or "").strip()
+            str(target or "").strip() for target in config.get("target_source_ids") or [] if str(target or "").strip()
         ]
         matched_targets = [target for target in source_targets if target in target_set]
         dispatch = _metadata_dict(metadata.get("dispatch"))
@@ -4308,9 +4302,8 @@ def rebalance_failed_instagram_comments_shard(
         metadata = _metadata_dict(row.get("metadata"))
         source_job_id = str(row.get("job_id") or "").strip()
         normalized_run_id = str(row.get("run_id") or "").strip()
-        source_already_claimed = (
-            str(row.get("status") or "").strip().lower() == "cancelled"
-            and bool(metadata.get("comments_retry_rebalance_claimed_at"))
+        source_already_claimed = str(row.get("status") or "").strip().lower() == "cancelled" and bool(
+            metadata.get("comments_retry_rebalance_claimed_at")
         )
         dispatch = _metadata_dict(metadata.get("dispatch"))
         remote_invocation_id = str(dispatch.get("remote_invocation_id") or "").strip()
@@ -4711,9 +4704,7 @@ def _instagram_comments_repair_run_config_value(
     ]
     if key in {"date_start", "date_end"}:
         sources.extend(
-            _metadata_dict(source.get("target_window"))
-            for source in list(sources)
-            if isinstance(source, Mapping)
+            _metadata_dict(source.get("target_window")) for source in list(sources) if isinstance(source, Mapping)
         )
     for source in sources:
         value = source.get(key)

--- a/trr_backend/socials/pipelines/comments/instagram.py
+++ b/trr_backend/socials/pipelines/comments/instagram.py
@@ -124,6 +124,9 @@ _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_SLOW_ELAPSED_SECONDS = 240
 _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_SLOW_POSTS_PER_MINUTE = 0.5
 _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_MIN_REMAINING_TARGETS = 10
 _PUBLIC_COMMENTS_WORKER_CAP_REBALANCE_MAX_RETRY_SHARD_SIZE = 10
+_INSTAGRAM_COMMENTS_NONTERMINAL_REMOTE_INVOCATION_STATUSES = frozenset(
+    {"pending", "running", "queued", "unknown"}
+)
 
 
 def _sync_core_overrides() -> None:
@@ -137,6 +140,26 @@ def _room_callable(name: str, local_impl: Any) -> Any:
     if callable(candidate) and candidate is not _CORE_ROOM_WRAPPERS.get(name):
         return candidate
     return local_impl
+
+
+def dispatch_due_social_jobs(*, run_id: str | None = None, limit: int | None = None) -> dict[str, Any]:
+    """Dispatch comments jobs through the cap-aware control-plane owner."""
+    from trr_backend.socials.control_plane.dispatch_runtime import dispatch_due_social_jobs as impl
+
+    return impl(run_id=run_id, limit=limit)
+
+
+def _dispatch_due_social_jobs_in_background(*, run_id: str) -> None:
+    """Run comments dispatch through the cap-aware owner from a background task."""
+    normalized_run_id = str(run_id or "").strip()
+    if normalized_run_id:
+        try:
+            dispatch_due_social_jobs(run_id=normalized_run_id)
+        except Exception:
+            logger.exception(
+                "[comments-dispatch] background dispatch failed: run_id=%s",
+                normalized_run_id,
+            )
 
 
 def _instagram_comments_stale_after_hours() -> int:
@@ -1483,30 +1506,76 @@ def _instagram_filter_incomplete_comment_targets(
     if not normalized_account or not requested:
         return requested
 
-    owner_match_clause = _social_account_profile_owner_match_sql("instagram", alias="p")
+    # Preserve the generic Instagram matcher exactly, but point it at explicit
+    # queryable columns instead of serializing each wide post row with
+    # ``to_jsonb(p)``.  The raw-data and collaborator fallbacks remain because
+    # older posts may not have every typed ownership field populated.
+    owner_account_ref = "_ig_account_match.account_handle"
+    owner_direct_candidates = (
+        "p.source_account",
+        "p.owner_username",
+        "p.username",
+        "p.raw_data ->> 'source_account'",
+        "p.raw_data ->> 'owner_username'",
+        "p.raw_data ->> 'username'",
+    )
+    owner_direct_array = ",\n                ".join(
+        "nullif(ltrim(lower(trim(coalesce(" + expr + ", ''))), '@'), '')"
+        for expr in owner_direct_candidates
+    )
+    owner_collaborator_paths = (
+        "p.collaborators",
+        "p.collaborators_detail",
+        "p.raw_data -> 'collaborators'",
+        "p.raw_data -> 'collaborators_detail'",
+    )
+    owner_collaborator_match = "\n              or ".join(
+        _instagram_account_jsonb_array_match_sql(
+            alias=f"_ig_incomplete_target_collaborator_{index}",
+            path_sql=path_sql,
+            account_ref=owner_account_ref,
+        )
+        for index, path_sql in enumerate(owner_collaborator_paths, start=1)
+    )
+    owner_match_clause = f"""
+        exists (
+          select 1
+          from (select %s::text as account_handle) _ig_account_match
+          where {owner_account_ref} = any(
+            array_remove(
+              array[
+                {owner_direct_array}
+              ],
+              null
+            )
+          )
+          or {owner_collaborator_match}
+        )
+    """
     reported_comments_expr = _instagram_reported_comments_sql("p")
     facebook_comments_expr = _instagram_external_facebook_comments_sql("p")
     lifecycle_supported = _comment_lifecycle_supported("instagram_comments")
     active_condition = "c.is_missing is not true" if lifecycle_supported else "true"
     missing_condition = "c.is_missing is true" if lifecycle_supported else "false"
-    parent_external_expr = "nullif(coalesce(to_jsonb(c) ->> 'parent_comment_external_id', ''), '')"
-    reply_depth_expr = """
-        case
-          when coalesce(to_jsonb(c) ->> 'reply_depth', '') ~ '^[0-9]+$'
-          then (to_jsonb(c) ->> 'reply_depth')::int
-          else 0
-        end
-    """
-    reply_condition = f"""
-        (
-          coalesce(c.is_reply, false)
-          or c.parent_comment_id is not null
-          or {parent_external_expr} is not null
-          or ({reply_depth_expr}) > 0
-        )
-    """
-    rows = pg.fetch_all(
-        f"""
+    parent_external_expr = "nullif(coalesce(c.parent_comment_external_id, ''), '')"
+    reply_depth_expr = "coalesce(c.reply_depth, 0)"
+
+    def _fetch_verification_rows(
+        *,
+        account_match_sql: str,
+        parent_external_sql: str,
+        reply_depth_sql: str,
+    ) -> list[dict[str, Any]]:
+        reply_condition = f"""
+            (
+              coalesce(c.is_reply, false)
+              or c.parent_comment_id is not null
+              or {parent_external_sql} is not null
+              or ({reply_depth_sql}) > 0
+            )
+        """
+        return pg.fetch_all(
+            f"""
         with requested as (
           select
             nullif(shortcode, '')::text as shortcode,
@@ -1526,7 +1595,7 @@ def _instagram_filter_incomplete_comment_targets(
             ) as row_number
           from social.instagram_posts p
           join requested r on r.shortcode = p.shortcode
-          where {owner_match_clause}
+          where {account_match_sql}
         ),
         selected_posts as (
           select post_id, shortcode, reported_comments, facebook_comments
@@ -1560,8 +1629,31 @@ def _instagram_filter_incomplete_comment_targets(
         left join saved_comment_counts scc on scc.shortcode = r.shortcode
         order by r.sort_order
         """,
-        [requested, normalized_account],
-    )
+            [requested, normalized_account],
+        )
+
+    try:
+        rows = _fetch_verification_rows(
+            account_match_sql=owner_match_clause,
+            parent_external_sql=parent_external_expr,
+            reply_depth_sql=reply_depth_expr,
+        )
+    except psycopg_errors.UndefinedColumn:
+        # An additive-schema deployment may briefly run this code before the
+        # queryable post/comment columns exist. Preserve the prior tolerant
+        # behavior only for that compatibility path; current schemas keep the
+        # narrow query above and never serialize whole rows.
+        rows = _fetch_verification_rows(
+            account_match_sql=_social_account_profile_owner_match_sql("instagram", alias="p"),
+            parent_external_sql="nullif(coalesce(to_jsonb(c) ->> 'parent_comment_external_id', ''), '')",
+            reply_depth_sql="""
+                case
+                  when coalesce(to_jsonb(c) ->> 'reply_depth', '') ~ '^[0-9]+$'
+                  then (to_jsonb(c) ->> 'reply_depth')::int
+                  else 0
+                end
+            """,
+        )
     if not rows:
         logger.warning(
             "Instagram comments incomplete-target filter returned no verification rows; preserving requested targets: "
@@ -2085,6 +2177,7 @@ def start_social_account_comments_scrape(
     cancel_active_before_relaunch: bool | None = None,
     date_start: str | None = None,
     date_end: str | None = None,
+    reserved_db_session_capacity: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     _sync_core_overrides()
     normalized_platform = _normalize_social_account_profile_platform(platform)
@@ -2162,7 +2255,9 @@ def start_social_account_comments_scrape(
     run_id: str | None = None
     payload: dict[str, Any] | None = None
     cancelled_active_run: dict[str, Any] | None = None
-    with pg.db_connection(label=lock_label, pool_name="social_control") as lock_conn:
+    active_run_to_cancel: dict[str, Any] | None = None
+    with _session_advisory_lock_connection(label=lock_label, pool_name="session_control") as lock_state:
+        lock_conn, discard_state = lock_state
         with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
             lock_row = pg.fetch_one_with_cursor(cur, "select pg_try_advisory_lock(%s) as locked", [lock_key]) or {}
         if not bool(lock_row.get("locked")):
@@ -2212,13 +2307,7 @@ def start_social_account_comments_scrape(
                         ),
                         detail=active_run,
                     )
-                cancelled_active_run = cancel_social_account_comments_run(
-                    platform=normalized_platform,
-                    account_handle=normalized_account,
-                    run_id=str(active_run.get("run_id") or ""),
-                    cancelled_by="comments_relaunch_guard",
-                    conn=lock_conn,
-                )
+                active_run_to_cancel = dict(active_run)
             target_source_ids: list[str]
             target_enumeration_started_at = time_module.perf_counter()
             if normalized_mode == "single_post":
@@ -2353,6 +2442,63 @@ def start_social_account_comments_scrape(
                     effective_shard_count=comments_shard_count,
                 )
                 strategy_warnings = _instagram_comments_load_strategy_warnings(strategy_metadata)
+            comments_worker_cap_config = _instagram_comments_worker_cap_launch_config(
+                public_mode=public_comments_mode,
+                requested_comments_worker_count=requested_comments_worker_count,
+            )
+            effective_capacity_worker_count = max(
+                1,
+                _normalize_non_negative_int(comments_worker_cap_config.get("comments_worker_cap_current"))
+                or requested_comments_worker_count
+                or comments_shard_count,
+            )
+            raw_capacity_worker_count = max(
+                1,
+                _normalize_non_negative_int(comments_worker_count) or effective_capacity_worker_count,
+            )
+            db_session_capacity = _metadata_dict(reserved_db_session_capacity) or None
+            if db_session_capacity is None:
+                from trr_backend.socials.control_plane.budget import get_instagram_db_session_capacity
+
+                db_session_capacity = get_instagram_db_session_capacity(
+                    requested_workers=effective_capacity_worker_count,
+                    raw_requested_workers=raw_capacity_worker_count,
+                    backend_effective_requested_workers=effective_capacity_worker_count,
+                    conn=lock_conn,
+                )
+                if db_session_capacity.get("session_pool_blocked") or not db_session_capacity.get("available"):
+                    read_error = str(db_session_capacity.get("read_error") or "")
+                    reason = (
+                        "session_pool_capacity"
+                        if db_session_capacity.get("session_pool_blocked")
+                        or "emaxconnsession" in read_error.lower()
+                        or "maxclientsinsessionmode" in read_error.lower()
+                        else "database_unavailable"
+                    )
+                    raise pg.DatabaseServiceUnavailableError(
+                        read_error
+                        or str(db_session_capacity.get("block_reason") or "Database capacity unavailable."),
+                        reason=reason,
+                    )
+                if db_session_capacity.get("blocked"):
+                    raise SocialIngestConflictError(
+                        "INSTAGRAM_DB_SESSION_WORKER_BUDGET_EXCEEDED",
+                        (
+                            "Instagram comments launch needs "
+                            f"{db_session_capacity.get('requested_workers') or effective_capacity_worker_count} "
+                            "workers "
+                            f"but only {db_session_capacity.get('remaining_workers') or 0} DB-safe slots remain."
+                        ),
+                        detail={"db_session_capacity": db_session_capacity},
+                    )
+            if active_run_to_cancel:
+                cancelled_active_run = cancel_social_account_comments_run(
+                    platform=normalized_platform,
+                    account_handle=normalized_account,
+                    run_id=str(active_run_to_cancel.get("run_id") or ""),
+                    cancelled_by="comments_relaunch_guard",
+                    conn=lock_conn,
+                )
             comments_max_attempts = _instagram_comments_job_max_attempts(
                 {
                     "target_filter": normalized_target_filter,
@@ -2394,10 +2540,8 @@ def start_social_account_comments_scrape(
                 "instagram_scrape_mode": PUBLIC_COMMENTS_SCRAPE_MODE if public_comments_mode else "authenticated",
                 "comments_worker_count": requested_comments_worker_count,
                 "comments_target_batch_size": effective_comments_target_batch_size,
-                **_instagram_comments_worker_cap_launch_config(
-                    public_mode=public_comments_mode,
-                    requested_comments_worker_count=requested_comments_worker_count,
-                ),
+                **comments_worker_cap_config,
+                "db_session_capacity": db_session_capacity,
                 "date_start": normalized_date_start,
                 "date_end": normalized_date_end,
                 "target_window": (
@@ -2529,6 +2673,7 @@ def start_social_account_comments_scrape(
                 },
                 "comments_enable_media_followups": bool(comments_enable_media_followups),
                 "comments_worker_count": requested_comments_worker_count,
+                "db_session_capacity": db_session_capacity,
                 "job_creation": job_creation_payload,
                 "launch_group_id": str(launch_group_id or "").strip() or None,
                 "required_worker_lane": required_worker_lane,
@@ -2552,6 +2697,11 @@ def start_social_account_comments_scrape(
                     normalized_platform,
                     normalized_account,
                     exc_info=True,
+                )
+                _discard_session_advisory_lock_connection(
+                    lock_conn,
+                    discard_state=discard_state,
+                    preserve_outcome=payload is not None,
                 )
     if queue_enabled and dispatch_immediately and run_id:
         dispatch_due_social_jobs(run_id=run_id)
@@ -2993,23 +3143,26 @@ def _split_instagram_comments_audit_cursor_targets_into_active_run(
             continue
         config = _public_comments_config_overlay(_metadata_dict(row.get("config")))
         metadata = _metadata_dict(row.get("metadata"))
+        source_targets = [
+            str(target or "").strip()
+            for target in config.get("target_source_ids") or []
+            if str(target or "").strip()
+        ]
+        matched_targets = [target for target in source_targets if target in target_set]
         dispatch = _metadata_dict(metadata.get("dispatch"))
         remote_invocation_id = str(dispatch.get("remote_invocation_id") or "").strip()
         remote_status = str(dispatch.get("remote_invocation_status") or "").strip().lower()
-        if remote_invocation_id and remote_status in {"pending", "running", "queued"}:
-            if not force_rerun_existing or remote_status == "running":
-                skipped_sources.append(
-                    {
-                        "job_id": source_job_id,
-                        "reason": "remote_invocation_active",
-                        "remote_invocation_status": remote_status,
-                    }
-                )
-                continue
-        source_targets = [
-            str(target or "").strip() for target in config.get("target_source_ids") or [] if str(target or "").strip()
-        ]
-        matched_targets = [target for target in source_targets if target in target_set]
+        if remote_invocation_id and remote_status in _INSTAGRAM_COMMENTS_NONTERMINAL_REMOTE_INVOCATION_STATUSES:
+            matched_target_set = set(matched_targets)
+            remaining_targets = [target for target in remaining_targets if target not in matched_target_set]
+            skipped_sources.append(
+                {
+                    "job_id": source_job_id,
+                    "reason": "remote_invocation_active",
+                    "remote_invocation_status": remote_status,
+                }
+            )
+            continue
         retry_targets = [target for target in matched_targets if target in remaining_targets]
         if not retry_targets:
             continue
@@ -3245,6 +3398,7 @@ def _append_instagram_comments_public_recovery_targets_to_active_run(
     batch_size: int,
     initiated_by: str | None,
     dispatch_immediately: bool,
+    exclude_active_job_id: str | None = None,
 ) -> dict[str, Any]:
     normalized_run_id = str(run_id or "").strip()
     normalized_account = _normalize_social_account_profile_handle(account_handle)
@@ -3266,10 +3420,17 @@ def _append_instagram_comments_public_recovery_targets_to_active_run(
         cross join lateral jsonb_array_elements_text(coalesce(j.config->'target_source_ids', '[]'::jsonb)) value
         where j.run_id = %s::uuid
           and j.status in ('queued', 'pending', 'retrying', 'running')
+          and (%s::uuid is null or j.id <> %s::uuid)
           and coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
           and (j.config->'target_source_ids') ?| %s::text[]
         """,
-        [normalized_run_id, INSTAGRAM_COMMENTS_SCRAPLING_STAGE, list(seen_targets)],
+        [
+            normalized_run_id,
+            str(exclude_active_job_id or "").strip() or None,
+            str(exclude_active_job_id or "").strip() or None,
+            INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+            list(seen_targets),
+        ],
     )
     active_targets = {
         str(row.get("target_source_id") or "").strip()
@@ -4112,75 +4273,204 @@ def rebalance_failed_instagram_comments_shard(
     max_retry_shard_size: int = 10,
 ) -> dict[str, Any]:
     _sync_core_overrides()
-    row = pg.fetch_one(
-        """
-        select
-          j.id::text as job_id,
-          j.run_id::text as run_id,
-          j.platform,
-          j.source_scope,
-          j.config,
-          j.metadata,
-          j.initiated_by,
-          j.items_found
-        from social.scrape_jobs j
-        where j.id = %s::uuid
-          and j.status = 'failed'
-          and coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
-        """,
-        [failed_job_id, INSTAGRAM_COMMENTS_SCRAPLING_STAGE],
-    )
-    if not row:
-        return {"created_job_ids": [], "reason": "failed_job_not_found"}
-    config = _canonicalize_instagram_comments_config_metadata(_metadata_dict(row.get("config")))
-    metadata = _metadata_dict(row.get("metadata"))
-    retry_rebalance = _metadata_dict(metadata.get("retry_rebalance"))
-    remaining_targets = [
-        str(item or "").strip()
-        for item in retry_rebalance.get("remaining_target_source_ids") or []
-        if str(item or "").strip()
-    ]
-    if not remaining_targets:
-        remaining_targets = _comments_job_remaining_target_source_ids(
-            row=row,
-            config=config,
-            metadata=metadata,
-            require_items_found_for_progress=True,
+    lock_label = f"comments-failed-rebalance:{str(failed_job_id or '')[:48]}"
+    with pg.db_connection(label=lock_label) as conn:
+        row = pg.fetch_one(
+            """
+            select
+              j.id::text as job_id,
+              j.run_id::text as run_id,
+              j.status,
+              j.platform,
+              j.source_scope,
+              j.config,
+              j.metadata,
+              j.initiated_by,
+              j.items_found
+            from social.scrape_jobs j
+            where j.id = %s::uuid
+              and (
+                j.status = 'failed'
+                or (
+                  j.status = 'cancelled'
+                  and j.metadata->>'comments_retry_rebalance_claimed_at' is not null
+                )
+              )
+              and coalesce(j.config->>'stage', j.metadata->>'stage', j.job_type) = %s
+            for update
+            """,
+            [failed_job_id, INSTAGRAM_COMMENTS_SCRAPLING_STAGE],
+            conn=conn,
         )
-    if not remaining_targets:
-        return {"created_job_ids": [], "reason": "no_remaining_targets"}
-    safe_max_retry_shard_size = max(1, int(max_retry_shard_size or 10))
-    retry_shard_count = max(1, (len(remaining_targets) + safe_max_retry_shard_size - 1) // safe_max_retry_shard_size)
-    chunks = _chunk_instagram_comment_targets(remaining_targets, retry_shard_count)
-    created_job_ids: list[str] = []
-    retry_group_id = str(uuid4())
-    for index, chunk in enumerate(chunks, start=1):
-        retry_config = {
-            **config,
-            "target_source_ids": chunk,
-            "comments_retry_rebalance": True,
-            "comments_retry_rebalance_source_job_id": str(row.get("job_id") or ""),
-            "comments_retry_rebalance_group_id": retry_group_id,
-            "comments_retry_rebalance_index": index,
-            "comments_retry_rebalance_count": len(chunks),
-            "comments_shard_target_count": len(chunk),
-        }
-        created_job_ids.append(
-            _create_job(
-                None,
-                run_id=str(row.get("run_id") or ""),
-                platform="instagram",
-                source_scope=str(row.get("source_scope") or "network"),
-                job_type="comments",
-                stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
-                config=retry_config,
-                initiated_by=str(row.get("initiated_by") or "") or None,
-                status="queued",
-                priority=110,
-                max_attempts=_instagram_comments_job_max_attempts(retry_config),
+        if not row:
+            return {"created_job_ids": [], "reason": "failed_job_not_found"}
+        config = _canonicalize_instagram_comments_config_metadata(_metadata_dict(row.get("config")))
+        metadata = _metadata_dict(row.get("metadata"))
+        source_job_id = str(row.get("job_id") or "").strip()
+        normalized_run_id = str(row.get("run_id") or "").strip()
+        source_already_claimed = (
+            str(row.get("status") or "").strip().lower() == "cancelled"
+            and bool(metadata.get("comments_retry_rebalance_claimed_at"))
+        )
+        dispatch = _metadata_dict(metadata.get("dispatch"))
+        remote_invocation_id = str(dispatch.get("remote_invocation_id") or "").strip()
+        remote_status = str(dispatch.get("remote_invocation_status") or "").strip().lower()
+        if remote_invocation_id and remote_status in _INSTAGRAM_COMMENTS_NONTERMINAL_REMOTE_INVOCATION_STATUSES:
+            return {
+                "created_job_ids": [],
+                "failed_job_id": source_job_id,
+                "reason": "remote_invocation_active",
+                "remote_invocation_status": remote_status,
+            }
+        retry_rebalance = _metadata_dict(metadata.get("retry_rebalance"))
+        remaining_targets = [
+            str(item or "").strip()
+            for item in retry_rebalance.get("remaining_target_source_ids") or []
+            if str(item or "").strip()
+        ]
+        if not remaining_targets:
+            remaining_targets = _comments_job_remaining_target_source_ids(
+                row=row,
+                config=config,
+                metadata=metadata,
+                require_items_found_for_progress=True,
             )
+        if not remaining_targets:
+            return {"created_job_ids": [], "reason": "no_remaining_targets"}
+
+        safe_max_retry_shard_size = max(1, int(max_retry_shard_size or 10))
+        requested_shard_count = max(
+            1,
+            (len(remaining_targets) + safe_max_retry_shard_size - 1) // safe_max_retry_shard_size,
         )
-    return {"created_job_ids": created_job_ids, "retry_group_id": retry_group_id}
+        persisted_shard_count = _normalize_non_negative_int(metadata.get("comments_retry_rebalance_shard_count"))
+        retry_shard_count = persisted_shard_count or requested_shard_count
+        chunks = _chunk_instagram_comment_targets(remaining_targets, retry_shard_count)
+        retry_group_id = (
+            str(metadata.get("comments_retry_rebalance_group_id") or "").strip()
+            if source_already_claimed
+            else str(uuid4())
+        )
+        if not retry_group_id:
+            return {
+                "created_job_ids": [],
+                "failed_job_id": source_job_id,
+                "reason": "claimed_source_missing_retry_group",
+            }
+
+        if not source_already_claimed:
+            claimed = pg.fetch_one(
+                """
+                update social.scrape_jobs
+                set
+                  status = 'cancelled',
+                  completed_at = now(),
+                  error_message = coalesce(error_message, 'Rebalanced failed comments shard'),
+                  metadata = coalesce(metadata, '{}'::jsonb) || jsonb_build_object(
+                    'comments_retry_rebalance_claimed_at', %s,
+                    'comments_retry_rebalance_group_id', %s,
+                    'comments_retry_rebalance_remaining_targets', %s,
+                    'comments_retry_rebalance_shard_count', %s
+                  )
+                where id = %s::uuid
+                  and status = 'failed'
+                  and metadata->>'comments_retry_rebalance_claimed_at' is null
+                returning id::text
+                """,
+                [
+                    _iso(_now_utc()),
+                    retry_group_id,
+                    len(remaining_targets),
+                    len(chunks),
+                    source_job_id,
+                ],
+                conn=conn,
+            )
+            if not claimed:
+                return {
+                    "created_job_ids": [],
+                    "failed_job_id": source_job_id,
+                    "reason": "source_status_changed",
+                }
+
+        existing_rows = pg.fetch_all(
+            """
+            select
+              id::text as job_id,
+              config->>'comments_retry_rebalance_index' as retry_index
+            from social.scrape_jobs
+            where run_id = %s::uuid
+              and coalesce(config->>'stage', metadata->>'stage', job_type) = %s
+              and config->>'comments_retry_rebalance_source_job_id' = %s
+              and config->>'comments_retry_rebalance_group_id' = %s
+            order by created_at asc, id asc
+            """,
+            [
+                normalized_run_id,
+                INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                source_job_id,
+                retry_group_id,
+            ],
+            conn=conn,
+        )
+        existing_indexes = {
+            _normalize_non_negative_int(existing_row.get("retry_index"))
+            for existing_row in existing_rows
+            if _normalize_non_negative_int(existing_row.get("retry_index")) > 0
+        }
+        missing_indexes = [index for index in range(1, len(chunks) + 1) if index not in existing_indexes]
+        if not missing_indexes:
+            return {
+                "created_job_ids": [],
+                "failed_job_id": source_job_id,
+                "retry_group_id": retry_group_id,
+                "reason": "already_rebalanced",
+            }
+
+        created_job_ids: list[str] = []
+        for index in missing_indexes:
+            chunk = chunks[index - 1]
+            retry_config = {
+                **config,
+                "target_source_ids": chunk,
+                "comments_retry_rebalance": True,
+                "comments_retry_rebalance_source_job_id": source_job_id,
+                "comments_retry_rebalance_group_id": retry_group_id,
+                "comments_retry_rebalance_index": index,
+                "comments_retry_rebalance_count": len(chunks),
+                "comments_shard_target_count": len(chunk),
+            }
+            created_job_ids.append(
+                _create_job(
+                    None,
+                    run_id=normalized_run_id,
+                    platform="instagram",
+                    source_scope=str(row.get("source_scope") or "network"),
+                    job_type="comments",
+                    stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+                    config=retry_config,
+                    initiated_by=str(row.get("initiated_by") or "") or None,
+                    status="queued",
+                    priority=110,
+                    max_attempts=_instagram_comments_job_max_attempts(retry_config),
+                    conn=conn,
+                    track_run_counters=False,
+                )
+            )
+        _increment_run_counters_on_job_create_batch(
+            run_id=normalized_run_id,
+            stage=INSTAGRAM_COMMENTS_SCRAPLING_STAGE,
+            status="queued",
+            count=len(created_job_ids),
+            conn=conn,
+        )
+        result: dict[str, Any] = {
+            "created_job_ids": created_job_ids,
+            "retry_group_id": retry_group_id,
+        }
+        if source_already_claimed:
+            result["resumed_from_claimed_source"] = True
+        return result
 
 
 def rebalance_waiting_instagram_comments_shards(
@@ -4239,7 +4529,7 @@ def rebalance_waiting_instagram_comments_shards(
         dispatch = _metadata_dict(metadata.get("dispatch"))
         remote_invocation_id = str(dispatch.get("remote_invocation_id") or "").strip()
         remote_status = str(dispatch.get("remote_invocation_status") or "").strip().lower()
-        if remote_invocation_id and remote_status in {"pending", "running", "queued"}:
+        if remote_invocation_id and remote_status in _INSTAGRAM_COMMENTS_NONTERMINAL_REMOTE_INVOCATION_STATUSES:
             skipped_sources.append(
                 {
                     "job_id": str(row.get("job_id") or ""),
@@ -4408,6 +4698,33 @@ def _comments_job_remaining_target_source_ids(
     return original_targets[min(processed_posts, len(original_targets)) :]
 
 
+def _instagram_comments_repair_run_config_value(
+    run_config: Mapping[str, Any],
+    run_metadata: Mapping[str, Any],
+    key: str,
+) -> str | None:
+    sources = [
+        run_config,
+        _metadata_dict(run_config.get("metadata")),
+        run_metadata,
+        _metadata_dict(run_metadata.get("metadata")),
+    ]
+    if key in {"date_start", "date_end"}:
+        sources.extend(
+            _metadata_dict(source.get("target_window"))
+            for source in list(sources)
+            if isinstance(source, Mapping)
+        )
+    for source in sources:
+        value = source.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
 def repair_instagram_comments_scrape_run_target_gaps(
     *,
     run_id: str,
@@ -4423,7 +4740,8 @@ def repair_instagram_comments_scrape_run_target_gaps(
           id::text as run_id,
           source_scope,
           initiated_by,
-          config
+          config,
+          summary as run_metadata
         from social.scrape_runs
         where id = %s::uuid
           and coalesce(config->>'stage', '') = %s
@@ -4438,11 +4756,32 @@ def repair_instagram_comments_scrape_run_target_gaps(
         return {"created_job_ids": [], "reason": "account_missing"}
     refresh_policy = str(run_config.get("refresh_policy") or "stale_or_missing").strip().lower() or "stale_or_missing"
     max_posts = run_config.get("max_posts")
-    target_source_ids = _instagram_social_account_comment_target_shortcodes(
-        account_handle,
-        limit=None if max_posts is None else max(1, int(max_posts)),
-        refresh_policy=refresh_policy,
+    run_metadata = _metadata_dict(run_row.get("run_metadata"))
+    repair_target_filter = _normalize_instagram_comments_target_filter(
+        _instagram_comments_repair_run_config_value(run_config, run_metadata, "target_filter")
     )
+    repair_window_start, repair_window_end = _normalize_comment_date_window(
+        _instagram_comments_repair_run_config_value(run_config, run_metadata, "date_start"),
+        _instagram_comments_repair_run_config_value(run_config, run_metadata, "date_end"),
+    )
+    repair_date_start = repair_window_start.isoformat() if repair_window_start is not None else None
+    repair_date_end = repair_window_end.isoformat() if repair_window_end is not None else None
+    target_limit = None if max_posts is None else max(1, int(max_posts))
+    if repair_target_filter == "incomplete":
+        target_source_ids = _instagram_social_account_incomplete_comment_target_shortcodes(
+            account_handle,
+            limit=target_limit,
+            date_start=repair_date_start,
+            date_end=repair_date_end,
+        )
+    else:
+        target_source_ids = _instagram_social_account_comment_target_shortcodes(
+            account_handle,
+            limit=target_limit,
+            refresh_policy=refresh_policy,
+            date_start=repair_date_start,
+            date_end=repair_date_end,
+        )
     job_rows = pg.fetch_all(
         """
         select status, config
@@ -4910,12 +5249,25 @@ def rebalance_slow_instagram_comments_shards(
     )
     created_job_ids: list[str] = []
     rebalanced_sources: list[str] = []
+    skipped_sources: list[dict[str, Any]] = []
     rebalance_group_id = str(uuid4())
     for row in rows:
         if len(rebalanced_sources) >= safe_max_rebalanced_shards:
             break
         config = _canonicalize_instagram_comments_config_metadata(_metadata_dict(row.get("config")))
         metadata = _metadata_dict(row.get("metadata"))
+        dispatch = _metadata_dict(metadata.get("dispatch"))
+        remote_invocation_id = str(dispatch.get("remote_invocation_id") or "").strip()
+        remote_status = str(dispatch.get("remote_invocation_status") or "").strip().lower()
+        if remote_invocation_id and remote_status in _INSTAGRAM_COMMENTS_NONTERMINAL_REMOTE_INVOCATION_STATUSES:
+            skipped_sources.append(
+                {
+                    "job_id": str(row.get("job_id") or ""),
+                    "reason": "remote_invocation_active",
+                    "remote_invocation_status": remote_status,
+                }
+            )
+            continue
         rebalance_depth = _normalize_non_negative_int(config.get("comments_slow_rebalance_depth"))
         if config.get("comments_slow_rebalance") and rebalance_depth <= 0:
             rebalance_depth = 1
@@ -4957,7 +5309,7 @@ def rebalance_slow_instagram_comments_shards(
         source_job_id = str(row.get("job_id") or "").strip()
         original_shard_count = _normalize_non_negative_int(config.get("comments_shard_count")) or len(rows) or 1
         effective_shard_count = original_shard_count + len(chunks)
-        pg.fetch_one(
+        cancelled = pg.fetch_one(
             """
             update social.scrape_jobs
             set
@@ -4984,6 +5336,9 @@ def rebalance_slow_instagram_comments_shards(
                 source_job_id,
             ],
         )
+        if not cancelled:
+            skipped_sources.append({"job_id": source_job_id, "reason": "source_status_changed"})
+            continue
         for index, chunk in enumerate(chunks, start=1):
             root_job_id = str(
                 config.get("comments_slow_rebalance_root_job_id")
@@ -5028,6 +5383,7 @@ def rebalance_slow_instagram_comments_shards(
         "created_job_ids": created_job_ids,
         "created_job_count": len(created_job_ids),
         "rebalanced_source_job_ids": rebalanced_sources,
+        "skipped_sources": skipped_sources,
         "rebalance_group_id": rebalance_group_id if created_job_ids else None,
     }
 
@@ -7513,7 +7869,8 @@ def guarded_restart_social_account_comments_run(
 
     lock_key = _social_account_comments_start_lock_key(normalized_platform, normalized_account)
     lock_label = f"comments-guarded-restart-lock:{normalized_platform}:{normalized_account[:48]}"
-    with pg.db_connection(label=lock_label, pool_name="social_control") as lock_conn:
+    lock_held = False
+    with pg.db_connection(label=lock_label, pool_name="session_control") as lock_conn:
         with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
             lock_row = pg.fetch_one_with_cursor(cur, "select pg_try_advisory_lock(%s) as locked", [lock_key]) or {}
         if not bool(lock_row.get("locked")):
@@ -7527,6 +7884,7 @@ def guarded_restart_social_account_comments_run(
                     "retryable": True,
                 },
             )
+        lock_held = True
         try:
             run_row = _load_social_account_comments_run_row(
                 platform=normalized_platform,
@@ -7568,6 +7926,16 @@ def guarded_restart_social_account_comments_run(
                 conn=lock_conn,
             )
 
+            # The normal launcher owns this same account lock. Release our
+            # cancel/read lock before handing off so it does not reject itself.
+            with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
+                unlock_row = (
+                    pg.fetch_one_with_cursor(cur, "select pg_advisory_unlock(%s) as unlocked", [lock_key]) or {}
+                )
+            if not bool(unlock_row.get("unlocked")):
+                raise RuntimeError(f"Failed to release comments restart lock for @{normalized_account}.")
+            lock_held = False
+
             new_run_payload = start_social_account_comments_scrape(
                 normalized_platform,
                 normalized_account,
@@ -7599,16 +7967,17 @@ def guarded_restart_social_account_comments_run(
                 conn=lock_conn,
             )
         finally:
-            try:
-                with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
-                    pg.fetch_one_with_cursor(cur, "select pg_advisory_unlock(%s) as unlocked", [lock_key])
-            except Exception:  # noqa: BLE001
-                logger.debug(
-                    "[comments-guarded-restart-lock] advisory unlock failed for %s/%s",
-                    normalized_platform,
-                    normalized_account,
-                    exc_info=True,
-                )
+            if lock_held:
+                try:
+                    with pg.db_cursor(conn=lock_conn, label=lock_label) as cur:
+                        pg.fetch_one_with_cursor(cur, "select pg_advisory_unlock(%s) as unlocked", [lock_key])
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "[comments-guarded-restart-lock] advisory unlock failed for %s/%s",
+                        normalized_platform,
+                        normalized_account,
+                        exc_info=True,
+                    )
 
     public_only_proof = {
         "no_cookies": True,
@@ -7787,6 +8156,8 @@ def cancel_social_account_comments_job(
 
 
 _LOCAL_ROOM_NAMES = {
+    "dispatch_due_social_jobs",
+    "_dispatch_due_social_jobs_in_background",
     "_instagram_comments_stale_after_hours",
     "_instagram_comments_target_count_expr",
     "_instagram_social_account_comments_coverage_diagnostics",

--- a/trr_backend/socials/pipelines/comments/instagram.py
+++ b/trr_backend/socials/pipelines/comments/instagram.py
@@ -10,6 +10,7 @@ import re
 import time as time_module
 from collections import Counter
 from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from typing import Any
 
@@ -158,6 +159,34 @@ def _dispatch_due_social_jobs_in_background(*, run_id: str) -> None:
                 "[comments-dispatch] background dispatch failed: run_id=%s",
                 normalized_run_id,
             )
+
+
+@contextmanager
+def _session_advisory_lock_connection(*, label: str, pool_name: str):
+    """Keep a session advisory lock on one pooled connection for the context."""
+    discard_state = {"discarded": False, "preserve_outcome": False}
+    try:
+        with pg.db_connection(label=label, pool_name=pool_name) as conn:
+            yield conn, discard_state
+    except Exception:
+        if discard_state["discarded"] and discard_state["preserve_outcome"]:
+            return
+        raise
+
+
+def _discard_session_advisory_lock_connection(
+    conn: Any,
+    *,
+    discard_state: dict[str, bool],
+    preserve_outcome: bool,
+) -> None:
+    """Close a connection whose session advisory lock could not be released."""
+    discard_state["discarded"] = True
+    discard_state["preserve_outcome"] = bool(preserve_outcome)
+    try:
+        conn.close()
+    except Exception:  # noqa: BLE001 - the pool context still attempts disposal
+        logger.debug("[advisory-lock] failed closing connection after unlock failure", exc_info=True)
 
 
 def _instagram_comments_stale_after_hours() -> int:
@@ -8149,6 +8178,8 @@ def cancel_social_account_comments_job(
 _LOCAL_ROOM_NAMES = {
     "dispatch_due_social_jobs",
     "_dispatch_due_social_jobs_in_background",
+    "_session_advisory_lock_connection",
+    "_discard_session_advisory_lock_connection",
     "_instagram_comments_stale_after_hours",
     "_instagram_comments_target_count_expr",
     "_instagram_social_account_comments_coverage_diagnostics",


### PR DESCRIPTION
## Outcome

- Persists Instagram auth cooldown state so admission decisions survive process restarts.
- Recovers incomplete Instagram comment work without discarding already-saved comments.
- Restores safe named-pool advisory-lock ownership and force-discards a connection if unlock fails.
- Consolidates advisor findings 031 and 033 on top of the social lifecycle contract.

## Dependencies

Stacked on #165. Review and merge the social lifecycle PR first.

## Database and rollback

Includes the Instagram shared cooldown migration and its rollback path. No migration has been applied to production.

## Validation

- 382 focused recovery tests passed during extraction.
- 16 recovery, redaction, and migration tests passed after review correction.
- 2 focused launch-lock tests passed.
- Ruff 0.14.4 check and format checks passed.
- git diff --check passed.

## Deployment

Modal and production database rollout wait until merge.