### PR TITLE
Normalize bounded social catalog targeting

### DIFF
--- a/scripts/socials/local_catalog_action.py
+++ b/scripts/socials/local_catalog_action.py
@@ -195,9 +195,7 @@ def _selected_tasks(args: argparse.Namespace) -> list[str]:
 
 def _comment_anchor_source_ids(args: argparse.Namespace) -> list[str]:
     return [
-        str(item).strip()
-        for item in list(getattr(args, "comment_anchor_source_ids", []) or [])
-        if str(item).strip()
+        str(item).strip() for item in list(getattr(args, "comment_anchor_source_ids", []) or []) if str(item).strip()
     ]
 
 
@@ -227,8 +225,7 @@ def _dry_run_payload(args: argparse.Namespace) -> dict[str, Any]:
         "date_end": str(getattr(args, "date_end", "") or "").strip() or None,
         "catalog_action_scope": (
             "bounded_window"
-            if str(getattr(args, "date_start", "") or "").strip()
-            and str(getattr(args, "date_end", "") or "").strip()
+            if str(getattr(args, "date_start", "") or "").strip() and str(getattr(args, "date_end", "") or "").strip()
             else "full_history"
         ),
         "confirmation_required": _is_bravotv_instagram_backfill(args),

--- a/scripts/socials/local_catalog_action.py
+++ b/scripts/socials/local_catalog_action.py
@@ -8,6 +8,8 @@ import importlib
 import json
 import os
 import sys
+from collections.abc import Mapping
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -18,8 +20,10 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 SUPPORTED_SOURCE_SCOPES = ("network", "news", "creator", "community", "bravo")
-SUPPORTED_ACTIONS = ("backfill", "sync_recent", "sync_newer", "fill_missing_posts", "fill_missing_photos")
+SUPPORTED_ACTIONS = ("backfill", "sync_recent", "sync_newer", "fill_missing_posts")
 SUPPORTED_SELECTED_TASKS = ("post_details", "comments", "media")
+EXECUTION_OWNERS = ("local-inline", "queue")
+QUEUE_ACCEPTED_STATUSES = {"queued", "pending", "running", "submitted"}
 LOCAL_SCRIPT_LABEL = "local-script:local_catalog_action.py"
 BRAVOTV_INSTAGRAM_BACKFILL_CONFIRMATION = "RUN BRAVOTV INSTAGRAM BACKFILL"
 LOCAL_CATALOG_DB_POOL_DEFAULTS = {
@@ -78,6 +82,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Print the planned catalog action without launching or executing any jobs.",
     )
     parser.add_argument(
+        "--execution-owner",
+        choices=EXECUTION_OWNERS,
+        default="local-inline",
+        help="Run a local inline worker, or submit work to the healthy Modal-backed queue.",
+    )
+    parser.add_argument(
         "--confirm-bravotv-instagram-backfill",
         default="",
         help=(
@@ -86,9 +96,39 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
-    if bool(str(args.date_start or "").strip()) != bool(str(args.date_end or "").strip()):
-        parser.error("--date-start and --date-end must be supplied together")
+    try:
+        _validate_backfill_window(
+            action=args.action,
+            date_start=args.date_start,
+            date_end=args.date_end,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
     return args
+
+
+def _parse_timestamp(value: str, *, option: str) -> datetime:
+    normalized = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{option} must be a valid ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{option} must include a timezone")
+    return parsed
+
+
+def _validate_backfill_window(*, action: str, date_start: str | None, date_end: str | None) -> None:
+    start = str(date_start or "").strip()
+    end = str(date_end or "").strip()
+    if not start and not end:
+        return
+    if str(action or "").strip().lower() != "backfill":
+        raise ValueError("--date-start and --date-end are only supported with --action backfill")
+    if not start or not end:
+        raise ValueError("--date-start and --date-end must be supplied together")
+    if _parse_timestamp(end, option="--date-end") < _parse_timestamp(start, option="--date-start"):
+        raise ValueError("--date-end must not be earlier than --date-start")
 
 
 def apply_workspace_runtime_env(*, repo_root: Path) -> Any:
@@ -117,6 +157,24 @@ def _load_module(name: str) -> Any:
 def _inline_worker_id(platform: str) -> str:
     normalized = str(platform or "").strip().lower() or "unknown"
     return f"local-script:catalog:{normalized}"
+
+
+def _execution_owner(args: argparse.Namespace) -> str:
+    return str(getattr(args, "execution_owner", "local-inline") or "local-inline").strip().lower()
+
+
+def _execution_launch_kwargs(*, owner: str, worker_id: str) -> dict[str, Any]:
+    if owner == "queue":
+        return {
+            "inline_worker_id": None,
+            "allow_local_dev_inline_bypass": False,
+            "execution_preference": "auto",
+        }
+    return {
+        "inline_worker_id": worker_id,
+        "allow_local_dev_inline_bypass": True,
+        "execution_preference": "prefer_local_inline",
+    }
 
 
 def _normalize_handle(value: Any) -> str:
@@ -152,10 +210,12 @@ def _bravotv_backfill_confirmation_valid(args: argparse.Namespace) -> bool:
 
 def _dry_run_payload(args: argparse.Namespace) -> dict[str, Any]:
     selected_tasks = _selected_tasks(args)
+    execution_owner = _execution_owner(args)
     return {
         "status": "dry_run",
         "would_launch": False,
-        "would_execute_inline_worker": False,
+        "execution_owner": execution_owner,
+        "would_execute_inline_worker": execution_owner == "local-inline",
         "platform": str(getattr(args, "platform", "") or "").strip().lower(),
         "account": _normalize_handle(getattr(args, "account", "")),
         "source_scope": str(getattr(args, "source_scope", "") or "").strip().lower(),
@@ -175,6 +235,42 @@ def _dry_run_payload(args: argparse.Namespace) -> dict[str, Any]:
         "required_confirmation": (
             BRAVOTV_INSTAGRAM_BACKFILL_CONFIRMATION if _is_bravotv_instagram_backfill(args) else None
         ),
+    }
+
+
+def _bounded_instagram_dry_run_preview(args: argparse.Namespace) -> dict[str, Any]:
+    date_start = str(getattr(args, "date_start", "") or "").strip()
+    date_end = str(getattr(args, "date_end", "") or "").strip()
+    if not (
+        str(getattr(args, "action", "") or "").strip().lower() == "backfill"
+        and str(getattr(args, "platform", "") or "").strip().lower() == "instagram"
+        and date_start
+        and date_end
+    ):
+        return {}
+    try:
+        apply_local_catalog_db_pool_defaults()
+        load_dotenv()
+        apply_workspace_runtime_env(repo_root=REPO_ROOT)
+        analytics_repo = _load_module("trr_backend.repositories.social_season_analytics")
+        preview = analytics_repo.preview_social_account_catalog_backfill_target(
+            str(getattr(args, "platform", "") or "").strip().lower(),
+            _normalize_handle(getattr(args, "account", "")),
+            date_start=_parse_timestamp(date_start, option="--date-start"),
+            date_end=_parse_timestamp(date_end, option="--date-end"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "bounded_preview_available": False,
+            "bounded_preview_error": f"{type(exc).__name__}: {exc}",
+        }
+    return {
+        "bounded_preview_available": True,
+        "bounded_preview_error": None,
+        "catalog_total": int(preview.get("catalog_total") or 0),
+        "materialized_total": int(preview.get("materialized_total") or 0),
+        "completion_target_posts": int(preview.get("completion_target_posts") or 0),
+        "completion_target_source": str(preview.get("completion_target_source") or "").strip() or None,
     }
 
 
@@ -204,6 +300,12 @@ def _payload_run_ids(payload: dict[str, Any]) -> list[str]:
         seen.add(run_id)
         run_ids.append(run_id)
     return run_ids
+
+
+def _execution_result_status(result: Any) -> str:
+    if not isinstance(result, Mapping):
+        return "unknown"
+    return str(result.get("status") or "").strip().lower() or "unknown"
 
 
 def _cancel_interrupted_runs(
@@ -251,21 +353,46 @@ def _execute_run(
     platform = str(payload.get("platform") or "").strip().lower() or None
     supported_platforms = [platform] if platform else None
     executed_run_ids: list[str] = []
+    outcomes: list[dict[str, str]] = []
     try:
         for index, run_id in enumerate(run_ids, start=1):
             executed_run_ids.append(run_id)
-            control_plane.execute_run_with_inline_worker_registration(
+            result = control_plane.execute_run_with_inline_worker_registration(
                 run_id,
                 worker_id=f"{worker_id}:{index}",
                 platform=platform,
                 supported_platforms=supported_platforms,
             )
+            status = _execution_result_status(result)
+            outcomes.append({"run_id": run_id, "status": status})
+            if status != "completed":
+                cleanup = _cancel_interrupted_runs(
+                    analytics_repo=analytics_repo,
+                    platform=platform,
+                    account_handle=account_handle,
+                    run_ids=run_ids,
+                    cancelled_by=f"{LOCAL_SCRIPT_LABEL}:execution_incomplete",
+                )
+                print(
+                    json.dumps(
+                        {
+                            **payload,
+                            "status": "failed",
+                            "reason": "local_run_did_not_complete",
+                            "executed_run_ids": executed_run_ids,
+                            "run_outcomes": outcomes,
+                            "launch_cleanup": cleanup,
+                        },
+                        sort_keys=True,
+                    )
+                )
+                return 1
     except KeyboardInterrupt:
         cleanup = _cancel_interrupted_runs(
             analytics_repo=analytics_repo,
             platform=platform,
             account_handle=account_handle,
-            run_ids=executed_run_ids,
+            run_ids=run_ids,
             cancelled_by=f"{LOCAL_SCRIPT_LABEL}:interrupted",
         )
         print(
@@ -273,23 +400,87 @@ def _execute_run(
                 {
                     "status": "interrupted",
                     "executed_run_ids": executed_run_ids,
+                    "run_outcomes": outcomes,
                     "interrupted_cleanup": cleanup,
                 },
                 sort_keys=True,
             )
         )
         return 130
-    except Exception:
-        _cancel_interrupted_runs(
+    except Exception as exc:  # noqa: BLE001
+        cleanup = _cancel_interrupted_runs(
             analytics_repo=analytics_repo,
             platform=platform,
             account_handle=account_handle,
-            run_ids=executed_run_ids,
+            run_ids=run_ids,
             cancelled_by=f"{LOCAL_SCRIPT_LABEL}:execution_error",
         )
-        raise
-    print(json.dumps({"run_id": run_ids[0], "executed_run_ids": run_ids, "status": "completed"}, sort_keys=True))
+        print(
+            json.dumps(
+                {
+                    **payload,
+                    "status": "failed",
+                    "reason": "local_run_execution_error",
+                    "error": str(exc),
+                    "executed_run_ids": executed_run_ids,
+                    "run_outcomes": outcomes,
+                    "launch_cleanup": cleanup,
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        json.dumps(
+            {"run_id": run_ids[0], "executed_run_ids": run_ids, "run_outcomes": outcomes, "status": "completed"},
+            sort_keys=True,
+        )
+    )
     return 0
+
+
+def _assert_modal_queue_owner(*, analytics_repo: Any, platform: str, account_handle: str) -> None:
+    if not bool(analytics_repo.is_queue_enabled()):
+        raise RuntimeError("Queue ownership requires SOCIAL_QUEUE_ENABLED and a Modal-backed worker.")
+    analytics_repo.assert_worker_available_when_queue_enabled(
+        required_execution_backend="modal",
+        platform=platform,
+        account_handle=account_handle,
+    )
+
+
+def _queue_submission_result(payload: dict[str, Any], *, execution_owner: str) -> int:
+    run_ids = _payload_run_ids(payload)
+    launch_status = str(payload.get("status") or "").strip().lower()
+    if run_ids and launch_status in QUEUE_ACCEPTED_STATUSES:
+        print(
+            json.dumps(
+                {
+                    **payload,
+                    "status": "submitted",
+                    "submission_status": launch_status,
+                    "execution_owner": execution_owner,
+                    "submitted_run_ids": run_ids,
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    print(
+        json.dumps(
+            {
+                **payload,
+                "status": "failed",
+                "reason": "queue_launch_not_accepted",
+                "execution_owner": execution_owner,
+                "submitted_run_ids": run_ids,
+            },
+            sort_keys=True,
+        ),
+        file=sys.stderr,
+    )
+    return 1
 
 
 def _start_backfill(
@@ -299,6 +490,7 @@ def _start_backfill(
     account: str,
     source_scope: str,
     worker_id: str,
+    execution_owner: str,
     scope: str,
     selected_tasks: list[str] | None = None,
     date_start: str | None = None,
@@ -308,6 +500,7 @@ def _start_backfill(
     normalized_selected_tasks = [str(task).strip() for task in (selected_tasks or []) if str(task).strip()]
     normalized_anchor_ids = [str(item).strip() for item in (comment_anchor_source_ids or []) if str(item).strip()]
     anchor_config = {platform: normalized_anchor_ids} if normalized_anchor_ids else None
+    execution_kwargs = _execution_launch_kwargs(owner=execution_owner, worker_id=worker_id)
     if normalized_selected_tasks:
         return analytics_repo.launch_social_account_catalog_backfill(
             platform=platform,
@@ -316,8 +509,7 @@ def _start_backfill(
             date_start=date_start,
             date_end=date_end,
             initiated_by=LOCAL_SCRIPT_LABEL,
-            inline_worker_id=worker_id,
-            allow_local_dev_inline_bypass=True,
+            **execution_kwargs,
             selected_tasks=normalized_selected_tasks,
             comment_anchor_source_ids=anchor_config,
         )
@@ -328,8 +520,7 @@ def _start_backfill(
         date_start=date_start,
         date_end=date_end,
         initiated_by=LOCAL_SCRIPT_LABEL,
-        inline_worker_id=worker_id,
-        allow_local_dev_inline_bypass=True,
+        **execution_kwargs,
         catalog_action="backfill",
         catalog_action_scope=scope,
         comment_anchor_source_ids=anchor_config,
@@ -343,7 +534,9 @@ def _dispatch_fill_missing_posts(
     account: str,
     source_scope: str,
     worker_id: str,
+    execution_owner: str,
 ) -> dict[str, Any]:
+    execution_kwargs = _execution_launch_kwargs(owner=execution_owner, worker_id=worker_id)
     gap_analysis = analytics_repo.get_social_account_catalog_gap_analysis(platform, account)
     recommended_action = str(gap_analysis.get("recommended_action") or "").strip().lower()
 
@@ -353,8 +546,7 @@ def _dispatch_fill_missing_posts(
             account_handle=account,
             source_scope=source_scope,
             initiated_by=LOCAL_SCRIPT_LABEL,
-            inline_worker_id=worker_id,
-            allow_local_dev_inline_bypass=True,
+            **execution_kwargs,
         )
     if recommended_action == "backfill_posts":
         return _start_backfill(
@@ -363,6 +555,7 @@ def _dispatch_fill_missing_posts(
             account=account,
             source_scope=source_scope,
             worker_id=worker_id,
+            execution_owner=execution_owner,
             scope="full_history",
         )
     if recommended_action == "bounded_window_backfill":
@@ -376,6 +569,7 @@ def _dispatch_fill_missing_posts(
             account=account,
             source_scope=source_scope,
             worker_id=worker_id,
+            execution_owner=execution_owner,
             scope="bounded_window",
             date_start=repair_window_start,
             date_end=repair_window_end,
@@ -390,7 +584,7 @@ def _dispatch_fill_missing_posts(
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if bool(getattr(args, "dry_run", False)):
-        print(json.dumps(_dry_run_payload(args), sort_keys=True))
+        print(json.dumps({**_dry_run_payload(args), **_bounded_instagram_dry_run_preview(args)}, sort_keys=True))
         return 0
     if not _bravotv_backfill_confirmation_valid(args):
         print(json.dumps(_blocked_confirmation_payload(args), sort_keys=True), file=sys.stderr)
@@ -411,8 +605,16 @@ def main(argv: list[str] | None = None) -> int:
 
     analytics_repo = _load_module("trr_backend.repositories.social_season_analytics")
     worker_id = _inline_worker_id(args.platform)
+    execution_owner = _execution_owner(args)
+    execution_kwargs = _execution_launch_kwargs(owner=execution_owner, worker_id=worker_id)
 
     try:
+        if execution_owner == "queue":
+            _assert_modal_queue_owner(
+                analytics_repo=analytics_repo,
+                platform=args.platform,
+                account_handle=args.account,
+            )
         if args.action == "backfill":
             date_start = str(getattr(args, "date_start", "") or "").strip() or None
             date_end = str(getattr(args, "date_end", "") or "").strip() or None
@@ -422,6 +624,7 @@ def main(argv: list[str] | None = None) -> int:
                 account=args.account,
                 source_scope=args.source_scope,
                 worker_id=worker_id,
+                execution_owner=execution_owner,
                 scope="bounded_window" if date_start and date_end else "full_history",
                 selected_tasks=_selected_tasks(args),
                 date_start=date_start,
@@ -434,8 +637,7 @@ def main(argv: list[str] | None = None) -> int:
                 account_handle=args.account,
                 source_scope=args.source_scope,
                 initiated_by=LOCAL_SCRIPT_LABEL,
-                inline_worker_id=worker_id,
-                allow_local_dev_inline_bypass=True,
+                **execution_kwargs,
             )
         elif args.action == "sync_newer":
             payload = analytics_repo.sync_newer_social_account_catalog(
@@ -443,8 +645,7 @@ def main(argv: list[str] | None = None) -> int:
                 account_handle=args.account,
                 source_scope=args.source_scope,
                 initiated_by=LOCAL_SCRIPT_LABEL,
-                inline_worker_id=worker_id,
-                allow_local_dev_inline_bypass=True,
+                **execution_kwargs,
             )
         else:
             payload = _dispatch_fill_missing_posts(
@@ -453,10 +654,28 @@ def main(argv: list[str] | None = None) -> int:
                 account=args.account,
                 source_scope=args.source_scope,
                 worker_id=worker_id,
+                execution_owner=execution_owner,
             )
     except Exception as exc:  # noqa: BLE001
+        if execution_owner == "queue":
+            print(
+                json.dumps(
+                    {
+                        "status": "blocked",
+                        "reason": "queue_owner_unavailable",
+                        "execution_owner": execution_owner,
+                        "error": str(exc),
+                    },
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+            )
+            return 1
         print(str(exc), file=sys.stderr)
         return 1
+
+    if execution_owner == "queue":
+        return _queue_submission_result(payload, execution_owner=execution_owner)
 
     control_plane = _load_module("trr_backend.socials.control_plane")
     return _execute_run(

--- a/scripts/socials/local_catalog_action.py
+++ b/scripts/socials/local_catalog_action.py
@@ -127,8 +127,8 @@ def _validate_backfill_window(*, action: str, date_start: str | None, date_end: 
         raise ValueError("--date-start and --date-end are only supported with --action backfill")
     if not start or not end:
         raise ValueError("--date-start and --date-end must be supplied together")
-    if _parse_timestamp(end, option="--date-end") < _parse_timestamp(start, option="--date-start"):
-        raise ValueError("--date-end must not be earlier than --date-start")
+    if _parse_timestamp(end, option="--date-end") <= _parse_timestamp(start, option="--date-start"):
+        raise ValueError("--date-end must be later than --date-start")
 
 
 def apply_workspace_runtime_env(*, repo_root: Path) -> Any:

--- a/scripts/socials/prepare_bravotv_2026_post_backfills.py
+++ b/scripts/socials/prepare_bravotv_2026_post_backfills.py
@@ -63,8 +63,8 @@ def _validate_bounded_window(*, date_start: str, date_end: str) -> None:
         raise ValueError("--date-start and --date-end must be valid ISO-8601 timestamps") from exc
     if start.tzinfo is None or end.tzinfo is None:
         raise ValueError("--date-start and --date-end must include a timezone")
-    if end < start:
-        raise ValueError("--date-end must not be earlier than --date-start")
+    if end <= start:
+        raise ValueError("--date-end must be later than --date-start")
 
 
 def build_prepared_commands(args: argparse.Namespace) -> list[PreparedBackfillCommand]:

--- a/scripts/socials/prepare_bravotv_2026_post_backfills.py
+++ b/scripts/socials/prepare_bravotv_2026_post_backfills.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
@@ -54,6 +55,18 @@ def _account_for_platform(args: argparse.Namespace, platform: str) -> str:
     return str(override or PLATFORM_DEFAULT_ACCOUNTS[platform]).strip().lstrip("@")
 
 
+def _validate_bounded_window(*, date_start: str, date_end: str) -> None:
+    try:
+        start = datetime.fromisoformat(str(date_start).strip().replace("Z", "+00:00"))
+        end = datetime.fromisoformat(str(date_end).strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("--date-start and --date-end must be valid ISO-8601 timestamps") from exc
+    if start.tzinfo is None or end.tzinfo is None:
+        raise ValueError("--date-start and --date-end must include a timezone")
+    if end < start:
+        raise ValueError("--date-end must not be earlier than --date-start")
+
+
 def build_prepared_commands(args: argparse.Namespace) -> list[PreparedBackfillCommand]:
     commands: list[PreparedBackfillCommand] = []
     for platform in _normalize_platforms(args.platform):
@@ -68,8 +81,8 @@ def build_prepared_commands(args: argparse.Namespace) -> list[PreparedBackfillCo
             "network",
             "--action",
             "backfill",
-            "--selected-task",
-            "post_details",
+            "--execution-owner",
+            "queue",
             "--date-start",
             args.date_start,
             "--date-end",
@@ -150,6 +163,10 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    try:
+        _validate_bounded_window(date_start=args.date_start, date_end=args.date_end)
+    except ValueError as exc:
+        parser.error(str(exc))
     commands = build_prepared_commands(args)
     if not commands:
         parser.error("at least one supported platform is required")

--- a/tests/api/routers/test_socials_season_analytics.py
+++ b/tests/api/routers/test_socials_season_analytics.py
@@ -1680,9 +1680,9 @@ def test_post_social_account_catalog_backfill_forwards_bounded_window_dates(
 
     assert response.status_code == 200
     assert mocked_begin.call_args.kwargs["date_start"] == datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
-    assert mocked_begin.call_args.kwargs["date_end"] == datetime(2026, 1, 8, 23, 59, 59, tzinfo=UTC)
+    assert mocked_begin.call_args.kwargs["date_end"] == datetime(2026, 1, 8, 0, 0, tzinfo=UTC)
     assert mocked_finalize.call_args.kwargs["date_start"] == datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
-    assert mocked_finalize.call_args.kwargs["date_end"] == datetime(2026, 1, 8, 23, 59, 59, tzinfo=UTC)
+    assert mocked_finalize.call_args.kwargs["date_end"] == datetime(2026, 1, 8, 0, 0, tzinfo=UTC)
 
 
 def test_get_social_account_catalog_post_detail_route(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scripts/test_local_catalog_action.py
+++ b/tests/scripts/test_local_catalog_action.py
@@ -207,8 +207,7 @@ def test_main_dispatches_selected_task_backfill_through_launch_orchestrator(monk
         "trr_backend.socials.control_plane",
         SimpleNamespace(
             execute_run_with_inline_worker_registration=lambda run_id, **kwargs: (
-                executed.append((run_id, kwargs["worker_id"]))
-                or {"run_id": run_id, "status": "completed"}
+                executed.append((run_id, kwargs["worker_id"])) or {"run_id": run_id, "status": "completed"}
             )
         ),
     )

--- a/tests/scripts/test_local_catalog_action.py
+++ b/tests/scripts/test_local_catalog_action.py
@@ -575,6 +575,7 @@ def test_main_cancels_all_launch_runs_when_a_sibling_does_not_complete(monkeypat
     [
         ["--date-start", "2026-01-01T00:00:00Z"],
         ["--date-start", "not-a-date", "--date-end", "2026-01-02T00:00:00Z"],
+        ["--date-start", "2026-01-01T00:00:00Z", "--date-end", "2026-01-01T00:00:00Z"],
         ["--date-start", "2026-01-02T00:00:00Z", "--date-end", "2026-01-01T00:00:00Z"],
     ],
 )

--- a/tests/scripts/test_local_catalog_action.py
+++ b/tests/scripts/test_local_catalog_action.py
@@ -206,8 +206,9 @@ def test_main_dispatches_selected_task_backfill_through_launch_orchestrator(monk
         __import__("sys").modules,
         "trr_backend.socials.control_plane",
         SimpleNamespace(
-            execute_run_with_inline_worker_registration=lambda run_id, **kwargs: executed.append(
-                (run_id, kwargs["worker_id"])
+            execute_run_with_inline_worker_registration=lambda run_id, **kwargs: (
+                executed.append((run_id, kwargs["worker_id"]))
+                or {"run_id": run_id, "status": "completed"}
             )
         ),
     )
@@ -215,6 +216,7 @@ def test_main_dispatches_selected_task_backfill_through_launch_orchestrator(monk
     assert cli.main() == 0
     assert captured["selected_tasks"] == ["post_details", "comments", "media"]
     assert captured["allow_local_dev_inline_bypass"] is True
+    assert captured["execution_preference"] == "prefer_local_inline"
     assert executed == [
         ("catalog-run-1", "local-script:catalog:instagram:1"),
         ("comments-run-1", "local-script:catalog:instagram:2"),
@@ -224,7 +226,98 @@ def test_main_dispatches_selected_task_backfill_through_launch_orchestrator(monk
     assert "local_catalog_db_pool_defaults" in captured_output.err
 
 
-def test_main_dry_run_prints_plan_without_loading_runtime(monkeypatch, capsys) -> None:
+def test_main_submits_queue_owned_launch_without_starting_an_inline_worker(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "apply_workspace_runtime_env", lambda **kwargs: {})
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda argv=None: SimpleNamespace(
+            platform="twitter",
+            account="bravotv",
+            source_scope="network",
+            action="backfill",
+            execution_owner="queue",
+            selected_tasks=[],
+            comment_anchor_source_ids=[],
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    def _start(*args, **kwargs):
+        captured.update(kwargs)
+        return {"run_id": "queued-run-1", "platform": "twitter", "status": "queued"}
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "trr_backend.repositories.social_season_analytics",
+        SimpleNamespace(
+            is_queue_enabled=lambda: True,
+            assert_worker_available_when_queue_enabled=lambda **kwargs: captured.update(worker_guard=kwargs),
+            start_social_account_catalog_backfill=_start,
+        ),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_load_module",
+        lambda name: (_ for _ in ()).throw(AssertionError("queue submission must not start a local worker"))
+        if name == "trr_backend.socials.control_plane"
+        else __import__("sys").modules[name],
+    )
+
+    assert cli.main() == 0
+    payload = __import__("json").loads(capsys.readouterr().out)
+    assert payload["status"] == "submitted"
+    assert payload["submission_status"] == "queued"
+    assert payload["execution_owner"] == "queue"
+    assert payload["submitted_run_ids"] == ["queued-run-1"]
+    assert captured["inline_worker_id"] is None
+    assert captured["allow_local_dev_inline_bypass"] is False
+    assert captured["execution_preference"] == "auto"
+    assert captured["worker_guard"] == {
+        "required_execution_backend": "modal",
+        "platform": "twitter",
+        "account_handle": "bravotv",
+    }
+
+
+def test_main_rejects_queue_launch_that_was_not_accepted(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "apply_workspace_runtime_env", lambda **kwargs: {})
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda argv=None: SimpleNamespace(
+            platform="twitter",
+            account="bravotv",
+            source_scope="network",
+            action="backfill",
+            execution_owner="queue",
+            selected_tasks=[],
+            comment_anchor_source_ids=[],
+        ),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "trr_backend.repositories.social_season_analytics",
+        SimpleNamespace(
+            is_queue_enabled=lambda: True,
+            assert_worker_available_when_queue_enabled=lambda **kwargs: None,
+            start_social_account_catalog_backfill=lambda *args, **kwargs: {
+                "run_id": "rejected-run-1",
+                "platform": "twitter",
+                "status": "failed",
+            },
+        ),
+    )
+
+    assert cli.main() == 1
+    payload = __import__("json").loads(capsys.readouterr().err.splitlines()[-1])
+    assert payload["reason"] == "queue_launch_not_accepted"
+    assert payload["submitted_run_ids"] == ["rejected-run-1"]
+
+
+def test_main_bounded_instagram_dry_run_preserves_offline_plan_when_preview_is_unavailable(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cli, "load_dotenv", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("no env")))
     monkeypatch.setattr(
         cli,
@@ -268,6 +361,75 @@ def test_main_dry_run_prints_plan_without_loading_runtime(monkeypatch, capsys) -
     assert payload["date_start"] == "2026-01-01T00:00:00Z"
     assert payload["date_end"] == "2026-12-31T23:59:59Z"
     assert payload["catalog_action_scope"] == "bounded_window"
+    assert payload["bounded_preview_available"] is False
+    assert payload["bounded_preview_error"] == "AssertionError: no env"
+
+
+def test_main_bounded_instagram_dry_run_emits_read_only_target_preview(monkeypatch, capsys) -> None:
+    calls: list[str] = []
+    preview_args: dict[str, object] = {}
+
+    monkeypatch.setattr(cli, "load_dotenv", lambda *args, **kwargs: calls.append("dotenv"))
+    monkeypatch.setattr(
+        cli,
+        "apply_workspace_runtime_env",
+        lambda **kwargs: calls.append("workspace_env") or {},
+    )
+
+    def _preview(*args, **kwargs):
+        calls.append("preview")
+        preview_args.update({"args": args, **kwargs})
+        return {
+            "catalog_total": 360,
+            "materialized_total": 360,
+            "completion_target_posts": 360,
+            "completion_target_source": "bounded_catalog",
+        }
+
+    def _unexpected_launch(*_args, **_kwargs):
+        raise AssertionError("dry-run must not launch")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "trr_backend.repositories.social_season_analytics",
+        SimpleNamespace(
+            preview_social_account_catalog_backfill_target=_preview,
+            start_social_account_catalog_backfill=_unexpected_launch,
+            launch_social_account_catalog_backfill=_unexpected_launch,
+        ),
+    )
+
+    assert (
+        cli.main(
+            [
+                "--platform",
+                "instagram",
+                "--account",
+                "bravotv",
+                "--action",
+                "backfill",
+                "--date-start",
+                "2026-06-01T00:00:00Z",
+                "--date-end",
+                "2026-08-01T00:00:00Z",
+                "--dry-run",
+            ]
+        )
+        == 0
+    )
+
+    payload = __import__("json").loads(capsys.readouterr().out)
+    assert calls == ["dotenv", "workspace_env", "preview"]
+    assert payload["would_launch"] is False
+    assert payload["bounded_preview_available"] is True
+    assert payload["bounded_preview_error"] is None
+    assert payload["catalog_total"] == 360
+    assert payload["materialized_total"] == 360
+    assert payload["completion_target_posts"] == 360
+    assert payload["completion_target_source"] == "bounded_catalog"
+    assert preview_args["args"] == ("instagram", "bravotv")
+    assert preview_args["date_start"].isoformat() == "2026-06-01T00:00:00+00:00"
+    assert preview_args["date_end"].isoformat() == "2026-08-01T00:00:00+00:00"
 
 
 def test_main_blocks_bravotv_instagram_backfill_without_confirmation(monkeypatch, capsys) -> None:
@@ -355,6 +517,71 @@ def test_main_cancels_started_run_on_keyboard_interrupt(monkeypatch, capsys) -> 
     assert cancelled[0]["platform"] == "instagram"
     assert cancelled[0]["account_handle"] == "bravotv"
     assert cancelled[0]["cancelled_by"] == "local-script:local_catalog_action.py:interrupted"
+
+
+def test_main_cancels_all_launch_runs_when_a_sibling_does_not_complete(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cli, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "apply_workspace_runtime_env", lambda **kwargs: {})
+    monkeypatch.setattr(
+        cli,
+        "parse_args",
+        lambda argv=None: SimpleNamespace(
+            platform="instagram",
+            account="bravotv",
+            source_scope="network",
+            action="backfill",
+            selected_tasks=["post_details", "comments"],
+            comment_anchor_source_ids=[],
+            confirm_bravotv_instagram_backfill=cli.BRAVOTV_INSTAGRAM_BACKFILL_CONFIRMATION,
+        ),
+    )
+    cancelled: list[str] = []
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "trr_backend.repositories.social_season_analytics",
+        SimpleNamespace(
+            launch_social_account_catalog_backfill=lambda *args, **kwargs: {
+                "platform": "instagram",
+                "catalog_run_id": "catalog-run-1",
+                "comments_run_id": "comments-run-1",
+            },
+            cancel_social_account_catalog_run=lambda **kwargs: (
+                cancelled.append(kwargs["run_id"]) or {"run_id": kwargs["run_id"], "status": "cancelled"}
+            ),
+        ),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "trr_backend.socials.control_plane",
+        SimpleNamespace(
+            execute_run_with_inline_worker_registration=lambda run_id, **kwargs: {
+                "run_id": run_id,
+                "status": "failed",
+            }
+        ),
+    )
+
+    assert cli.main() == 1
+    payload = __import__("json").loads(capsys.readouterr().out)
+    assert payload["status"] == "failed"
+    assert payload["reason"] == "local_run_did_not_complete"
+    assert payload["run_outcomes"] == [{"run_id": "catalog-run-1", "status": "failed"}]
+    assert payload["launch_cleanup"]["cancelled_run_ids"] == ["catalog-run-1", "comments-run-1"]
+    assert cancelled == ["catalog-run-1", "comments-run-1"]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--date-start", "2026-01-01T00:00:00Z"],
+        ["--date-start", "not-a-date", "--date-end", "2026-01-02T00:00:00Z"],
+        ["--date-start", "2026-01-02T00:00:00Z", "--date-end", "2026-01-01T00:00:00Z"],
+    ],
+)
+def test_parse_args_rejects_invalid_bounded_windows(args: list[str]) -> None:
+    with pytest.raises(SystemExit):
+        cli.parse_args(["--platform", "twitter", "--account", "bravotv", "--action", "backfill", *args])
 
 
 def test_main_prints_blocked_launch_payload_without_run_id(monkeypatch, capsys) -> None:

--- a/tests/scripts/test_prepare_bravotv_2026_post_backfills.py
+++ b/tests/scripts/test_prepare_bravotv_2026_post_backfills.py
@@ -109,6 +109,7 @@ def test_prepared_commands_do_not_limit_catalog_post_discovery_to_details() -> N
     "args",
     [
         ["--date-start", "invalid"],
+        ["--date-start", "2026-01-01T00:00:00Z", "--date-end", "2026-01-01T00:00:00Z"],
         ["--date-start", "2026-01-02T00:00:00Z", "--date-end", "2026-01-01T00:00:00Z"],
     ],
 )

--- a/tests/scripts/test_prepare_bravotv_2026_post_backfills.py
+++ b/tests/scripts/test_prepare_bravotv_2026_post_backfills.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from scripts.socials import prepare_bravotv_2026_post_backfills as prep
 
 
@@ -31,8 +33,8 @@ def test_build_prepared_commands_defaults_to_three_separate_platforms() -> None:
             "network",
             "--action",
             "backfill",
-            "--selected-task",
-            "post_details",
+            "--execution-owner",
+            "queue",
             "--date-start",
             "2026-01-01T00:00:00Z",
             "--date-end",
@@ -85,3 +87,31 @@ def test_run_executes_selected_platform(monkeypatch) -> None:
         "bravo",
         "--source-scope",
     )
+
+
+def test_prepared_commands_do_not_limit_catalog_post_discovery_to_details() -> None:
+    args = SimpleNamespace(
+        platform=["twitter"],
+        date_start="2026-01-01T00:00:00Z",
+        date_end="2026-12-31T23:59:59Z",
+        tiktok_account="bravotv",
+        twitter_account="bravotv",
+        youtube_account="bravo",
+    )
+
+    command = prep.build_prepared_commands(args)[0]
+
+    assert "--selected-task" not in command.run_argv
+    assert command.run_argv[command.run_argv.index("--execution-owner") + 1] == "queue"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["--date-start", "invalid"],
+        ["--date-start", "2026-01-02T00:00:00Z", "--date-end", "2026-01-01T00:00:00Z"],
+    ],
+)
+def test_prepared_commands_reject_invalid_windows(args: list[str]) -> None:
+    with pytest.raises(SystemExit):
+        prep.main(args)

--- a/tests/socials/instagram/test_catalog_backfill_wiring.py
+++ b/tests/socials/instagram/test_catalog_backfill_wiring.py
@@ -5,6 +5,30 @@ from trr_backend.socials.pipelines.account_catalog import launch, progress
 from trr_backend.socials.pipelines.comments import instagram as comments
 
 
+def test_comments_dispatch_stays_owned_by_control_plane_after_core_sync(monkeypatch) -> None:
+    from trr_backend.socials.control_plane import dispatch_runtime
+
+    calls: list[dict[str, object]] = []
+
+    def fake_dispatch(*, run_id=None, limit=None):
+        calls.append({"run_id": run_id, "limit": limit})
+        return {"dispatched_job_ids": ["job-1"]}
+
+    monkeypatch.setattr(dispatch_runtime, "dispatch_due_social_jobs", fake_dispatch)
+    monkeypatch.setattr(
+        comments._core,
+        "dispatch_due_social_jobs",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("legacy dispatcher restored")),
+    )
+
+    comments._sync_core_overrides()
+    result = comments.dispatch_due_social_jobs(run_id="run-1", limit=3)
+
+    assert "dispatch_due_social_jobs" in comments._LOCAL_ROOM_NAMES
+    assert result == {"dispatched_job_ids": ["job-1"]}
+    assert calls == [{"run_id": "run-1", "limit": 3}]
+
+
 def test_budget_worker_limit_caps_requested_workers() -> None:
     decision = {"state": "reduced", "limits": {"effective_max_concurrent_jobs": 1}}
 

--- a/tests/socials/instagram/test_catalog_backfill_wiring.py
+++ b/tests/socials/instagram/test_catalog_backfill_wiring.py
@@ -344,9 +344,7 @@ def test_backfill_response_surfaces_comments_not_selected_skip_reason() -> None:
 
     assert skip["comments_skip_reason"] == "comments_not_selected"
     assert skip["comments_skip_detail"] == "comments task not selected for this run"
-    assert skip["comments_operator_action"] == (
-        "Relaunch with the comments task selected to scrape comments."
-    )
+    assert skip["comments_operator_action"] == ("Relaunch with the comments task selected to scrape comments.")
 
 
 def test_backfill_response_surfaces_posts_auth_blocked_skip_reason() -> None:

--- a/tests/socials/instagram/test_catalog_detail_refresh_progress.py
+++ b/tests/socials/instagram/test_catalog_detail_refresh_progress.py
@@ -224,4 +224,3 @@ def test_bounded_detail_refresh_shard_progress_and_completion_use_enumerated_row
         assert progress_updates[-1]["total_posts"] == enumerated_total
     else:
         assert enumerated_total == 0
-

--- a/tests/socials/instagram/test_catalog_detail_refresh_progress.py
+++ b/tests/socials/instagram/test_catalog_detail_refresh_progress.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from trr_backend.socials.instagram import catalog_ingest as catalog
+from trr_backend.socials.pipelines.account_catalog import progress
+
+
+def _patch_catalog_and_core(monkeypatch: pytest.MonkeyPatch, name: str, value: Any) -> None:
+    monkeypatch.setattr(catalog, name, value)
+    if hasattr(catalog._core, name):
+        monkeypatch.setattr(catalog._core, name, value)
+
+
+@contextmanager
+def _fake_account_execution(*_args: Any, **_kwargs: Any):
+    yield "bravotv"
+
+
+@contextmanager
+def _fake_db_connection(**_kwargs: Any):
+    yield object()
+
+
+class _FakeDetailScraper:
+    def fetch_post_info(self, shortcode: str, *, delay: float) -> dict[str, Any]:
+        assert shortcode == "SHORT1"
+        assert delay >= 0
+        return {"items": [{"code": shortcode}]}
+
+    def _parse_post_node(self, node: dict[str, Any], _config: Any) -> SimpleNamespace:
+        post = SimpleNamespace(
+            shortcode=node["code"],
+            pk="media-1",
+            username="bravotv",
+            caption="detail caption",
+            post_type="reel",
+            media_urls=["https://example.test/detail.mp4"],
+            thumbnail_url="https://example.test/detail.jpg",
+            likes=12,
+            comments=7,
+            video_views_observed=44,
+            taken_at=1_700_000_000,
+            hashtags=[],
+            mentions=[],
+            collaborators=[],
+            profile_tags=[],
+        )
+        post.to_dict = lambda: {"code": node["code"]}
+        return post
+
+
+def test_detail_refresh_stamps_metadata_on_successful_fetched_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    fixed_now = datetime(2026, 7, 8, 12, 0, tzinfo=UTC)
+    captured_posts: list[Any] = []
+    progress_updates: list[dict[str, Any]] = []
+
+    def _fake_upsert_instagram_post(*_args: Any, post: Any, **_kwargs: Any) -> dict[str, Any]:
+        captured_posts.append(post)
+        return {
+            "id": "post-1",
+            "shortcode": post.shortcode,
+            "metadata_source": getattr(post, "metadata_source", None),
+            "metadata_scraped_at": getattr(post, "metadata_scraped_at", None),
+        }
+
+    _patch_catalog_and_core(monkeypatch, "_now_utc", lambda: fixed_now)
+    _patch_catalog_and_core(monkeypatch, "_shared_instagram_account_execution", _fake_account_execution)
+    _patch_catalog_and_core(monkeypatch, "_shared_instagram_frontier_auth_validation", lambda _config: (False, None))
+    _patch_catalog_and_core(monkeypatch, "_build_shared_instagram_scraper", lambda **_kwargs: _FakeDetailScraper())
+    _patch_catalog_and_core(
+        monkeypatch,
+        "_shared_account_expected_total_posts_from_config",
+        lambda *_a, **_k: 17_518,
+    )
+    _patch_catalog_and_core(monkeypatch, "_refresh_instagram_post_metrics_only", lambda **_kwargs: None)
+    _patch_catalog_and_core(monkeypatch, "_upsert_instagram_post", _fake_upsert_instagram_post)
+    _patch_catalog_and_core(
+        monkeypatch,
+        "_load_existing_social_account_posts",
+        lambda *_args, **_kwargs: [
+            {
+                "id": "post-1",
+                "shortcode": "SHORT1",
+                "likes": 1,
+                "comments_count": 1,
+                "views": 1,
+                "metadata_scraped_at": None,
+            }
+        ],
+    )
+    monkeypatch.setattr(catalog.pg, "db_connection", _fake_db_connection)
+
+    rows, meta = catalog._scrape_shared_instagram_post_details_refresh(
+        run_id="run-1",
+        account_handle="bravotv",
+        config={
+            "selected_tasks": ["post_details"],
+            "date_start": "2026-06-01T00:00:00+00:00",
+            "date_end": "2026-08-01T00:00:00+00:00",
+            "details_refresh_force_detail_fetch": True,
+            "details_refresh_skip_media_followups": True,
+            "details_refresh_write_batch_size": 1,
+        },
+        job_id="job-1",
+        progress_cb=progress_updates.append,
+    )
+
+    assert meta["details_refreshed_posts"] == 1
+    assert rows[0]["metadata_scraped_at"] == fixed_now
+    assert rows[0]["metadata_source"] == "api_permalink"
+    assert captured_posts[0].metadata_scraped_at == fixed_now
+    assert captured_posts[0].metadata_source == "api_permalink"
+    assert captured_posts[0].metadata_error is None
+    assert meta["expected_total_posts"] == 17_518
+    assert meta["total_posts"] == 1
+    assert meta["completion_target_posts"] == 1
+    assert meta["completion_target_source"] == "bounded_catalog"
+    assert {update["total_posts"] for update in progress_updates} == {1}
+    assert [update["phase"] for update in progress_updates] == [
+        "details_refresh_fetch",
+        "details_refresh_update",
+    ]
+
+
+def test_detail_refresh_progress_uses_terminal_job_rows_over_stale_nonterminal_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(progress, "instagram_posts_acceleration_flags", lambda: {"flags": {}})
+    run_config = {
+        "selected_tasks": ["post_details"],
+        "effective_selected_tasks": ["post_details"],
+        "pagination_state": {},
+        "stage_graph": {
+            "detail_refresh": {
+                "status": "queued",
+                "selected": True,
+                "blocker_reasons": [],
+            },
+        },
+        "target_readiness": {"detail_gap_count": 687},
+    }
+    job_rows = [
+        {
+            "stage": "shared_account_posts",
+            "status": "completed",
+            "metadata": {"fetcher_runtime": {"auth_state": "anonymous"}},
+        }
+    ]
+
+    stage_payload = progress._catalog_progress_stage_graph_payload(
+        run_config=run_config,
+        stages_payload={},
+        job_rows=job_rows,
+    )
+    runtime_payload = progress._catalog_posts_runtime_additive_payload(
+        platform="instagram",
+        account_handle="bravotv",
+        run_id="run-1",
+        run_config=run_config,
+        job_rows=job_rows,
+    )
+
+    assert stage_payload["stage_graph"]["detail_refresh"]["status"] == "completed"
+    assert runtime_payload["details_progress"]["status"] == "completed"
+
+
+@pytest.mark.parametrize("bounded_total", [360, 0])
+def test_bounded_detail_refresh_shard_progress_and_completion_use_enumerated_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    bounded_total: int,
+) -> None:
+    progress_updates: list[dict[str, Any]] = []
+    rows = [
+        {
+            "id": f"post-{index}",
+            "shortcode": f"SHORT{index}",
+            "likes": 1,
+            "comments_count": 1,
+            "views": 1,
+        }
+        for index in range(bounded_total)
+    ]
+
+    _patch_catalog_and_core(monkeypatch, "_shared_instagram_account_execution", _fake_account_execution)
+    _patch_catalog_and_core(monkeypatch, "_shared_instagram_frontier_auth_validation", lambda _config: (False, None))
+    _patch_catalog_and_core(monkeypatch, "_build_shared_instagram_scraper", lambda **_kwargs: SimpleNamespace())
+    _patch_catalog_and_core(monkeypatch, "_load_existing_social_account_posts", lambda *_args, **_kwargs: rows)
+    _patch_catalog_and_core(
+        monkeypatch,
+        "_shared_account_expected_total_posts_from_config",
+        lambda *_args, **_kwargs: 17_518,
+    )
+
+    refreshed_rows, meta = catalog._scrape_shared_instagram_post_details_refresh(
+        run_id="run-bounded",
+        account_handle="bravotv",
+        config={
+            "selected_tasks": ["post_details"],
+            "date_start": "2026-06-01T00:00:00+00:00",
+            "date_end": "2026-08-01T00:00:00+00:00",
+            "details_refresh_dry_run": True,
+            "details_refresh_skip_media_followups": True,
+            "details_refresh_shard_index": 1,
+            "details_refresh_shard_count": 6,
+        },
+        job_id="job-bounded",
+        progress_cb=progress_updates.append,
+    )
+
+    enumerated_total = bounded_total // 6
+    assert len(refreshed_rows) == enumerated_total
+    assert meta["details_refresh_rows_seen"] == enumerated_total
+    assert meta["total_posts"] == enumerated_total
+    assert meta["completion_target_posts"] == enumerated_total
+    assert meta["completion_target_source"] == "bounded_catalog"
+    if progress_updates:
+        assert progress_updates[-1]["posts_checked"] == enumerated_total
+        assert progress_updates[-1]["total_posts"] == enumerated_total
+    else:
+        assert enumerated_total == 0
+

--- a/tests/socials/test_catalog_backfill_window_validation.py
+++ b/tests/socials/test_catalog_backfill_window_validation.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+import trr_backend.repositories.social_season_analytics as social_repo
+from trr_backend.socials.social_season_analytics_impl import (
+    _normalize_catalog_backfill_window,
+    resolve_social_account_catalog_action_seed,
+)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"date_start": "2026-01-01T00:00:00Z"},
+        {"date_start": "invalid", "date_end": "2026-01-02T00:00:00Z"},
+        {"date_start": "2026-01-02T00:00:00Z", "date_end": "2026-01-01T00:00:00Z"},
+        {"catalog_action_scope": "bounded_window"},
+        {
+            "catalog_action_scope": "full_history",
+            "date_start": "2026-01-01T00:00:00Z",
+            "date_end": "2026-01-02T00:00:00Z",
+        },
+    ],
+)
+def test_catalog_action_seed_rejects_ambiguous_windows(kwargs: dict[str, str]) -> None:
+    with pytest.raises(ValueError):
+        resolve_social_account_catalog_action_seed(**kwargs)
+
+
+def test_catalog_action_seed_allows_full_history_without_dates() -> None:
+    assert resolve_social_account_catalog_action_seed() == {
+        "date_start": None,
+        "date_end": None,
+        "resume_frontier_cursor": None,
+        "catalog_action": "backfill",
+        "catalog_action_scope": "full_history",
+    }
+
+
+def test_catalog_window_preserves_exclusive_midnight_end() -> None:
+    start = datetime(2026, 6, 1, tzinfo=UTC)
+    exclusive_end = datetime(2026, 8, 1, tzinfo=UTC)
+
+    assert _normalize_catalog_backfill_window(date_start=start, date_end=exclusive_end) == (
+        start,
+        exclusive_end,
+    )
+
+
+def test_bounded_catalog_counts_and_enumeration_use_half_open_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    queries: list[str] = []
+    start = datetime(2026, 6, 1, tzinfo=UTC)
+    exclusive_end = datetime(2026, 8, 1, tzinfo=UTC)
+
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_one",
+        lambda sql, _params=None: queries.append(" ".join(sql.split()).lower()) or {"total": 0},
+    )
+    monkeypatch.setattr(
+        social_repo.pg,
+        "fetch_all",
+        lambda sql, _params=None: queries.append(" ".join(sql.split()).lower()) or [],
+    )
+
+    social_repo._shared_catalog_total_posts_for_window(
+        "instagram",
+        "bravotv",
+        date_start=start,
+        date_end=exclusive_end,
+    )
+    social_repo._materialized_social_account_total_posts(
+        "instagram",
+        "bravotv",
+        date_start=start,
+        date_end=exclusive_end,
+    )
+    social_repo._load_existing_social_account_posts("instagram", "bravotv", start, exclusive_end)
+
+    assert len(queries) == 3
+    assert all("posted_at < %s" in query for query in queries)
+    assert all("posted_at <= %s" not in query for query in queries)
+    selected, _crossed_start = social_repo._filter_shared_instagram_posts_for_window(
+        [
+            SimpleNamespace(taken_at=int(start.timestamp())),
+            SimpleNamespace(taken_at=int(exclusive_end.timestamp())),
+        ],
+        date_start=start,
+        date_end=exclusive_end,
+    )
+    assert [post.taken_at for post in selected] == [int(start.timestamp())]
+
+
+def test_catalog_shards_are_contiguous_half_open_windows() -> None:
+    start = datetime(2026, 6, 1, tzinfo=UTC)
+    exclusive_end = datetime(2026, 6, 7, tzinfo=UTC)
+
+    shards = social_repo._build_catalog_backfill_shards(
+        platform="tiktok",
+        date_start=start,
+        date_end=exclusive_end,
+        runner_count=2,
+    )
+
+    assert [(shard.window_start, shard.window_end) for shard in shards] == [
+        (datetime(2026, 6, 1, tzinfo=UTC), datetime(2026, 6, 3, tzinfo=UTC)),
+        (datetime(2026, 6, 3, tzinfo=UTC), datetime(2026, 6, 5, tzinfo=UTC)),
+        (datetime(2026, 6, 5, tzinfo=UTC), datetime(2026, 6, 7, tzinfo=UTC)),
+    ]
+
+
+@pytest.mark.parametrize("bounded_total", [360, 0])
+def test_bounded_target_preview_is_read_only_and_preserves_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    bounded_total: int,
+) -> None:
+    monkeypatch.setattr(
+        social_repo,
+        "_shared_catalog_total_posts_for_window",
+        lambda *_args, **_kwargs: bounded_total,
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_materialized_social_account_total_posts",
+        lambda *_args, **_kwargs: bounded_total,
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_run",
+        lambda *_args, **_kwargs: pytest.fail("bounded preview must not create a run"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_create_job",
+        lambda *_args, **_kwargs: pytest.fail("bounded preview must not create a job"),
+    )
+    monkeypatch.setattr(
+        social_repo,
+        "_best_known_social_account_total_posts",
+        lambda *_args, **_kwargs: pytest.fail("bounded preview must not use profile history"),
+    )
+
+    preview = social_repo.preview_social_account_catalog_backfill_target(
+        "instagram",
+        "bravotv",
+        date_start=datetime(2026, 6, 1, tzinfo=UTC),
+        date_end=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+
+    assert preview == {
+        "catalog_total": bounded_total,
+        "materialized_total": bounded_total,
+        "completion_target_posts": bounded_total,
+        "completion_target_source": "bounded_catalog",
+    }
+

--- a/tests/socials/test_catalog_backfill_window_validation.py
+++ b/tests/socials/test_catalog_backfill_window_validation.py
@@ -157,4 +157,3 @@ def test_bounded_target_preview_is_read_only_and_preserves_zero(
         "completion_target_posts": bounded_total,
         "completion_target_source": "bounded_catalog",
     }
-

--- a/tests/socials/test_instagram_permalink_metadata.py
+++ b/tests/socials/test_instagram_permalink_metadata.py
@@ -30,10 +30,7 @@ def _data_sjs_html(payload: dict[str, object]) -> str:
 
 
 def test_instagram_post_permalink_uses_plural_reels_for_known_reels() -> None:
-    assert (
-        instagram_post_permalink("DaCAsaUhOYw", post_format="reel")
-        == "https://www.instagram.com/reels/DaCAsaUhOYw/"
-    )
+    assert instagram_post_permalink("DaCAsaUhOYw", post_format="reel") == "https://www.instagram.com/reels/DaCAsaUhOYw/"
     assert (
         instagram_post_permalink("DaCAsaUhOYw", raw_data={"product_type": "clips"})
         == "https://www.instagram.com/reels/DaCAsaUhOYw/"

--- a/tests/socials/test_instagram_permalink_metadata.py
+++ b/tests/socials/test_instagram_permalink_metadata.py
@@ -6,6 +6,7 @@ from urllib.parse import quote
 
 import pytest
 
+from trr_backend.socials.instagram.constants import instagram_post_permalink
 from trr_backend.socials.instagram.permalink_metadata import (
     _graphql_extract_collaborators,
     _graphql_extract_collaborators_detail,
@@ -26,6 +27,25 @@ def _fixture_json(name: str) -> dict[str, object]:
 
 def _data_sjs_html(payload: dict[str, object]) -> str:
     return f'<html><body><script type="application/json" data-sjs>{json.dumps(payload)}</script></body></html>'
+
+
+def test_instagram_post_permalink_uses_plural_reels_for_known_reels() -> None:
+    assert (
+        instagram_post_permalink("DaCAsaUhOYw", post_format="reel")
+        == "https://www.instagram.com/reels/DaCAsaUhOYw/"
+    )
+    assert (
+        instagram_post_permalink("DaCAsaUhOYw", raw_data={"product_type": "clips"})
+        == "https://www.instagram.com/reels/DaCAsaUhOYw/"
+    )
+
+
+def test_instagram_post_permalink_preserves_explicit_and_feed_fallback() -> None:
+    assert (
+        instagram_post_permalink("ABC123", explicit="https://www.instagram.com/reel/ABC123/")
+        == "https://www.instagram.com/reel/ABC123/"
+    )
+    assert instagram_post_permalink("ABC123", post_format="post") == "https://www.instagram.com/p/ABC123/"
 
 
 def test_fetch_permalink_media_item_parses_data_sjs_payload(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/socials/test_season_comment_rollup_counts.py
+++ b/tests/socials/test_season_comment_rollup_counts.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from trr_backend.socials import social_season_analytics_impl as impl
+
+
+def test_instagram_saved_comment_counts_uses_active_rollup(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(impl, "_relation_exists", lambda *_args, **_kwargs: True)
+
+    def fake_fetch_all(sql: str, params: list[Any]) -> list[dict[str, Any]]:
+        calls.append({"sql": sql, "params": params})
+        return [{"post_id": "post-1", "cnt": 3}]
+
+    monkeypatch.setattr(impl.pg, "fetch_all", fake_fetch_all)
+
+    counts = impl._instagram_saved_comment_counts_by_post(["post-1"], active_filter_applied=True)
+
+    assert counts == {"post-1": 3}
+    assert "from social.instagram_post_comment_rollups r" in calls[0]["sql"]
+    assert "r.active_comment_count::int as cnt" in calls[0]["sql"]
+    assert "total_comment_count" not in calls[0]["sql"]
+    assert calls[0]["params"] == [["post-1"]]
+
+
+def test_instagram_saved_comment_counts_uses_total_rollup(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(impl, "_relation_exists", lambda *_args, **_kwargs: True)
+
+    def fake_fetch_all(sql: str, params: list[Any]) -> list[dict[str, Any]]:
+        calls.append({"sql": sql, "params": params})
+        return [{"post_id": "post-1", "cnt": 5}]
+
+    monkeypatch.setattr(impl.pg, "fetch_all", fake_fetch_all)
+
+    counts = impl._instagram_saved_comment_counts_by_post(["post-1"], active_filter_applied=False)
+
+    assert counts == {"post-1": 5}
+    assert "from social.instagram_post_comment_rollups r" in calls[0]["sql"]
+    assert "r.total_comment_count::int as cnt" in calls[0]["sql"]
+    assert "active_comment_count" not in calls[0]["sql"]
+
+
+@pytest.mark.parametrize(
+    ("active_filter_applied", "expected_counts"),
+    [
+        (True, {"post-1": 2, "post-2": 1}),
+        (False, {"post-1": 3, "post-2": 2}),
+    ],
+)
+def test_instagram_saved_comment_counts_falls_back_to_raw_aggregate(
+    monkeypatch: pytest.MonkeyPatch,
+    active_filter_applied: bool,
+    expected_counts: dict[str, int],
+) -> None:
+    comments = [
+        {"post_id": "post-1", "is_missing": False},
+        {"post_id": "post-1", "is_missing": False},
+        {"post_id": "post-1", "is_missing": True},
+        {"post_id": "post-2", "is_missing": False},
+        {"post_id": "post-2", "is_missing": True},
+    ]
+    calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(impl, "_relation_exists", lambda *_args, **_kwargs: False)
+
+    def direct_count(post_ids: list[str]) -> dict[str, int]:
+        counts = dict.fromkeys(post_ids, 0)
+        for comment in comments:
+            if comment["post_id"] not in counts:
+                continue
+            if active_filter_applied and comment["is_missing"]:
+                continue
+            counts[comment["post_id"]] += 1
+        return {post_id: count for post_id, count in counts.items() if count}
+
+    def fake_fetch_all(sql: str, params: list[Any]) -> list[dict[str, Any]]:
+        calls.append({"sql": sql, "params": params})
+        return [{"post_id": post_id, "cnt": count} for post_id, count in direct_count(params[0]).items()]
+
+    monkeypatch.setattr(impl.pg, "fetch_all", fake_fetch_all)
+
+    post_ids = ["post-1", "post-2"]
+    counts = impl._instagram_saved_comment_counts_by_post(
+        post_ids,
+        active_filter_applied=active_filter_applied,
+    )
+
+    assert counts == expected_counts
+    assert counts == direct_count(post_ids)
+    assert "from social.instagram_comments c" in calls[0]["sql"]
+    assert "group by c.post_id" in calls[0]["sql"]
+    if active_filter_applied:
+        assert "coalesce(c.is_missing, false) = false" in calls[0]["sql"]
+    else:
+        assert "coalesce(c.is_missing, false) = false" not in calls[0]["sql"]

--- a/tests/socials/test_source_scopes.py
+++ b/tests/socials/test_source_scopes.py
@@ -31,4 +31,3 @@ def test_social_analytics_module_reexports_source_scope_helpers() -> None:
     assert legacy.normalize_source_scope("bravo") == "network"
     assert legacy._normalize_source_scope_input("bravo") == "bravo"
     assert legacy._source_scope_is_network_family("creator") is False
-

--- a/tests/socials/test_source_scopes.py
+++ b/tests/socials/test_source_scopes.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from trr_backend.socials import social_season_analytics_impl as legacy
+from trr_backend.socials.source_scopes import (
+    LEGACY_SOURCE_SCOPE_ALIASES,
+    SUPPORTED_SCOPES,
+    normalize_source_scope,
+    normalize_source_scope_input,
+    source_scope_is_network_family,
+)
+
+
+def test_source_scope_helpers_normalize_canonical_and_legacy_values() -> None:
+    assert normalize_source_scope(None) == "network"
+    assert normalize_source_scope(" Creator ") == "creator"
+    assert normalize_source_scope("bravo") == "network"
+    assert normalize_source_scope_input("bravo") == "bravo"
+    assert source_scope_is_network_family("bravo") is True
+
+
+def test_source_scope_helpers_reject_unsupported_values() -> None:
+    with pytest.raises(ValueError, match="Unsupported source scope"):
+        normalize_source_scope("unsupported")
+
+
+def test_social_analytics_module_reexports_source_scope_helpers() -> None:
+    assert legacy.SUPPORTED_SCOPES is SUPPORTED_SCOPES
+    assert legacy.LEGACY_SOURCE_SCOPE_ALIASES is LEGACY_SOURCE_SCOPE_ALIASES
+    assert legacy.normalize_source_scope("bravo") == "network"
+    assert legacy._normalize_source_scope_input("bravo") == "bravo"
+    assert legacy._source_scope_is_network_family("creator") is False
+

--- a/tests/socials/twitter/test_twitter_posts_catalog.py
+++ b/tests/socials/twitter/test_twitter_posts_catalog.py
@@ -146,12 +146,15 @@ class FakeCatalogPersistenceAdapter:
     def upsert_tweet(self, context, **kwargs) -> dict[str, Any]:
         self.legacy_upsert_calls.append({"context": context, **kwargs})
         tweet = kwargs["tweet"]
-        return {
+        row = {
             "job_id": kwargs["job_id"],
             "run_id": kwargs["run_id"],
             "source_account": kwargs["account"],
             "tweet_id": tweet.tweet_id,
         }
+        if getattr(tweet, "is_reply", False) or getattr(tweet, "is_quote", False):
+            row["__trr_inserted"] = True
+        return row
 
 
 def _dependencies(
@@ -440,6 +443,53 @@ def test_shared_catalog_writes_reply_interaction_fetch_state() -> None:
     assert final_state["duplicate_count"] == 0
     assert final_state["status"] == "completed"
     assert final_state["last_error_code"] is None
+
+
+def test_shared_catalog_reply_state_counts_inserts_duplicates_and_skips() -> None:
+    root = _tweet("root", username="TheTraitorsUS")
+    root.replies = 60
+    replies = [_tweet(f"fresh-{index}", username="viewer", is_reply=True) for index in range(2)]
+    replies.extend(_tweet(f"dupe-{index}", username="viewer", is_reply=True) for index in range(4))
+    replies.extend(_tweet(f"skip-{index}", username="viewer", is_reply=True) for index in range(51))
+    scraper = FakeTwitterScraper([root], replies_by_tweet_id={"root": replies})
+    persistence = FakeCatalogPersistenceAdapter()
+    interaction_state_calls: list[dict[str, Any]] = []
+
+    def _upsert_tweet(context, **kwargs):
+        persistence.legacy_upsert_calls.append({"context": context, **kwargs})
+        tweet_id = kwargs["tweet"].tweet_id
+        if tweet_id.startswith("fresh-"):
+            return {"tweet_id": tweet_id, "__trr_inserted": True}
+        if tweet_id.startswith("dupe-"):
+            return {"tweet_id": tweet_id, "__trr_inserted": False}
+        if tweet_id.startswith("skip-"):
+            return None
+        return {"tweet_id": tweet_id}
+
+    persistence.upsert_tweet = _upsert_tweet
+
+    scrape_shared_twitter_posts(
+        run_id="run-1",
+        account_handle="TheTraitorsUS",
+        config={
+            "pipeline_ingest_mode": SHARED_MODE,
+            "catalog_action_scope": "full_history",
+            "twitter_comments_in_posts_stage": True,
+        },
+        job_id="11111111-1111-1111-1111-111111111111",
+        dependencies=_dependencies(
+            scraper=scraper,
+            persistence=persistence,
+            interaction_state_calls=interaction_state_calls,
+        ),
+    )
+
+    reply_states = [call for call in interaction_state_calls if call["interaction_kind"] == "reply"]
+    final_state = reply_states[-1]
+    assert final_state["saved_count_after"] == 6
+    assert final_state["unique_saved_delta"] == 2
+    assert final_state["duplicate_count"] == 4
+    assert final_state["metadata"]["skipped_count"] == 51
 
 
 def test_shared_catalog_writes_exhausted_quote_interaction_fetch_state() -> None:

--- a/trr_backend/socials/instagram/catalog_ingest.py
+++ b/trr_backend/socials/instagram/catalog_ingest.py
@@ -2152,6 +2152,10 @@ def _scrape_shared_instagram_post_details_refresh(
             _coerce_dt(config.get("date_end")),
         )
         all_existing_posts_count = len(existing_posts)
+        bounded_window = _catalog_backfill_has_bounded_window(
+            date_start=_coerce_dt(config.get("date_start")),
+            date_end=_coerce_dt(config.get("date_end")),
+        )
         if detail_shard_count > 1:
             existing_posts = [
                 post for index, post in enumerate(existing_posts) if index % detail_shard_count == detail_shard_index
@@ -2161,7 +2165,9 @@ def _scrape_shared_instagram_post_details_refresh(
             platform="instagram",
             account_handle=account_handle,
         )
-        progress_total_posts = max(all_existing_posts_count, expected_total_posts)
+        progress_total_posts = (
+            len(existing_posts) if bounded_window else max(all_existing_posts_count, expected_total_posts)
+        )
         metrics_pages_scanned = 0
         metrics_posts_checked = 0
         progress_every_posts = _instagram_detail_refresh_progress_every_posts(config)
@@ -2447,6 +2453,10 @@ def _scrape_shared_instagram_post_details_refresh(
                         error_code="metadata_enrichment_exception",
                     )
                     details_refresh_error_reasons["metadata_enrichment_exception"] += 1
+            if parsed_post is not None and not legacy_inline_enrichment:
+                if not str(getattr(parsed_post, "metadata_source", "") or "").strip():
+                    parsed_post.metadata_source = "api_permalink"
+                _mark_instagram_metadata_attempt(post=parsed_post, now_utc=now_utc, success=True)
             unresolved_required_detail_fields = detail_fetch_skipped and (
                 bool(classification.get("metrics_missing"))
                 or "missing_required_source_media" in (classification.get("reasons") or [])
@@ -2545,9 +2555,10 @@ def _scrape_shared_instagram_post_details_refresh(
     )
     retrieval_meta: dict[str, Any] = {
         "source": "db_metrics_refresh",
-        "expected_total_posts": expected_total_posts or None,
-        "total_posts": progress_total_posts or None,
-        "completion_target_posts": details_refresh_completion_target_posts or None,
+        "expected_total_posts": expected_total_posts if bounded_window else expected_total_posts or None,
+        "total_posts": progress_total_posts,
+        "completion_target_posts": details_refresh_completion_target_posts,
+        "completion_target_source": "bounded_catalog" if bounded_window else None,
         "details_refresh_account_rows_seen": all_existing_posts_count,
         "details_refreshed_posts": details_refreshed_posts,
         "details_refresh_views_updated": details_refresh_views_updated,

--- a/trr_backend/socials/instagram/scraper.py
+++ b/trr_backend/socials/instagram/scraper.py
@@ -74,6 +74,7 @@ from trr_backend.socials.instagram.constants import (
     QUERY_TYPE_GRAPHQL_PROFILE_POSTS,
     QUERY_TYPE_LEGACY,
     QUERY_TYPE_PROFILE_INFO,
+    is_instagram_graphql_auth_blocking_error,
     resolve_comment_sort_order,
     resolve_profile_page_content_doc_ids,
 )
@@ -96,7 +97,6 @@ logger = logging.getLogger(__name__)
 
 
 def _sessionid_fingerprint(cookies: Mapping[str, Any]) -> str:
-    """Non-reversible, stable fingerprint of the sessionid for log correlation."""
     raw = str((cookies or {}).get("sessionid") or "")
     if not raw:
         return "none"
@@ -979,7 +979,7 @@ class InstagramScraper:
                 self.session.cookies.set(k, v, domain=".instagram.com")
             self._clear_profile_page_context_cache()
             logger.info(
-                "[instagram] interactive login succeeded — sessionid_fp=%s",
+                "[instagram] interactive login succeeded - sessionid_fp=%s",
                 _sessionid_fingerprint(fresh_cookies),
             )
             return {"refreshed": True, "reason": None, "method": "interactive_chrome"}
@@ -1469,11 +1469,7 @@ class InstagramScraper:
                     error_code = "instagram_graphql_initial_request_failed"
                     if status_code == 400 and failure_message == "checkpoint_required":
                         error_code = "instagram_graphql_checkpoint_required"
-                auth_fatal = error_code in {
-                    "instagram_graphql_cursor_unauthorized",
-                    "instagram_graphql_cursor_forbidden",
-                    "instagram_graphql_checkpoint_required",
-                }
+                auth_fatal = is_instagram_graphql_auth_blocking_error(error_code)
                 self.last_retrieval_meta.update(
                     {
                         "error_code": error_code,
@@ -1621,9 +1617,7 @@ class InstagramScraper:
                 error_code = "instagram_graphql_checkpoint_required"
             else:
                 error_code = "instagram_graphql_initial_request_failed"
-        auth_fatal = error_code in {
-            "instagram_graphql_checkpoint_required",
-        }
+        auth_fatal = is_instagram_graphql_auth_blocking_error(error_code)
         return {
             "error_code": error_code,
             "error_class": error.__class__.__name__ if error is not None else "RequestException",

--- a/trr_backend/socials/social_season_analytics_impl.py
+++ b/trr_backend/socials/social_season_analytics_impl.py
@@ -53366,7 +53366,7 @@ def _comments_coverage_for_platform(
 
     apply_account_filter = source_scope != "community" and bool(platform_accounts)
     account_handles_list = sorted(platform_accounts)
-    instagram_active_filter = "and c.is_missing = false" if _comment_lifecycle_supported("instagram_comments") else ""
+    instagram_lifecycle_supported = bool(_comment_lifecycle_supported("instagram_comments"))
     tiktok_active_filter = "and c.is_missing = false" if _comment_lifecycle_supported("tiktok_comments") else ""
     youtube_active_filter = "and c.is_missing = false" if _comment_lifecycle_supported("youtube_comments") else ""
     facebook_active_filter = "and c.is_missing = false" if _comment_lifecycle_supported("facebook_comments") else ""
@@ -53387,41 +53387,39 @@ def _comments_coverage_for_platform(
         params: list[Any] = [season_id, start_dt, end_dt]
         if apply_account_filter:
             params.append(account_handles_list)
-        row = (
-            pg.fetch_one(
-                f"""
-            with posts as (
-              select
-                p.id,
-                ({reported_comments_expr})::bigint as reported_comments
-              from social.instagram_posts p
-              where p.season_id = %s
-                and p.posted_at >= %s
-                and p.posted_at <= %s
-                {account_filter}
-            ), comment_counts as (
-              select c.post_id, count(*)::bigint as saved_comments
-              from social.instagram_comments c
-              join posts p on p.id = c.post_id
-              where true
-                {instagram_active_filter}
-              group by c.post_id
-            )
+        posts = pg.fetch_all(
+            f"""
             select
-              count(*)::bigint as posts_scanned,
-              coalesce(
-                sum(case when coalesce(cc.saved_comments, 0) < p.reported_comments then 1 else 0 end),
-                0
-              )::bigint as stale_posts_count,
-              coalesce(sum(coalesce(cc.saved_comments, 0)), 0)::bigint as saved_comments,
-              coalesce(sum(p.reported_comments), 0)::bigint as reported_comments
-            from posts p
-            left join comment_counts cc on cc.post_id = p.id
+              p.id,
+              ({reported_comments_expr})::bigint as reported_comments
+            from social.instagram_posts p
+            where p.season_id = %s
+              and p.posted_at >= %s
+              and p.posted_at <= %s
+              {account_filter}
             """,
-                params,
-            )
-            or {}
+            params,
         )
+        saved_counts = _instagram_saved_comment_counts_by_post(
+            [post["id"] for post in posts],
+            active_filter_applied=instagram_lifecycle_supported,
+        )
+        saved_comments = 0
+        reported_comments = 0
+        stale_posts_count = 0
+        for post in posts:
+            reported = int(post.get("reported_comments") or 0)
+            saved = int(saved_counts.get(post.get("id"), 0) or 0)
+            saved_comments += saved
+            reported_comments += reported
+            if saved < reported:
+                stale_posts_count += 1
+        row = {
+            "posts_scanned": len(posts),
+            "stale_posts_count": stale_posts_count,
+            "saved_comments": saved_comments,
+            "reported_comments": reported_comments,
+        }
     elif platform == "tiktok":
         account_filter = (
             "and ltrim(lower(coalesce(nullif(p.username, ''), nullif(p.source_account, ''), '')), '@') = any(%s)"
@@ -55146,6 +55144,42 @@ def _instagram_has_custom_cover_hint(node: Any) -> bool:
     return False
 
 
+def _instagram_saved_comment_counts_by_post(
+    post_ids: list[Any],
+    *,
+    active_filter_applied: bool,
+) -> dict[Any, int]:
+    """Per-post Instagram comment counts, from the rollup table when present."""
+    counts: dict[Any, int] = defaultdict(int)
+    if not post_ids:
+        return counts
+    if _relation_exists("social.instagram_post_comment_rollups"):
+        column = "active_comment_count" if active_filter_applied else "total_comment_count"
+        rows = pg.fetch_all(
+            f"""
+            select r.post_id, r.{column}::int as cnt
+            from social.instagram_post_comment_rollups r
+            where r.post_id = any(%s::uuid[])
+            """,
+            [post_ids],
+        )
+    else:
+        active_filter = "and coalesce(c.is_missing, false) = false" if active_filter_applied else ""
+        rows = pg.fetch_all(
+            f"""
+            select c.post_id, count(*)::int as cnt
+            from social.instagram_comments c
+            where c.post_id = any(%s::uuid[])
+              {active_filter}
+            group by c.post_id
+            """,
+            [post_ids],
+        )
+    for row in rows:
+        counts[row["post_id"]] = row["cnt"]
+    return counts
+
+
 def _normalize_media_url_for_compare(url: str | None) -> str:
     value = str(url or "").strip()
     if not value:
@@ -55304,26 +55338,16 @@ def _week_detail_instagram(
 
     post_ids = [p["id"] for p in posts]
     comments_by_post: dict[Any, list[dict]] = defaultdict(list)
-    comment_counts_by_post: dict[Any, int] = defaultdict(int)
+    instagram_comment_lifecycle_supported = bool(_comment_lifecycle_supported("instagram_comments"))
+    comment_counts_by_post = _instagram_saved_comment_counts_by_post(
+        post_ids,
+        active_filter_applied=instagram_comment_lifecycle_supported,
+    )
     instagram_comment_active_filter = (
-        "and coalesce(c.is_missing, false) = false" if _comment_lifecycle_supported("instagram_comments") else ""
+        "and coalesce(c.is_missing, false) = false" if instagram_comment_lifecycle_supported else ""
     )
 
     if post_ids:
-        # Get total comment counts per post
-        count_rows = pg.fetch_all(
-            f"""
-            select c.post_id, count(*)::int as cnt
-            from social.instagram_comments c
-            where c.post_id = any(%s::uuid[])
-              {instagram_comment_active_filter}
-            group by c.post_id
-            """,
-            [post_ids],
-        )
-        for row in count_rows:
-            comment_counts_by_post[row["post_id"]] = row["cnt"]
-
         # Get top N comments per post using lateral join (0 = no cap)
         limit_clause = f"limit {max_comments}" if max_comments > 0 else "limit all"
         comment_rows = pg.fetch_all(

--- a/trr_backend/socials/social_season_analytics_impl.py
+++ b/trr_backend/socials/social_season_analytics_impl.py
@@ -29099,7 +29099,7 @@ def _upsert_tweet(
         return None
 
     _tweet_id, payload = prepared
-    row = _pg_upsert("twitter_tweets", payload, conflict_col="tweet_id", conn=conn)
+    row = _pg_upsert("twitter_tweets", payload, conflict_col="tweet_id", conn=conn, include_inserted_flag=True)
     if persist_stats is not None and row:
         persist_stats["comments_upserted"] = int(persist_stats.get("comments_upserted") or 0) + 1
     return row

--- a/trr_backend/socials/social_season_analytics_impl.py
+++ b/trr_backend/socials/social_season_analytics_impl.py
@@ -67929,6 +67929,8 @@ def get_social_account_profile_collaborators_tags(*args: Any, **kwargs: Any) -> 
     from trr_backend.socials.account_catalog.profile_reads import _LOCAL_ROOM_FUNCTIONS
 
     return _LOCAL_ROOM_FUNCTIONS["get_social_account_profile_collaborators_tags"](*args, **kwargs)
+
+
 def preview_social_account_catalog_backfill_target(
     platform: str,
     account_handle: str,

--- a/trr_backend/socials/social_season_analytics_impl.py
+++ b/trr_backend/socials/social_season_analytics_impl.py
@@ -60,6 +60,7 @@ from trr_backend.modal_dispatch import (
     modal_social_job_function_names,
     resolve_modal_function,
 )
+from trr_backend.socials import source_scopes as _source_scopes
 from trr_backend.socials.crawlee_runtime import (
     AuthPreflightError,
     AuthPreflightResult,
@@ -92,10 +93,11 @@ _MODAL_REMOTE_AUTH_PROBE_CACHE: dict[tuple[str, str, str], tuple[float, dict[str
 _MODAL_REMOTE_AUTH_PROBE_CACHE_LOCK = Lock()
 
 SUPPORTED_PLATFORMS = SOCIAL_SUPPORTED_PLATFORMS
-SUPPORTED_SCOPES = ("network", "creator", "community", "news")
-LEGACY_SOURCE_SCOPE_ALIASES = {
-    "bravo": "network",
-}
+SUPPORTED_SCOPES = _source_scopes.SUPPORTED_SCOPES
+LEGACY_SOURCE_SCOPE_ALIASES = _source_scopes.LEGACY_SOURCE_SCOPE_ALIASES
+normalize_source_scope = _source_scopes.normalize_source_scope
+_normalize_source_scope_input = _source_scopes.normalize_source_scope_input
+_source_scope_is_network_family = _source_scopes.source_scope_is_network_family
 SOCIAL_ACCOUNT_PROFILE_COMMENT_FILTERS = {"commentable", "incomplete", "not_commentable"}
 SOCIAL_ACCOUNT_PROFILE_POST_SORT_FIELDS = {
     "post",
@@ -125,24 +127,6 @@ SUPPORTED_PIPELINE_INGEST_MODES = (
     "shared_account_async",
     "shared_account_catalog_backfill",
 )
-
-
-def normalize_source_scope(value: Any, *, default: str = "network") -> str:
-    normalized = str(value or default).strip().lower() or default
-    canonical = LEGACY_SOURCE_SCOPE_ALIASES.get(normalized, normalized)
-    if canonical not in SUPPORTED_SCOPES:
-        raise ValueError(f"Unsupported source scope: {value}")
-    return canonical
-
-
-def _normalize_source_scope_input(value: Any, *, default: str = "network") -> str:
-    normalized = str(value or default).strip().lower() or default
-    canonical = normalize_source_scope(normalized, default=default)
-    return normalized if normalized in LEGACY_SOURCE_SCOPE_ALIASES else canonical
-
-
-def _source_scope_is_network_family(value: Any) -> bool:
-    return normalize_source_scope(value) == "network"
 
 
 SUPPORTED_SYNC_STRATEGIES = ("incremental", "full_refresh")
@@ -1490,9 +1474,14 @@ def _build_catalog_backfill_shards(
 ) -> list[IngestTimeShard]:
     start_dt = _coerce_dt(date_start)
     end_dt = _coerce_dt(date_end)
-    span_days = _window_span_days(date_start=start_dt, date_end=end_dt)
+    window_span = end_dt - start_dt if start_dt is not None and end_dt is not None and end_dt > start_dt else None
+    span_days = (
+        max(1, window_span.days + int(bool(window_span.seconds or window_span.microseconds)))
+        if window_span is not None
+        else None
+    )
     shard_days = _catalog_backfill_window_shard_days(platform, span_days=span_days)
-    if start_dt is None or end_dt is None or end_dt < start_dt or shard_days is None:
+    if start_dt is None or end_dt is None or end_dt <= start_dt or shard_days is None:
         return [
             IngestTimeShard(
                 shard_index=0,
@@ -1510,10 +1499,8 @@ def _build_catalog_backfill_shards(
     shard_index = 0
     lanes = _catalog_backfill_run_scheduler_lanes(runner_count)
     shards: list[IngestTimeShard] = []
-    while cursor <= end_dt:
-        window_end = min(cursor + shard_delta - timedelta(microseconds=1), end_dt)
-        if window_end < cursor:
-            window_end = cursor
+    while cursor < end_dt:
+        window_end = min(cursor + shard_delta, end_dt)
         day_offset = max(0, (cursor.date() - start_dt.date()).days)
         shards.append(
             IngestTimeShard(
@@ -1526,9 +1513,7 @@ def _build_catalog_backfill_shards(
                 day_weight=1.0,
             )
         )
-        if window_end >= end_dt:
-            break
-        cursor = window_end + timedelta(microseconds=1)
+        cursor = window_end
         shard_index += 1
     return shards
 
@@ -1949,14 +1934,18 @@ def _normalize_catalog_backfill_window(
     date_start: datetime | None,
     date_end: datetime | None,
 ) -> tuple[datetime | None, datetime | None]:
+    start_supplied = date_start is not None and str(date_start).strip() != ""
+    end_supplied = date_end is not None and str(date_end).strip() != ""
+    if start_supplied != end_supplied:
+        raise ValueError("date_start and date_end must be supplied together for a bounded catalog backfill.")
+    if not start_supplied:
+        return None, None
     bounded_start = _coerce_dt(date_start)
     bounded_end = _coerce_dt(date_end)
-    if bounded_start is None or bounded_end is None or bounded_end < bounded_start:
-        return bounded_start, bounded_end
-    # Treat midnight end bounds as inclusive whole-day windows so a bounded
-    # backfill does not silently omit the final day on literal-timestamp scrapers.
-    if bounded_end.hour == 0 and bounded_end.minute == 0 and bounded_end.second == 0 and bounded_end.microsecond == 0:
-        bounded_end = bounded_end + timedelta(days=1) - timedelta(seconds=1)
+    if bounded_start is None or bounded_end is None:
+        raise ValueError("date_start and date_end must be valid timestamps for a bounded catalog backfill.")
+    if bounded_end <= bounded_start:
+        raise ValueError("date_end must be later than date_start for a bounded catalog backfill.")
     return bounded_start, bounded_end
 
 
@@ -20830,7 +20819,7 @@ def _load_existing_social_account_posts(
         conditions.append(f"{ts_col} >= %s")
         params.append(date_start)
     if date_end:
-        conditions.append(f"{ts_col} <= %s")
+        conditions.append(f"{ts_col} < %s")
         params.append(date_end)
     if source_ids is not None:
         normalized_source_ids = sorted({str(item or "").strip() for item in source_ids if str(item or "").strip()})
@@ -34391,7 +34380,7 @@ def _shared_catalog_total_posts_for_window(
         where_clauses.append(f"p.{posted_at_column} >= %s")
         params.append(start_dt)
     if end_dt is not None:
-        where_clauses.append(f"p.{posted_at_column} <= %s")
+        where_clauses.append(f"p.{posted_at_column} < %s")
         params.append(end_dt)
     try:
         row = (
@@ -38250,7 +38239,7 @@ def _filter_shared_instagram_posts_for_window(
         if start_dt is not None and posted_at < start_dt:
             crossed_start = True
             continue
-        if end_dt is not None and posted_at > end_dt:
+        if end_dt is not None and posted_at >= end_dt:
             continue
         selected_posts.append(post)
     return selected_posts, crossed_start
@@ -61920,7 +61909,7 @@ def _materialized_social_account_total_posts(
         date_clauses.append(f"and p.{posted_at_column} >= %s")
         date_params.append(start_dt)
     if end_dt is not None:
-        date_clauses.append(f"and p.{posted_at_column} <= %s")
+        date_clauses.append(f"and p.{posted_at_column} < %s")
         date_params.append(end_dt)
     sql = f"""
         select count(*)::int as total
@@ -66515,6 +66504,12 @@ def resolve_social_account_catalog_action_seed(
     catalog_action: str | None = None,
     catalog_action_scope: str | None = None,
 ) -> dict[str, Any]:
+    normalized_action = str(catalog_action or "").strip().lower() or "backfill"
+    normalized_scope = str(catalog_action_scope or "").strip().lower() or None
+    if normalized_scope == "bounded_window" and (date_start is None or date_end is None):
+        raise ValueError("date_start and date_end are required when catalog_action_scope is bounded_window.")
+    if normalized_scope == "full_history" and (date_start is not None or date_end is not None):
+        raise ValueError("date_start and date_end are not valid when catalog_action_scope is full_history.")
     normalized_date_start, normalized_date_end = _normalize_catalog_backfill_window(
         date_start=date_start,
         date_end=date_end,
@@ -66524,10 +66519,6 @@ def resolve_social_account_catalog_action_seed(
         date_start=normalized_date_start,
         date_end=normalized_date_end,
     )
-    normalized_action = str(catalog_action or "").strip().lower() or None
-    normalized_scope = str(catalog_action_scope or "").strip().lower() or None
-    if normalized_action is None:
-        normalized_action = "backfill"
     if normalized_scope is None:
         if normalized_action == "sync_recent":
             normalized_scope = "recent_window"
@@ -67938,3 +67929,37 @@ def get_social_account_profile_collaborators_tags(*args: Any, **kwargs: Any) -> 
     from trr_backend.socials.account_catalog.profile_reads import _LOCAL_ROOM_FUNCTIONS
 
     return _LOCAL_ROOM_FUNCTIONS["get_social_account_profile_collaborators_tags"](*args, **kwargs)
+def preview_social_account_catalog_backfill_target(
+    platform: str,
+    account_handle: str,
+    *,
+    date_start: datetime,
+    date_end: datetime,
+) -> dict[str, Any]:
+    normalized_platform = _normalize_social_account_profile_platform(platform)
+    normalized_account = _normalize_social_account_profile_handle(account_handle)
+    if normalized_platform not in set(CATALOG_SUPPORTED_PLATFORMS):
+        raise ValueError("Catalog backfill is not supported for this platform.")
+    bounded_start, bounded_end = _normalize_catalog_backfill_window(
+        date_start=date_start,
+        date_end=date_end,
+    )
+    assert bounded_start is not None and bounded_end is not None
+    catalog_total = _shared_catalog_total_posts_for_window(
+        normalized_platform,
+        normalized_account,
+        date_start=bounded_start,
+        date_end=bounded_end,
+    )
+    materialized_total = _materialized_social_account_total_posts(
+        normalized_platform,
+        normalized_account,
+        date_start=bounded_start,
+        date_end=bounded_end,
+    )
+    return {
+        "catalog_total": catalog_total,
+        "materialized_total": materialized_total,
+        "completion_target_posts": max(catalog_total, materialized_total),
+        "completion_target_source": "bounded_catalog",
+    }

--- a/trr_backend/socials/source_scopes.py
+++ b/trr_backend/socials/source_scopes.py
@@ -26,4 +26,3 @@ def normalize_source_scope_input(value: Any, *, default: str = "network") -> str
 
 def source_scope_is_network_family(value: Any) -> bool:
     return normalize_source_scope(value) == "network"
-

--- a/trr_backend/socials/source_scopes.py
+++ b/trr_backend/socials/source_scopes.py
@@ -1,0 +1,29 @@
+"""Source-scope normalization helpers for social analytics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+SUPPORTED_SCOPES = ("network", "creator", "community", "news")
+LEGACY_SOURCE_SCOPE_ALIASES = {
+    "bravo": "network",
+}
+
+
+def normalize_source_scope(value: Any, *, default: str = "network") -> str:
+    normalized = str(value or default).strip().lower() or default
+    canonical = LEGACY_SOURCE_SCOPE_ALIASES.get(normalized, normalized)
+    if canonical not in SUPPORTED_SCOPES:
+        raise ValueError(f"Unsupported source scope: {value}")
+    return canonical
+
+
+def normalize_source_scope_input(value: Any, *, default: str = "network") -> str:
+    normalized = str(value or default).strip().lower() or default
+    canonical = normalize_source_scope(normalized, default=default)
+    return normalized if normalized in LEGACY_SOURCE_SCOPE_ALIASES else canonical
+
+
+def source_scope_is_network_family(value: Any) -> bool:
+    return normalize_source_scope(value) == "network"
+

--- a/trr_backend/socials/twitter/posts_catalog/catalog.py
+++ b/trr_backend/socials/twitter/posts_catalog/catalog.py
@@ -873,7 +873,9 @@ def _persist_tweet_interactions(
             comment_fail_reasons.add("fetch_exception")
             replies = []
 
-        reply_upserted = 0
+        reply_inserted = 0
+        reply_duplicate = 0
+        reply_skipped = 0
         for reply_index, reply in enumerate(replies, start=1):
             if not getattr(reply, "reply_to_tweet_id", None):
                 reply.reply_to_tweet_id = tweet_id
@@ -894,7 +896,12 @@ def _persist_tweet_interactions(
             stats["comments_fetched"] += 1
             if row:
                 stats["comments_upserted"] += 1
-                reply_upserted += 1
+                if row.get("__trr_inserted"):
+                    reply_inserted += 1
+                else:
+                    reply_duplicate += 1
+            else:
+                reply_skipped += 1
             if reply_index == 1 or reply_index % 25 == 0 or reply_index == len(replies):
                 _emit_interaction_progress(
                     index=index,
@@ -917,9 +924,9 @@ def _persist_tweet_interactions(
                 root_source_id=tweet_id,
                 interaction_kind="reply",
                 reported_count=expected_replies,
-                saved_count_after=reply_upserted,
-                unique_saved_delta=reply_upserted,
-                duplicate_count=max(0, len(replies) - reply_upserted),
+                saved_count_after=reply_inserted + reply_duplicate,
+                unique_saved_delta=reply_inserted,
+                duplicate_count=reply_duplicate,
                 pages_scanned=max(reply_pages_scanned, _shared_catalog_progress_pages_scanned(retrieval_meta)),
                 status=reply_status,
                 exhaustion_reason=reply_fail_reason if reply_status == "exhausted" else None,
@@ -929,6 +936,7 @@ def _persist_tweet_interactions(
                     "phase": "persist_twitter_replies",
                     "run_id": run_id,
                     "fetched_count": len(replies),
+                    "skipped_count": reply_skipped,
                 },
             )
 
@@ -1015,7 +1023,9 @@ def _persist_tweet_interactions(
             quote_fail_reasons.add("fetch_exception")
             quotes = []
 
-        quote_upserted = 0
+        quote_inserted = 0
+        quote_duplicate = 0
+        quote_skipped = 0
         for quote_index, quote in enumerate(quotes, start=1):
             quote.is_reply = False
             quote.reply_to_tweet_id = None
@@ -1045,7 +1055,12 @@ def _persist_tweet_interactions(
             stats["quotes_fetched"] += 1
             if row:
                 stats["quotes_upserted"] += 1
-                quote_upserted += 1
+                if row.get("__trr_inserted"):
+                    quote_inserted += 1
+                else:
+                    quote_duplicate += 1
+            else:
+                quote_skipped += 1
             if should_emit_quote_progress:
                 _emit_interaction_progress(
                     index=index,
@@ -1069,9 +1084,9 @@ def _persist_tweet_interactions(
                 root_source_id=tweet_id,
                 interaction_kind="quote",
                 reported_count=expected_quotes,
-                saved_count_after=quote_upserted,
-                unique_saved_delta=quote_upserted,
-                duplicate_count=max(0, quote_saved_total - quote_upserted),
+                saved_count_after=quote_inserted + quote_duplicate,
+                unique_saved_delta=quote_inserted,
+                duplicate_count=quote_duplicate,
                 off_root_count=quote_off_root_count,
                 pages_scanned=max(quote_pages_scanned, _shared_catalog_progress_pages_scanned(retrieval_meta)),
                 status=quote_status,
@@ -1083,6 +1098,7 @@ def _persist_tweet_interactions(
                     "run_id": run_id,
                     "fetched_count": len(quotes),
                     "saved_candidate_count": quote_saved_total,
+                    "skipped_count": quote_skipped,
                 },
             )
 


### PR DESCRIPTION
## Outcome

- Applies bounded targeting consistently across supported social catalog workflows.
- Preserves ownership and admission constraints while avoiding unbounded catalog work.
- Consolidates advisor findings 027 and 042.

## Dependencies

Stacked on #167 after Threads and TikTok persistence.

## Validation

- 114 focused tests passed.
- Ruff 0.14.4 check and format checks passed.
- git diff --check passed.

## Deployment

No production deployment was performed. Modal rollout waits until merge.