### PR TITLE
Hydrate Modal maintenance owner settings in deploy tooling

### DIFF
--- a/scripts/modal/deploy_backend.py
+++ b/scripts/modal/deploy_backend.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from dotenv import dotenv_values
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -27,6 +29,13 @@ DEFAULT_INCIDENT_NOTE = (
 INCIDENT_NOTES_DIR = REPO_ROOT / "docs" / "observability"
 REQUIRED_MODAL_PROFILE = "admin-56995"
 REQUIRED_MODAL_WORKSPACE = "admin-56995"
+MODAL_OWNERSHIP_ENV_KEYS = frozenset(
+    {
+        "TRR_MODAL_MAINTENANCE_OWNER_REQUIRED",
+        "TRR_MODAL_ALWAYS_ON_SCHEDULES_ENABLED",
+        "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED",
+    }
+)
 DEFAULT_HISTORY_LIMIT = 5
 HISTORY_STAMP_START = "<!-- modal-deploy-history:start -->"
 HISTORY_STAMP_END = "<!-- modal-deploy-history:end -->"
@@ -39,8 +48,28 @@ def python_command() -> str:
     return sys.executable or "python3.11"
 
 
+def modal_source_env_path(
+    environ: dict[str, str] | None = None,
+    *,
+    repo_root: Path = REPO_ROOT,
+) -> Path:
+    env = os.environ if environ is None else environ
+    configured = str(env.get("TRR_MODAL_SOURCE_ENV") or "").strip()
+    candidate = Path(configured).expanduser() if configured else repo_root / ".env"
+    if not candidate.is_absolute():
+        candidate = (repo_root / candidate).resolve()
+    return candidate
+
+
 def pinned_modal_env(environ: dict[str, str] | None = None) -> dict[str, str]:
-    env = dict(environ or os.environ)
+    env = dict(os.environ if environ is None else environ)
+    source_env = modal_source_env_path(env)
+    if source_env.is_file():
+        configured = dotenv_values(source_env)
+        for key in MODAL_OWNERSHIP_ENV_KEYS:
+            value = configured.get(key)
+            if key not in env and value is not None:
+                env[key] = str(value)
     env["MODAL_PROFILE"] = REQUIRED_MODAL_PROFILE
     env["TRR_MODAL_APP_NAME"] = DEFAULT_APP_NAME
     return env

--- a/scripts/modal/reconcile_modal_runtime.py
+++ b/scripts/modal/reconcile_modal_runtime.py
@@ -196,7 +196,8 @@ def modal_fingerprint_files(repo_root: Path = REPO_ROOT) -> list[Path]:
 
 
 def build_modal_fingerprint(repo_root: Path = REPO_ROOT) -> str:
-    source_env = prepare_named_secrets._load_source_env(repo_root / ".env")
+    source_env_path = deploy_backend.modal_source_env_path(repo_root=repo_root)
+    source_env = prepare_named_secrets._load_source_env(source_env_path)
     runtime_values, social_values = prepare_named_secrets._split_env(source_env)
     runtime_values = prepare_named_secrets._apply_runtime_overrides(
         runtime_values,

--- a/scripts/modal/verify_modal_readiness.py
+++ b/scripts/modal/verify_modal_readiness.py
@@ -73,11 +73,11 @@ def _maybe_reexec_with_repo_venv() -> None:
 if __name__ == "__main__":
     _maybe_reexec_with_repo_venv()
 
-from scripts.modal.deploy_backend import REQUIRED_MODAL_PROFILE, pinned_modal_env
+from scripts.modal.deploy_backend import pinned_modal_env
 
 # Pin the Modal workspace before the trr_backend imports below load the Modal
 # SDK, which resolves MODAL_PROFILE at import time.
-os.environ["MODAL_PROFILE"] = REQUIRED_MODAL_PROFILE
+os.environ.update(pinned_modal_env())
 
 from scripts._workspace_runtime_env import apply_workspace_runtime_env
 from trr_backend.modal_dispatch import (

--- a/tests/scripts/test_deploy_backend_modal.py
+++ b/tests/scripts/test_deploy_backend_modal.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import sys
 from contextlib import contextmanager
 
 import pytest
@@ -26,6 +28,97 @@ def test_pinned_modal_env_forces_admin_profile() -> None:
     assert env["TRR_MODAL_INSTAGRAM_PAYLOAD_READ_MODE"] == "compare"
     assert env["TRR_MODAL_INSTAGRAM_PAYLOAD_COMPARE_SAMPLE_RATE"] == "0.1"
     assert env["OTHER"] == "1"
+
+
+def test_pinned_modal_env_hydrates_only_missing_ownership_settings(
+    tmp_path,
+) -> None:
+    source_env = tmp_path / "modal.env"
+    source_env.write_text(
+        "TRR_MODAL_MAINTENANCE_OWNER_REQUIRED=1\n"
+        "TRR_MODAL_ALWAYS_ON_SCHEDULES_ENABLED=0\n"
+        "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED=1\n"
+        "DATABASE_URL=must-not-leak\n",
+        encoding="utf-8",
+    )
+
+    env = cli.pinned_modal_env(
+        {
+            "TRR_MODAL_SOURCE_ENV": str(source_env),
+            "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED": "0",
+        }
+    )
+
+    assert env["TRR_MODAL_MAINTENANCE_OWNER_REQUIRED"] == "1"
+    assert env["TRR_MODAL_ALWAYS_ON_SCHEDULES_ENABLED"] == "0"
+    assert env["TRR_MODAL_RUNTIME_SCHEDULER_ENABLED"] == "0"
+    assert "DATABASE_URL" not in env
+
+
+def test_pinned_modal_env_respects_an_explicit_empty_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("TRR_MODAL_RUNTIME_SCHEDULER_ENABLED", "1")
+
+    env = cli.pinned_modal_env({"TRR_MODAL_SOURCE_ENV": str(tmp_path / "missing.env")})
+
+    assert "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED" not in env
+
+
+def test_pinned_modal_env_resolves_relative_source_from_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    source_dir = cli.REPO_ROOT / f".tmp-test-modal-env-{tmp_path.name}"
+    source_dir.mkdir()
+    source_env = source_dir / "modal.env"
+    source_env.write_text(
+        "TRR_MODAL_MAINTENANCE_OWNER_REQUIRED=1\n"
+        "TRR_MODAL_ALWAYS_ON_SCHEDULES_ENABLED=0\n"
+        "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED=1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    try:
+        env = cli.pinned_modal_env(
+            {"TRR_MODAL_SOURCE_ENV": str(source_env.relative_to(cli.REPO_ROOT))}
+        )
+    finally:
+        source_env.unlink(missing_ok=True)
+        source_dir.rmdir()
+
+    assert env["TRR_MODAL_MAINTENANCE_OWNER_REQUIRED"] == "1"
+    assert env["TRR_MODAL_ALWAYS_ON_SCHEDULES_ENABLED"] == "0"
+    assert env["TRR_MODAL_RUNTIME_SCHEDULER_ENABLED"] == "1"
+
+
+def test_readiness_import_hydrates_ownership_before_modal_jobs_import(tmp_path) -> None:
+    source_env = tmp_path / "modal.env"
+    source_env.write_text(
+        "TRR_MODAL_MAINTENANCE_OWNER_REQUIRED=1\n"
+        "TRR_MODAL_ALWAYS_ON_SCHEDULES_ENABLED=0\n"
+        "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED=1\n",
+        encoding="utf-8",
+    )
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in cli.MODAL_OWNERSHIP_ENV_KEYS
+    }
+    env["TRR_MODAL_SOURCE_ENV"] = str(source_env)
+
+    completed = subprocess.run(
+        [sys.executable, "-c", "import scripts.modal.verify_modal_readiness"],
+        cwd=cli.REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_verify_required_workspace_accepts_admin_workspace(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/scripts/test_deploy_backend_modal.py
+++ b/tests/scripts/test_deploy_backend_modal.py
@@ -81,9 +81,7 @@ def test_pinned_modal_env_resolves_relative_source_from_repo_root(
     )
     monkeypatch.chdir(tmp_path)
     try:
-        env = cli.pinned_modal_env(
-            {"TRR_MODAL_SOURCE_ENV": str(source_env.relative_to(cli.REPO_ROOT))}
-        )
+        env = cli.pinned_modal_env({"TRR_MODAL_SOURCE_ENV": str(source_env.relative_to(cli.REPO_ROOT))})
     finally:
         source_env.unlink(missing_ok=True)
         source_dir.rmdir()
@@ -101,11 +99,7 @@ def test_readiness_import_hydrates_ownership_before_modal_jobs_import(tmp_path) 
         "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED=1\n",
         encoding="utf-8",
     )
-    env = {
-        key: value
-        for key, value in os.environ.items()
-        if key not in cli.MODAL_OWNERSHIP_ENV_KEYS
-    }
+    env = {key: value for key, value in os.environ.items() if key not in cli.MODAL_OWNERSHIP_ENV_KEYS}
     env["TRR_MODAL_SOURCE_ENV"] = str(source_env)
 
     completed = subprocess.run(

--- a/tests/scripts/test_reconcile_modal_runtime.py
+++ b/tests/scripts/test_reconcile_modal_runtime.py
@@ -399,6 +399,26 @@ def test_save_and_load_fingerprint_round_trip(tmp_path) -> None:
     assert saved["fingerprint"] == "abc123"
 
 
+def test_modal_fingerprint_uses_explicit_source_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    repo_root = tmp_path / "backend"
+    repo_root.mkdir()
+    source_env = tmp_path / "canonical.env"
+    source_env.write_text(
+        "TRR_DB_URL=postgresql://user:pass@localhost:5432/trr\n"
+        "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED=1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TRR_MODAL_SOURCE_ENV", str(source_env))
+
+    fingerprint = cli.build_modal_fingerprint(repo_root)
+
+    assert isinstance(fingerprint, str)
+    assert len(fingerprint) == 64
+
+
 def test_modal_fingerprint_changes_when_instagram_comments_fetcher_changes(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/scripts/test_reconcile_modal_runtime.py
+++ b/tests/scripts/test_reconcile_modal_runtime.py
@@ -407,8 +407,7 @@ def test_modal_fingerprint_uses_explicit_source_env(
     repo_root.mkdir()
     source_env = tmp_path / "canonical.env"
     source_env.write_text(
-        "TRR_DB_URL=postgresql://user:pass@localhost:5432/trr\n"
-        "TRR_MODAL_RUNTIME_SCHEDULER_ENABLED=1\n",
+        "TRR_DB_URL=postgresql://user:pass@localhost:5432/trr\nTRR_MODAL_RUNTIME_SCHEDULER_ENABLED=1\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("TRR_MODAL_SOURCE_ENV", str(source_env))


### PR DESCRIPTION
## Summary
- load only the three non-secret Modal maintenance-owner flags from `TRR_MODAL_SOURCE_ENV` or the backend `.env`
- preserve explicit process overrides and repo-relative source-env semantics
- use the same source-env path for runtime fingerprinting and readiness imports

## Why
Clean `main` deployment/readiness and workspace `make dev-hybrid` preflight failed before reaching Modal because `modal_jobs` validates its maintenance owner at import time while the scripts had not projected the canonical owner settings into the process environment.

## Validation
- `pytest -q tests/scripts/test_deploy_backend_modal.py tests/scripts/test_reconcile_modal_runtime.py tests/scripts/test_verify_modal_readiness.py` (70 passed)
- `ruff check` on changed Python files
- clean-process deploy dry run with ownership flags unset
- clean-process readiness import with ownership flags unset
- `git diff --check`

## Runtime / rollback
No database migration. Roll back by reverting this commit; explicit environment values still take precedence. After merge, redeploy `trr-backend-jobs` and rerun workspace `make dev-hybrid` preflight.