### PR TITLE
fix(migrations): qualify trigram operator class

### DIFF
--- a/supabase/migrations/20260323175500_add_social_post_search_indexes.sql
+++ b/supabase/migrations/20260323175500_add_social_post_search_indexes.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pg_trgm with schema extensions;
 
 create index if not exists instagram_posts_search_text_trgm_idx
-  on social.instagram_posts using gin (search_text gin_trgm_ops);
+  on social.instagram_posts using gin (search_text extensions.gin_trgm_ops);
 create index if not exists instagram_posts_search_hashtags_idx
   on social.instagram_posts using gin (search_hashtags);
 create index if not exists instagram_posts_search_handles_idx
@@ -12,7 +12,7 @@ create index if not exists instagram_posts_search_handle_identities_idx
   on social.instagram_posts using gin (search_handle_identities);
 
 create index if not exists tiktok_posts_search_text_trgm_idx
-  on social.tiktok_posts using gin (search_text gin_trgm_ops);
+  on social.tiktok_posts using gin (search_text extensions.gin_trgm_ops);
 create index if not exists tiktok_posts_search_hashtags_idx
   on social.tiktok_posts using gin (search_hashtags);
 create index if not exists tiktok_posts_search_handles_idx
@@ -21,7 +21,7 @@ create index if not exists tiktok_posts_search_handle_identities_idx
   on social.tiktok_posts using gin (search_handle_identities);
 
 create index if not exists youtube_videos_search_text_trgm_idx
-  on social.youtube_videos using gin (search_text gin_trgm_ops);
+  on social.youtube_videos using gin (search_text extensions.gin_trgm_ops);
 create index if not exists youtube_videos_search_hashtags_idx
   on social.youtube_videos using gin (search_hashtags);
 create index if not exists youtube_videos_search_handles_idx
@@ -30,7 +30,7 @@ create index if not exists youtube_videos_search_handle_identities_idx
   on social.youtube_videos using gin (search_handle_identities);
 
 create index if not exists twitter_tweets_search_text_trgm_idx
-  on social.twitter_tweets using gin (search_text gin_trgm_ops);
+  on social.twitter_tweets using gin (search_text extensions.gin_trgm_ops);
 create index if not exists twitter_tweets_search_hashtags_idx
   on social.twitter_tweets using gin (search_hashtags);
 create index if not exists twitter_tweets_search_handles_idx
@@ -39,7 +39,7 @@ create index if not exists twitter_tweets_search_handle_identities_idx
   on social.twitter_tweets using gin (search_handle_identities);
 
 create index if not exists facebook_posts_search_text_trgm_idx
-  on social.facebook_posts using gin (search_text gin_trgm_ops);
+  on social.facebook_posts using gin (search_text extensions.gin_trgm_ops);
 create index if not exists facebook_posts_search_hashtags_idx
   on social.facebook_posts using gin (search_hashtags);
 create index if not exists facebook_posts_search_handles_idx
@@ -48,7 +48,7 @@ create index if not exists facebook_posts_search_handle_identities_idx
   on social.facebook_posts using gin (search_handle_identities);
 
 create index if not exists meta_threads_posts_search_text_trgm_idx
-  on social.meta_threads_posts using gin (search_text gin_trgm_ops);
+  on social.meta_threads_posts using gin (search_text extensions.gin_trgm_ops);
 create index if not exists meta_threads_posts_search_hashtags_idx
   on social.meta_threads_posts using gin (search_hashtags);
 create index if not exists meta_threads_posts_search_handles_idx


### PR DESCRIPTION
Qualifies six historical `gin_trgm_ops` references as `extensions.gin_trgm_ops` so fresh Supabase replay does not depend on the session search path.

Evidence:
- exact one-file child of c7f675c8
- source/file and statement-array hashes match PREVIEW-22
- production indexes already use the same `extensions.gin_trgm_ops` OID
- production migration history updated statements-only, 310/310 with zero empty entries
- independent PREVIEW-24 review: ACCEPT

No application DDL was replayed.