### PR TITLE
refactor(socials): extract ingest debug control plane

### DIFF
--- a/tests/repositories/test_social_season_analytics.py
+++ b/tests/repositories/test_social_season_analytics.py
@@ -4,7 +4,6 @@ import hashlib
 import inspect
 import json
 import os
-import subprocess
 import time
 from collections import Counter
 from collections.abc import Iterator, Mapping
@@ -52085,90 +52084,6 @@ def test_get_worker_detail_returns_worker_only_when_no_job(monkeypatch: pytest.M
     assert payload["current_job"] is None
     assert payload["run"] is None
     assert payload["currently_scraping"] == "any"
-
-
-def test_validate_debug_patch_paths_rejects_traversal() -> None:
-    with pytest.raises(ValueError, match="traversal"):
-        social_repo._validate_debug_patch_paths(["../outside.py"])
-
-
-def test_debug_ingest_job_uses_fallback_model(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    monkeypatch.setenv("SOCIAL_DEBUG_OPENAI_MODEL", "gpt-5.3-codex")
-    monkeypatch.setenv("SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL", "gpt-5.3-codex-fallback")
-    monkeypatch.setattr(
-        social_repo,
-        "_fetch_job_debug_context",
-        lambda _job_id: {"job": {"id": "job-1", "run_id": "run-1"}, "worker": {}, "run": {}},
-    )
-    calls: list[str] = []
-
-    def _fake_openai_completion(*, model: str, prompt: str, api_key: str, timeout_seconds: int):
-        del prompt, api_key, timeout_seconds
-        calls.append(model)
-        if model == "gpt-5.3-codex":
-            raise RuntimeError("rate limited")
-        return {
-            "root_cause": "fallback succeeded",
-            "confidence": 0.7,
-            "patch_unified_diff": "--- a/api/routers/socials.py\n+++ b/api/routers/socials.py\n@@\n-foo\n+bar\n",
-            "files_touched": ["api/routers/socials.py"],
-            "tests_to_run": ["pytest -q tests/api/routers/test_socials_season_analytics.py"],
-        }
-
-    monkeypatch.setattr(social_repo, "_run_social_debug_openai_completion", _fake_openai_completion)
-
-    payload = social_repo.debug_ingest_job_with_openai("job-1", include_context=False)
-
-    assert calls == ["gpt-5.3-codex", "gpt-5.3-codex-fallback"]
-    assert payload["model_used"] == "gpt-5.3-codex-fallback"
-    assert payload["fallback_used"] is True
-
-
-def test_social_debug_fallback_model_default_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL", raising=False)
-
-    assert social_repo._social_debug_fallback_model_name() == ""
-
-
-def test_debug_ingest_job_apply_returns_check_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
-    monkeypatch.setenv("SOCIAL_DEBUG_PATCH_APPLY_ENABLED", "true")
-    monkeypatch.setattr(
-        social_repo,
-        "_fetch_job_debug_context",
-        lambda _job_id: {"job": {"id": "job-1", "run_id": "run-1"}, "worker": {}, "run": {}},
-    )
-    monkeypatch.setattr(
-        social_repo,
-        "_run_social_debug_openai_completion",
-        lambda **_kwargs: {
-            "root_cause": "x",
-            "confidence": 0.5,
-            "patch_unified_diff": "--- a/api/routers/socials.py\n+++ b/api/routers/socials.py\n@@\n-foo\n+bar\n",
-            "files_touched": ["api/routers/socials.py"],
-            "tests_to_run": [],
-        },
-    )
-    monkeypatch.setattr(
-        social_repo,
-        "_run_git_apply",
-        lambda **_kwargs: subprocess.CompletedProcess(
-            args=["git", "apply"], returncode=1, stdout="", stderr="check failed"
-        ),
-    )
-
-    payload = social_repo.debug_ingest_job_with_openai(
-        "job-1",
-        include_context=False,
-        apply_patch=True,
-        confirm_apply=True,
-    )
-
-    assert payload["apply"]["requested"] is True
-    assert payload["apply"]["check_ok"] is False
-    assert payload["apply"]["applied"] is False
-    assert payload["apply"]["error"] == "check failed"
 
 
 def test_cancel_stuck_jobs_targets_only_requested_ids(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/socials/test_control_plane_debug.py
+++ b/tests/socials/test_control_plane_debug.py
@@ -26,9 +26,20 @@ def _debug_completion_payload() -> dict[str, object]:
     }
 
 
-def test_validate_debug_patch_paths_rejects_traversal() -> None:
-    with pytest.raises(ValueError, match="traversal"):
-        social_debug._validate_debug_patch_paths(["../outside.py"])
+@pytest.mark.parametrize(
+    ("paths", "error_match"),
+    [
+        ([], "did not include file paths"),
+        ([""], "path is empty"),
+        (["/tmp/outside.py"], "path is absolute"),
+        (["~/outside.py"], "path is absolute"),
+        (["../outside.py"], "path contains traversal"),
+        (["unapproved/outside.py"], "path outside allowlist"),
+    ],
+)
+def test_validate_debug_patch_paths_rejects_unsafe_paths(paths: list[str], error_match: str) -> None:
+    with pytest.raises(ValueError, match=error_match):
+        social_debug._validate_debug_patch_paths(paths)
 
 
 def test_debug_ingest_job_uses_fallback_model(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/socials/test_control_plane_debug.py
+++ b/tests/socials/test_control_plane_debug.py
@@ -1,0 +1,146 @@
+"""Unit contracts for the import-neutral social debug control-plane leaf."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import trr_backend.socials.control_plane.debug as social_debug
+
+
+def _job_context(_job_id: str) -> dict[str, object]:
+    return {"job": {"id": "job-1", "run_id": "run-1"}, "worker": {}, "run": {}}
+
+
+def _debug_completion_payload() -> dict[str, object]:
+    return {
+        "root_cause": "fallback succeeded",
+        "confidence": 0.7,
+        "patch_unified_diff": "--- a/api/routers/socials.py\n+++ b/api/routers/socials.py\n@@\n-foo\n+bar\n",
+        "files_touched": ["api/routers/socials.py"],
+        "tests_to_run": ["pytest -q tests/api/routers/test_socials_season_analytics.py"],
+    }
+
+
+def test_validate_debug_patch_paths_rejects_traversal() -> None:
+    with pytest.raises(ValueError, match="traversal"):
+        social_debug._validate_debug_patch_paths(["../outside.py"])
+
+
+def test_debug_ingest_job_uses_fallback_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SOCIAL_DEBUG_OPENAI_MODEL", "gpt-5.3-codex")
+    monkeypatch.setenv("SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL", "gpt-5.3-codex-fallback")
+    calls: list[str] = []
+
+    def _fake_openai_completion(*, model: str, prompt: str, api_key: str, timeout_seconds: int):
+        del prompt, api_key, timeout_seconds
+        calls.append(model)
+        if model == "gpt-5.3-codex":
+            raise RuntimeError("rate limited")
+        return _debug_completion_payload()
+
+    monkeypatch.setattr(social_debug, "_run_social_debug_openai_completion", _fake_openai_completion)
+
+    payload = social_debug.run_social_debug(
+        job_id="job-1",
+        fetch_job_context=_job_context,
+        include_context=False,
+    )
+
+    assert calls == ["gpt-5.3-codex", "gpt-5.3-codex-fallback"]
+    assert payload["model_used"] == "gpt-5.3-codex-fallback"
+    assert payload["fallback_used"] is True
+
+
+def test_social_debug_fallback_model_default_is_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL", raising=False)
+
+    assert social_debug._social_debug_fallback_model_name() == ""
+
+
+def test_debug_ingest_job_apply_returns_check_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("SOCIAL_DEBUG_PATCH_APPLY_ENABLED", "true")
+
+    def _fake_openai_completion(**_kwargs):
+        return _debug_completion_payload()
+
+    monkeypatch.setattr(social_debug, "_run_social_debug_openai_completion", _fake_openai_completion)
+    monkeypatch.setattr(
+        social_debug,
+        "_run_git_apply",
+        lambda **_kwargs: subprocess.CompletedProcess(
+            args=["git", "apply"], returncode=1, stdout="", stderr="check failed"
+        ),
+    )
+
+    payload = social_debug.run_social_debug(
+        job_id="job-1",
+        fetch_job_context=_job_context,
+        include_context=False,
+        apply_patch=True,
+        confirm_apply=True,
+    )
+
+    assert payload["apply"]["requested"] is True
+    assert payload["apply"]["check_ok"] is False
+    assert payload["apply"]["applied"] is False
+    assert payload["apply"]["error"] == "check failed"
+
+
+def test_debug_leaf_cold_import_does_not_load_the_social_monolith() -> None:
+    backend_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = os.pathsep.join(path for path in (str(backend_root), existing_pythonpath) if path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "import importlib",
+                    "import os",
+                    "import sys",
+                    "leaf_name = 'trr_backend.socials.control_plane.debug'",
+                    "legacy_name = 'trr_backend.socials.social_season_analytics_impl'",
+                    "recovery_name = 'trr_backend.socials.control_plane.recovery'",
+                    "alias_name = 'trr_backend.repositories.social_season_analytics'",
+                    "assert all(name not in sys.modules for name in (legacy_name, recovery_name, alias_name))",
+                    "leaf = importlib.import_module(leaf_name)",
+                    "assert all(name not in sys.modules for name in (legacy_name, recovery_name, alias_name))",
+                    "def completion(**_kwargs):",
+                    "    return {",
+                    "        'root_cause': 'ok',",
+                    "        'confidence': 1,",
+                    "        'patch_unified_diff': '',",
+                    "        'files_touched': [],",
+                    "        'tests_to_run': [],",
+                    "    }",
+                    "leaf._run_social_debug_openai_completion = completion",
+                    "os.environ['OPENAI_API_KEY'] = 'test-key'",
+                    "def fetch_job_context(_job_id):",
+                    "    return {'job': {'id': 'job-1', 'run_id': None}, 'worker': {}, 'run': {}}",
+                    "payload = leaf.run_social_debug(",
+                    "    job_id='job-1',",
+                    "    fetch_job_context=fetch_job_context,",
+                    "    include_context=False,",
+                    ")",
+                    "assert payload['job_id'] == 'job-1'",
+                    "assert all(name not in sys.modules for name in (legacy_name, recovery_name, alias_name))",
+                ]
+            ),
+        ],
+        cwd=backend_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/trr_backend/socials/control_plane/debug.py
+++ b/trr_backend/socials/control_plane/debug.py
@@ -1,0 +1,388 @@
+"""OpenAI social-ingest debug orchestration and guarded patch application."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import requests
+
+SOCIAL_DEBUG_OPENAI_MODEL_DEFAULT = "gpt-5.3-codex"
+SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL_DEFAULT = ""
+SOCIAL_DEBUG_OPENAI_TIMEOUT_SECONDS_DEFAULT = 45
+SOCIAL_DEBUG_CONTEXT_MAX_BYTES_DEFAULT = 18_000
+SOCIAL_DEBUG_PATCH_MAX_BYTES_DEFAULT = 200_000
+SOCIAL_DEBUG_ALLOWED_TOP_LEVEL_PATHS = {
+    "api",
+    "trr_backend",
+    "scripts",
+    "tests",
+    "docs",
+    ".env.example",
+}
+
+
+def _env_truthy(name: str, *, default: bool = False) -> bool:
+    raw = (os.getenv(name) or "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _resolve_positive_int_env(name: str, default: int, *, minimum: int = 1) -> int:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return max(minimum, default)
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        return max(minimum, default)
+
+
+def _social_debug_repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _social_debug_context_max_bytes() -> int:
+    return _resolve_positive_int_env(
+        "SOCIAL_DEBUG_CONTEXT_MAX_BYTES",
+        SOCIAL_DEBUG_CONTEXT_MAX_BYTES_DEFAULT,
+        minimum=2_000,
+    )
+
+
+def _social_debug_patch_max_bytes() -> int:
+    return _resolve_positive_int_env(
+        "SOCIAL_DEBUG_PATCH_MAX_BYTES",
+        SOCIAL_DEBUG_PATCH_MAX_BYTES_DEFAULT,
+        minimum=10_000,
+    )
+
+
+def _social_debug_patch_apply_enabled() -> bool:
+    return _env_truthy("SOCIAL_DEBUG_PATCH_APPLY_ENABLED", default=False)
+
+
+def _social_debug_model_name() -> str:
+    return (
+        os.getenv("SOCIAL_DEBUG_OPENAI_MODEL") or SOCIAL_DEBUG_OPENAI_MODEL_DEFAULT
+    ).strip() or SOCIAL_DEBUG_OPENAI_MODEL_DEFAULT
+
+
+def _social_debug_fallback_model_name() -> str:
+    fallback = (os.getenv("SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL") or SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL_DEFAULT).strip()
+    return fallback or SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL_DEFAULT
+
+
+def _social_debug_timeout_seconds() -> int:
+    return _resolve_positive_int_env(
+        "SOCIAL_DEBUG_OPENAI_TIMEOUT_SECONDS",
+        SOCIAL_DEBUG_OPENAI_TIMEOUT_SECONDS_DEFAULT,
+        minimum=5,
+    )
+
+
+def _extract_snippet_around_marker(
+    text: str,
+    *,
+    marker: str,
+    before_chars: int = 200,
+    after_chars: int = 2200,
+) -> str | None:
+    idx = text.find(marker)
+    if idx < 0:
+        return None
+    start = max(0, idx - before_chars)
+    end = min(len(text), idx + after_chars)
+    return text[start:end].strip()
+
+
+def _load_social_debug_source_context() -> list[dict[str, str]]:
+    repo_root = _social_debug_repo_root()
+    sources: list[tuple[str, list[str]]] = [
+        (
+            "trr_backend/repositories/social_season_analytics.py",
+            [
+                "def get_queue_status(",
+                "def _claim_next_jobs(",
+                "def _execute_claimed_job(",
+                "def recover_stale_running_jobs(",
+            ],
+        ),
+        (
+            "scripts/socials/worker.py",
+            [
+                "class WorkerHeartbeat:",
+                "def main() -> int:",
+            ],
+        ),
+        (
+            "api/routers/socials/__init__.py",
+            [
+                "def get_social_ingest_queue_status(",
+                "def ingest_season_social(",
+            ],
+        ),
+    ]
+    snippets: list[dict[str, str]] = []
+    per_file_budget = max(2_000, _social_debug_context_max_bytes() // max(1, len(sources)))
+    for rel_path, markers in sources:
+        abs_path = repo_root / rel_path
+        try:
+            raw = abs_path.read_text(encoding="utf-8", errors="ignore")
+        except Exception:  # noqa: BLE001
+            continue
+        extracted: list[str] = []
+        for marker in markers:
+            candidate = _extract_snippet_around_marker(raw, marker=marker)
+            if candidate:
+                extracted.append(candidate)
+        joined = "\n\n".join(extracted).strip() if extracted else raw[:per_file_budget].strip()
+        if not joined:
+            continue
+        snippets.append(
+            {
+                "path": rel_path,
+                "content": joined[:per_file_budget],
+            }
+        )
+    return snippets
+
+
+def _build_social_debug_prompt(
+    *,
+    job_context: dict[str, Any],
+    source_context: list[dict[str, str]],
+) -> str:
+    prompt_payload = {
+        "job_context": job_context,
+        "source_context": source_context,
+        "task": "Diagnose stuck/failed social ingest job and produce exact unified diff patch.",
+        "required_output_schema": {
+            "root_cause": "string",
+            "confidence": "number between 0 and 1",
+            "patch_unified_diff": "string unified diff",
+            "files_touched": ["string file paths"],
+            "tests_to_run": ["string commands"],
+        },
+        "constraints": [
+            "Return strict JSON object only.",
+            "patch_unified_diff must be valid unified diff with ---/+++ headers.",
+            "Avoid changing unrelated files.",
+            "Focus on root-cause fix with smallest safe patch.",
+        ],
+    }
+    return json.dumps(prompt_payload, separators=(",", ":"), ensure_ascii=True)
+
+
+def _run_social_debug_openai_completion(
+    *,
+    model: str,
+    prompt: str,
+    api_key: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    response = requests.post(
+        "https://api.openai.com/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a senior backend engineer. Return strict JSON only.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+        },
+        timeout=max(5, int(timeout_seconds)),
+    )
+    response.raise_for_status()
+    payload = response.json()
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise RuntimeError("OpenAI response missing choices")
+    message = choices[0].get("message") if isinstance(choices[0], dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, str) or not content.strip():
+        raise RuntimeError("OpenAI response missing content")
+    parsed = json.loads(content)
+    if not isinstance(parsed, dict):
+        raise RuntimeError("OpenAI response is not a JSON object")
+    return parsed
+
+
+def _extract_unified_diff_paths(patch_unified_diff: str) -> list[str]:
+    paths: list[str] = []
+    for raw_line in patch_unified_diff.splitlines():
+        line = raw_line.strip()
+        if not (line.startswith("+++ ") or line.startswith("--- ")):
+            continue
+        candidate = line[4:].strip()
+        if candidate == "/dev/null":
+            continue
+        if candidate.startswith("a/") or candidate.startswith("b/"):
+            candidate = candidate[2:]
+        if not candidate:
+            continue
+        if candidate not in paths:
+            paths.append(candidate)
+    return paths
+
+
+def _validate_debug_patch_paths(paths: list[str]) -> None:
+    if not paths:
+        raise ValueError("patch_unified_diff did not include file paths")
+    for path in paths:
+        normalized = str(path or "").strip()
+        if not normalized:
+            raise ValueError("patch path is empty")
+        if normalized.startswith("/") or normalized.startswith("~"):
+            raise ValueError(f"patch path is absolute: {normalized}")
+        if ".." in Path(normalized).parts:
+            raise ValueError(f"patch path contains traversal: {normalized}")
+        top_level = normalized.split("/", 1)[0]
+        if top_level not in SOCIAL_DEBUG_ALLOWED_TOP_LEVEL_PATHS:
+            raise ValueError(f"patch path outside allowlist: {normalized}")
+
+
+def _run_git_apply(*, patch_unified_diff: str, check_only: bool) -> subprocess.CompletedProcess[str]:
+    cmd = ["git", "apply", "--whitespace=nowarn"]
+    if check_only:
+        cmd.append("--check")
+    cmd.append("-")
+    return subprocess.run(
+        cmd,
+        cwd=str(_social_debug_repo_root()),
+        input=patch_unified_diff,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def run_social_debug(
+    *,
+    job_id: str,
+    fetch_job_context: Callable[[str], dict[str, Any]],
+    apply_patch: bool = False,
+    confirm_apply: bool = False,
+    include_context: bool = True,
+) -> dict[str, Any]:
+    normalized_job_id = str(job_id or "").strip()
+    if not normalized_job_id:
+        raise ValueError("job_not_found")
+    context_payload = fetch_job_context(normalized_job_id)
+    api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError("openai_api_key_missing")
+
+    source_context = _load_social_debug_source_context() if include_context else []
+    prompt = _build_social_debug_prompt(job_context=context_payload, source_context=source_context)
+    models = [_social_debug_model_name(), _social_debug_fallback_model_name()]
+    models = [model for idx, model in enumerate(models) if model and (idx == 0 or model != models[0])]
+
+    ai_payload: dict[str, Any] | None = None
+    model_used: str | None = None
+    fallback_used = False
+    final_error: Exception | None = None
+    for idx, model in enumerate(models):
+        try:
+            ai_payload = _run_social_debug_openai_completion(
+                model=model,
+                prompt=prompt,
+                api_key=api_key,
+                timeout_seconds=_social_debug_timeout_seconds(),
+            )
+            model_used = model
+            fallback_used = idx > 0
+            break
+        except Exception as exc:  # noqa: BLE001
+            final_error = exc
+            continue
+    if ai_payload is None or model_used is None:
+        raise RuntimeError(f"openai_debug_failed: {final_error}")
+
+    root_cause = str(ai_payload.get("root_cause") or "").strip() or "No root cause provided."
+    raw_confidence: Any = ai_payload.get("confidence")
+    try:
+        confidence = max(0.0, min(1.0, float(raw_confidence)))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    files_touched_raw = ai_payload.get("files_touched")
+    files_touched = (
+        [str(item).strip() for item in files_touched_raw if str(item).strip()]
+        if isinstance(files_touched_raw, list)
+        else []
+    )
+    tests_to_run_raw = ai_payload.get("tests_to_run")
+    tests_to_run = (
+        [str(item).strip() for item in tests_to_run_raw if str(item).strip()]
+        if isinstance(tests_to_run_raw, list)
+        else []
+    )
+    patch_unified_diff = str(ai_payload.get("patch_unified_diff") or "")
+    patch_max_bytes = _social_debug_patch_max_bytes()
+    if len(patch_unified_diff.encode("utf-8")) > patch_max_bytes:
+        patch_unified_diff = patch_unified_diff.encode("utf-8")[:patch_max_bytes].decode("utf-8", errors="ignore")
+
+    apply_enabled = _social_debug_patch_apply_enabled()
+    apply_requested = bool(apply_patch)
+    apply_result = {
+        "enabled": apply_enabled,
+        "requested": apply_requested,
+        "applied": False,
+        "check_ok": False,
+        "error": None,
+        "files_changed": [],
+    }
+    if apply_requested:
+        if not apply_enabled:
+            apply_result["error"] = "Patch apply is disabled by server configuration."
+        elif not confirm_apply:
+            apply_result["error"] = "confirm_apply=true is required to apply patch."
+        elif not patch_unified_diff.strip():
+            apply_result["error"] = "No patch_unified_diff returned by debug model."
+        else:
+            paths = _extract_unified_diff_paths(patch_unified_diff)
+            try:
+                _validate_debug_patch_paths(paths)
+                check_proc = _run_git_apply(patch_unified_diff=patch_unified_diff, check_only=True)
+                apply_result["check_ok"] = check_proc.returncode == 0
+                if check_proc.returncode != 0:
+                    apply_result["error"] = (
+                        check_proc.stderr or check_proc.stdout or "git apply --check failed"
+                    ).strip()
+                else:
+                    apply_proc = _run_git_apply(patch_unified_diff=patch_unified_diff, check_only=False)
+                    if apply_proc.returncode != 0:
+                        apply_result["error"] = (apply_proc.stderr or apply_proc.stdout or "git apply failed").strip()
+                    else:
+                        apply_result["applied"] = True
+                        apply_result["files_changed"] = paths
+            except Exception as exc:  # noqa: BLE001
+                apply_result["error"] = str(exc)
+
+    return {
+        "job_id": context_payload["job"]["id"],
+        "run_id": context_payload["job"].get("run_id"),
+        "model_used": model_used,
+        "fallback_used": fallback_used,
+        "analysis": {
+            "root_cause": root_cause,
+            "confidence": confidence,
+            "files_touched": files_touched,
+            "tests_to_run": tests_to_run,
+        },
+        "patch_unified_diff": patch_unified_diff,
+        "apply": apply_result,
+    }

--- a/trr_backend/socials/social_season_analytics_impl.py
+++ b/trr_backend/socials/social_season_analytics_impl.py
@@ -66,6 +66,7 @@ from trr_backend.modal_dispatch import (
 from trr_backend.runtime_version import build_runtime_version_stamp
 from trr_backend.socials import source_scopes as _source_scopes
 from trr_backend.socials import windowing as _windowing
+from trr_backend.socials.control_plane.debug import run_social_debug
 from trr_backend.socials.cookie_sources import (
     _default_platform_cookie_file_path,
     _platform_cookie_file_candidates,
@@ -270,9 +271,6 @@ SHARED_CLASSIFY_BATCH_SIZE_DEFAULT = 50
 SOCIAL_MODAL_MIRROR_LAG_PENDING_DEFAULT = 500
 SOCIAL_PROFILE_TOTAL_POSTS_CACHE_TTL_SECONDS_DEFAULT = 300
 QUEUE_STATUS_STAGES = ("queued", "pending", "running", "retrying", "cancelling", "failed", "cancelled", "completed")
-SOCIAL_DEBUG_OPENAI_MODEL_DEFAULT = "gpt-5.3-codex"
-SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL_DEFAULT = ""
-SOCIAL_DEBUG_OPENAI_TIMEOUT_SECONDS_DEFAULT = 45
 INSTAGRAM_METADATA_RETRY_COOLDOWN_LADDER: tuple[tuple[int, timedelta], ...] = (
     (3, timedelta(hours=6)),
     (6, timedelta(hours=24)),
@@ -280,8 +278,6 @@ INSTAGRAM_METADATA_RETRY_COOLDOWN_LADDER: tuple[tuple[int, timedelta], ...] = (
 INSTAGRAM_METADATA_RETRY_MAX_COOLDOWN = timedelta(hours=72)
 CATALOG_START_LOCK_NAMESPACE = 0x53434154
 TIKTOK_PARTITION_RETRY_DELAYS_SECONDS = (30, 120, 600)
-SOCIAL_DEBUG_CONTEXT_MAX_BYTES_DEFAULT = 18_000
-SOCIAL_DEBUG_PATCH_MAX_BYTES_DEFAULT = 200_000
 SOCIAL_MEDIA_MIRROR_MAX_BYTES_DEFAULT = 50 * 1024 * 1024
 SOCIAL_MEDIA_MIRROR_CHUNK_SIZE_BYTES = 64 * 1024
 SOCIAL_AVATAR_MIRROR_MAX_BYTES_DEFAULT = 5 * 1024 * 1024
@@ -473,15 +469,6 @@ GENERIC_ACCOUNT_HANDLE_RE = re.compile(r"^[a-z0-9._-]{1,64}$")
 INSTAGRAM_ACCOUNT_HANDLE_RE = re.compile(r"^[a-z0-9._]{1,30}$")
 FIELD_UNSET = object()
 ANALYTICS_CACHE_TTL_SECONDS = 15.0
-SOCIAL_DEBUG_ALLOWED_TOP_LEVEL_PATHS = {
-    "api",
-    "trr_backend",
-    "scripts",
-    "tests",
-    "docs",
-    ".env.example",
-}
-
 _week_detail_cache_invalidator: Callable[[], None] | None = None
 
 
@@ -6659,116 +6646,6 @@ def reset_social_ingest_health(
     }
 
 
-def _social_debug_repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def _social_debug_context_max_bytes() -> int:
-    return _resolve_positive_int_env(
-        "SOCIAL_DEBUG_CONTEXT_MAX_BYTES",
-        SOCIAL_DEBUG_CONTEXT_MAX_BYTES_DEFAULT,
-        minimum=2_000,
-    )
-
-
-def _social_debug_patch_max_bytes() -> int:
-    return _resolve_positive_int_env(
-        "SOCIAL_DEBUG_PATCH_MAX_BYTES",
-        SOCIAL_DEBUG_PATCH_MAX_BYTES_DEFAULT,
-        minimum=10_000,
-    )
-
-
-def _social_debug_patch_apply_enabled() -> bool:
-    return _env_truthy("SOCIAL_DEBUG_PATCH_APPLY_ENABLED", default=False)
-
-
-def _social_debug_model_name() -> str:
-    return (
-        os.getenv("SOCIAL_DEBUG_OPENAI_MODEL") or SOCIAL_DEBUG_OPENAI_MODEL_DEFAULT
-    ).strip() or SOCIAL_DEBUG_OPENAI_MODEL_DEFAULT
-
-
-def _social_debug_fallback_model_name() -> str:
-    fallback = (os.getenv("SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL") or SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL_DEFAULT).strip()
-    return fallback or SOCIAL_DEBUG_OPENAI_FALLBACK_MODEL_DEFAULT
-
-
-def _social_debug_timeout_seconds() -> int:
-    return _resolve_positive_int_env(
-        "SOCIAL_DEBUG_OPENAI_TIMEOUT_SECONDS",
-        SOCIAL_DEBUG_OPENAI_TIMEOUT_SECONDS_DEFAULT,
-        minimum=5,
-    )
-
-
-def _extract_snippet_around_marker(
-    text: str,
-    *,
-    marker: str,
-    before_chars: int = 200,
-    after_chars: int = 2200,
-) -> str | None:
-    idx = text.find(marker)
-    if idx < 0:
-        return None
-    start = max(0, idx - before_chars)
-    end = min(len(text), idx + after_chars)
-    return text[start:end].strip()
-
-
-def _load_social_debug_source_context() -> list[dict[str, str]]:
-    repo_root = _social_debug_repo_root()
-    sources: list[tuple[str, list[str]]] = [
-        (
-            "trr_backend/repositories/social_season_analytics.py",
-            [
-                "def get_queue_status(",
-                "def _claim_next_jobs(",
-                "def _execute_claimed_job(",
-                "def recover_stale_running_jobs(",
-            ],
-        ),
-        (
-            "scripts/socials/worker.py",
-            [
-                "class WorkerHeartbeat:",
-                "def main() -> int:",
-            ],
-        ),
-        (
-            "api/routers/socials/__init__.py",
-            [
-                "def get_social_ingest_queue_status(",
-                "def ingest_season_social(",
-            ],
-        ),
-    ]
-    snippets: list[dict[str, str]] = []
-    per_file_budget = max(2_000, _social_debug_context_max_bytes() // max(1, len(sources)))
-    for rel_path, markers in sources:
-        abs_path = repo_root / rel_path
-        try:
-            raw = abs_path.read_text(encoding="utf-8", errors="ignore")
-        except Exception:  # noqa: BLE001
-            continue
-        extracted: list[str] = []
-        for marker in markers:
-            candidate = _extract_snippet_around_marker(raw, marker=marker)
-            if candidate:
-                extracted.append(candidate)
-        joined = "\n\n".join(extracted).strip() if extracted else raw[:per_file_budget].strip()
-        if not joined:
-            continue
-        snippets.append(
-            {
-                "path": rel_path,
-                "content": joined[:per_file_budget],
-            }
-        )
-    return snippets
-
-
 def _fetch_job_debug_context(job_id: str) -> dict[str, Any]:
     _assert_social_queue_schema_ready()
     features = _scrape_jobs_features()
@@ -6913,123 +6790,6 @@ def _fetch_job_debug_context(job_id: str) -> dict[str, Any]:
     }
 
 
-def _build_social_debug_prompt(
-    *,
-    job_context: dict[str, Any],
-    source_context: list[dict[str, str]],
-) -> str:
-    prompt_payload = {
-        "job_context": job_context,
-        "source_context": source_context,
-        "task": "Diagnose stuck/failed social ingest job and produce exact unified diff patch.",
-        "required_output_schema": {
-            "root_cause": "string",
-            "confidence": "number between 0 and 1",
-            "patch_unified_diff": "string unified diff",
-            "files_touched": ["string file paths"],
-            "tests_to_run": ["string commands"],
-        },
-        "constraints": [
-            "Return strict JSON object only.",
-            "patch_unified_diff must be valid unified diff with ---/+++ headers.",
-            "Avoid changing unrelated files.",
-            "Focus on root-cause fix with smallest safe patch.",
-        ],
-    }
-    return json.dumps(prompt_payload, separators=(",", ":"), ensure_ascii=True)
-
-
-def _run_social_debug_openai_completion(
-    *,
-    model: str,
-    prompt: str,
-    api_key: str,
-    timeout_seconds: int,
-) -> dict[str, Any]:
-    response = requests.post(
-        "https://api.openai.com/v1/chat/completions",
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
-        json={
-            "model": model,
-            "messages": [
-                {
-                    "role": "system",
-                    "content": "You are a senior backend engineer. Return strict JSON only.",
-                },
-                {"role": "user", "content": prompt},
-            ],
-            "temperature": 0,
-            "response_format": {"type": "json_object"},
-        },
-        timeout=max(5, int(timeout_seconds)),
-    )
-    response.raise_for_status()
-    payload = response.json()
-    choices = payload.get("choices")
-    if not isinstance(choices, list) or not choices:
-        raise RuntimeError("OpenAI response missing choices")
-    message = choices[0].get("message") if isinstance(choices[0], dict) else None
-    content = message.get("content") if isinstance(message, dict) else None
-    if not isinstance(content, str) or not content.strip():
-        raise RuntimeError("OpenAI response missing content")
-    parsed = json.loads(content)
-    if not isinstance(parsed, dict):
-        raise RuntimeError("OpenAI response is not a JSON object")
-    return parsed
-
-
-def _extract_unified_diff_paths(patch_unified_diff: str) -> list[str]:
-    paths: list[str] = []
-    for raw_line in patch_unified_diff.splitlines():
-        line = raw_line.strip()
-        if not (line.startswith("+++ ") or line.startswith("--- ")):
-            continue
-        candidate = line[4:].strip()
-        if candidate == "/dev/null":
-            continue
-        if candidate.startswith("a/") or candidate.startswith("b/"):
-            candidate = candidate[2:]
-        if not candidate:
-            continue
-        if candidate not in paths:
-            paths.append(candidate)
-    return paths
-
-
-def _validate_debug_patch_paths(paths: list[str]) -> None:
-    if not paths:
-        raise ValueError("patch_unified_diff did not include file paths")
-    for path in paths:
-        normalized = str(path or "").strip()
-        if not normalized:
-            raise ValueError("patch path is empty")
-        if normalized.startswith("/") or normalized.startswith("~"):
-            raise ValueError(f"patch path is absolute: {normalized}")
-        if ".." in Path(normalized).parts:
-            raise ValueError(f"patch path contains traversal: {normalized}")
-        top_level = normalized.split("/", 1)[0]
-        if top_level not in SOCIAL_DEBUG_ALLOWED_TOP_LEVEL_PATHS:
-            raise ValueError(f"patch path outside allowlist: {normalized}")
-
-
-def _run_git_apply(*, patch_unified_diff: str, check_only: bool) -> subprocess.CompletedProcess[str]:
-    cmd = ["git", "apply", "--whitespace=nowarn"]
-    if check_only:
-        cmd.append("--check")
-    cmd.append("-")
-    return subprocess.run(
-        cmd,
-        cwd=str(_social_debug_repo_root()),
-        input=patch_unified_diff,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-
 def debug_ingest_job_with_openai(
     job_id: str,
     *,
@@ -7037,114 +6797,13 @@ def debug_ingest_job_with_openai(
     confirm_apply: bool = False,
     include_context: bool = True,
 ) -> dict[str, Any]:
-    normalized_job_id = str(job_id or "").strip()
-    if not normalized_job_id:
-        raise ValueError("job_not_found")
-    context_payload = _fetch_job_debug_context(normalized_job_id)
-    api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
-    if not api_key:
-        raise ValueError("openai_api_key_missing")
-
-    source_context = _load_social_debug_source_context() if include_context else []
-    prompt = _build_social_debug_prompt(job_context=context_payload, source_context=source_context)
-    models = [_social_debug_model_name(), _social_debug_fallback_model_name()]
-    models = [model for idx, model in enumerate(models) if model and (idx == 0 or model != models[0])]
-
-    ai_payload: dict[str, Any] | None = None
-    model_used: str | None = None
-    fallback_used = False
-    final_error: Exception | None = None
-    for idx, model in enumerate(models):
-        try:
-            ai_payload = _run_social_debug_openai_completion(
-                model=model,
-                prompt=prompt,
-                api_key=api_key,
-                timeout_seconds=_social_debug_timeout_seconds(),
-            )
-            model_used = model
-            fallback_used = idx > 0
-            break
-        except Exception as exc:  # noqa: BLE001
-            final_error = exc
-            continue
-    if ai_payload is None or model_used is None:
-        raise RuntimeError(f"openai_debug_failed: {final_error}")
-
-    root_cause = str(ai_payload.get("root_cause") or "").strip() or "No root cause provided."
-    raw_confidence: Any = ai_payload.get("confidence")
-    try:
-        confidence = max(0.0, min(1.0, float(raw_confidence)))
-    except (TypeError, ValueError):
-        confidence = 0.0
-    files_touched_raw = ai_payload.get("files_touched")
-    files_touched = (
-        [str(item).strip() for item in files_touched_raw if str(item).strip()]
-        if isinstance(files_touched_raw, list)
-        else []
+    return run_social_debug(
+        job_id=job_id,
+        fetch_job_context=_fetch_job_debug_context,
+        apply_patch=apply_patch,
+        confirm_apply=confirm_apply,
+        include_context=include_context,
     )
-    tests_to_run_raw = ai_payload.get("tests_to_run")
-    tests_to_run = (
-        [str(item).strip() for item in tests_to_run_raw if str(item).strip()]
-        if isinstance(tests_to_run_raw, list)
-        else []
-    )
-    patch_unified_diff = str(ai_payload.get("patch_unified_diff") or "")
-    patch_max_bytes = _social_debug_patch_max_bytes()
-    if len(patch_unified_diff.encode("utf-8")) > patch_max_bytes:
-        patch_unified_diff = patch_unified_diff.encode("utf-8")[:patch_max_bytes].decode("utf-8", errors="ignore")
-
-    apply_enabled = _social_debug_patch_apply_enabled()
-    apply_requested = bool(apply_patch)
-    apply_result = {
-        "enabled": apply_enabled,
-        "requested": apply_requested,
-        "applied": False,
-        "check_ok": False,
-        "error": None,
-        "files_changed": [],
-    }
-    if apply_requested:
-        if not apply_enabled:
-            apply_result["error"] = "Patch apply is disabled by server configuration."
-        elif not confirm_apply:
-            apply_result["error"] = "confirm_apply=true is required to apply patch."
-        elif not patch_unified_diff.strip():
-            apply_result["error"] = "No patch_unified_diff returned by debug model."
-        else:
-            paths = _extract_unified_diff_paths(patch_unified_diff)
-            try:
-                _validate_debug_patch_paths(paths)
-                check_proc = _run_git_apply(patch_unified_diff=patch_unified_diff, check_only=True)
-                apply_result["check_ok"] = check_proc.returncode == 0
-                if check_proc.returncode != 0:
-                    apply_result["error"] = (
-                        check_proc.stderr or check_proc.stdout or "git apply --check failed"
-                    ).strip()
-                else:
-                    apply_proc = _run_git_apply(patch_unified_diff=patch_unified_diff, check_only=False)
-                    if apply_proc.returncode != 0:
-                        apply_result["error"] = (apply_proc.stderr or apply_proc.stdout or "git apply failed").strip()
-                    else:
-                        apply_result["applied"] = True
-                        apply_result["files_changed"] = paths
-            except Exception as exc:  # noqa: BLE001
-                apply_result["error"] = str(exc)
-
-    return {
-        "job_id": context_payload["job"]["id"],
-        "run_id": context_payload["job"].get("run_id"),
-        "model_used": model_used,
-        "fallback_used": fallback_used,
-        "analysis": {
-            "root_cause": root_cause,
-            "confidence": confidence,
-            "files_touched": files_touched,
-            "tests_to_run": tests_to_run,
-        },
-        "patch_unified_diff": patch_unified_diff,
-        "apply": apply_result,
-    }
 
 
 def _resolve_depth_defaults(


### PR DESCRIPTION
## Result

- extracts OpenAI ingest-debug orchestration and guarded patch application into an import-neutral control-plane leaf
- preserves the legacy public callable identity and signature through a narrow parent delegator
- reduces `social_season_analytics_impl.py` from 68,478 to 68,137 lines (ceiling: 68,316)

## Validation

- 90 focused extraction and compatibility tests passed on Python 3.11
- 6 debug endpoint tests passed
- Ruff check and format check passed
- canonical workspace import-graph baseline passed with zero backend/social/app cycles and zero legacy social imports
- independent implementation review found no P0-P3 issues

## Boundaries

- no public contract, migration, provider, database, deployment, or compatibility deletion change
- gated OpenAI and `git apply` side effects remained mocked during validation
