### PR TITLE
build: declare hotspot schema validator

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -47,6 +47,7 @@ anthropic>=0.43.0
 pytest>=8.0.0
 httpx>=0.28.0
 playwright>=1.61.0
+jsonschema==4.26.0
 
 # Local Chrome cookie extraction for operator-run auth repair helpers.
 pycookiecheat>=0.8.0,<0.9

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -246,7 +246,9 @@ jmespath==1.1.0
     #   boto3
     #   botocore
 jsonschema==4.26.0
-    # via mcp
+    # via
+    #   -r requirements.in
+    #   mcp
 jsonschema-specifications==2025.9.1
     # via jsonschema
 keyring==25.7.0


### PR DESCRIPTION
## Outcome

Declares the JSON Schema validator used by the Stage 2 workspace hotspot checker as a direct backend development/test dependency.

## Changes

- add `jsonschema==4.26.0` to `requirements.in`
- regenerate the Python 3.11 Linux lockfile; resolved versions do not change

## Validation

- CI-equivalent `uv pip compile` followed by zero-drift diff
- `git diff --check`
- workspace `make architecture-hotspots-check` and 21 focused checker tests passed against this environment

This is the backend-first package prerequisite for the workspace hotspot-ratchet PR.
